### PR TITLE
Travis publish goreleaser on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,13 @@ after_success:
   - echo "travis go version='$TRAVIS_GO_VERSION'"
   - bash <(curl -s https://codecov.io/bash) -f client-coverage.txt -F client
   - bash <(curl -s https://codecov.io/bash) -f provider-coverage.txt -F provider
+  # Add a tag for this release
+  - git tag "v0.2.$TRAVIS_BUILD_NUMBER"
+
+deploy:
+- provider: script
+  skip_cleanup: true
+  script: curl -sL https://git.io/goreleaser | bash
+  on:
+    tags: true
+    branch: master


### PR DESCRIPTION
#117 This PR look at adding a `deploy` stage to the `travis` pipeline which will run GoReleaser on any changes to `master` and publish a new github release. 

I think this will work but it will need someone with Travis permissions to test out.

This will need the `GITHUB_TOKEN` environment set with a token that has access to the repo. This can be added here: https://docs.travis-ci.com/user/environment-variables/#defining-variables-in-repository-settings and set to only be available when on the `master` branch to stop anyone abusing this and pushing a release from a PR build. 

![image](https://user-images.githubusercontent.com/1939288/85009553-8252f500-b156-11ea-905d-982d4a2fdb93.png)
