### PR TITLE
[FEATURE] Added databricks_cluster_policy resource

### DIFF
--- a/client/model/cluster_policies.go
+++ b/client/model/cluster_policies.go
@@ -1,84 +1,15 @@
 package model
 
-import (
-	"encoding/json"
-	"fmt"
-
-	"github.com/pkg/errors"
-)
-
-// AttributePolicy defines JSON mapping for attribute policy
-type AttributePolicy struct {
-	Path         *string       `json:"-"`
-	Type         string        `json:"type"`
-	Value        interface{}   `json:"value,omitempty"`
-	DefaultValue interface{}   `json:"defaultValue,omitempty"`
-	Values       []interface{} `json:"values,omitempty"`
-	Hidden       bool          `json:"hidden,omitempty"`
-	IsOptional   bool          `json:"isOptional,omitempty"`
-	Pattern      string        `json:"pattern,omitempty"`
-	MinValue     int           `json:"minValue,omitempty"`
-	MaxValue     int           `json:"maxValue,omitempty"`
-}
-
 // ClusterPolicy defines cluster policy
 type ClusterPolicy struct {
 	PolicyID           string `json:"policy_id,omitempty"`
 	Name               string `json:"name"`
 	Definition         string `json:"definition"`
 	CreatedAtTimeStamp int64  `json:"created_at_timestamp"`
-
-	Attributes map[string]*AttributePolicy
-}
-
-// ParseDefinition parses policy definition
-func (clusterPolicy *ClusterPolicy) ParseDefinition(definition string) error {
-	clusterPolicy.Definition = definition
-
-	err := json.Unmarshal([]byte(definition), &clusterPolicy.Attributes)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 // ClusterPolicyCreate is the endity used for request
 type ClusterPolicyCreate struct {
 	Name       string `json:"name"`
 	Definition string `json:"definition"`
-}
-
-// // Prepare sets definition from attributes
-// func (clusterPolicy *ClusterPolicy) Prepare() ([]byte, error) {
-// 	policyJSONBytes, err := json.Marshal(clusterPolicy.attributes)
-// 	if err != nil {
-// 		return nil, errors.Wrapf(err, "Problem serializing %s policy", clusterPolicy.Name)
-// 	}
-// 	clusterPolicy.Definition = string(policyJSONBytes)
-// }
-
-// MarshalJSON is called when json.Marshal is invoked
-func (clusterPolicy *ClusterPolicy) MarshalJSON() ([]byte, error) {
-	policyJSONBytes, err := json.Marshal(clusterPolicy.Attributes)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Problem serializing %s policy", clusterPolicy.Name)
-	}
-	clusterPolicy.Definition = string(policyJSONBytes)
-	return json.Marshal(&struct {
-		PolicyID   string `json:"policy_id,omitempty"`
-		Name       string `json:"name"`
-		Definition string `json:"definition"`
-	}{
-		clusterPolicy.PolicyID, clusterPolicy.Name, clusterPolicy.Definition,
-	})
-}
-
-// ToString returns debug JSON, ignoring errors
-func (clusterPolicy *ClusterPolicy) ToString() string {
-	j, err := clusterPolicy.MarshalJSON()
-	if err != nil {
-		return ""
-	}
-	return fmt.Sprintf("%s", j)
 }

--- a/client/model/cluster_policies.go
+++ b/client/model/cluster_policies.go
@@ -1,0 +1,84 @@
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+// AttributePolicy defines JSON mapping for attribute policy
+type AttributePolicy struct {
+	Path         *string       `json:"-"`
+	Type         string        `json:"type"`
+	Value        interface{}   `json:"value,omitempty"`
+	DefaultValue interface{}   `json:"defaultValue,omitempty"`
+	Values       []interface{} `json:"values,omitempty"`
+	Hidden       bool          `json:"hidden,omitempty"`
+	IsOptional   bool          `json:"isOptional,omitempty"`
+	Pattern      string        `json:"pattern,omitempty"`
+	MinValue     int           `json:"minValue,omitempty"`
+	MaxValue     int           `json:"maxValue,omitempty"`
+}
+
+// ClusterPolicy defines cluster policy
+type ClusterPolicy struct {
+	PolicyID           string `json:"policy_id,omitempty"`
+	Name               string `json:"name"`
+	Definition         string `json:"definition"`
+	CreatedAtTimeStamp int64  `json:"created_at_timestamp"`
+
+	Attributes map[string]*AttributePolicy
+}
+
+// ParseDefinition parses policy definition
+func (clusterPolicy *ClusterPolicy) ParseDefinition(definition string) error {
+	clusterPolicy.Definition = definition
+
+	err := json.Unmarshal([]byte(definition), &clusterPolicy.Attributes)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ClusterPolicyCreate is the endity used for request
+type ClusterPolicyCreate struct {
+	Name       string `json:"name"`
+	Definition string `json:"definition"`
+}
+
+// // Prepare sets definition from attributes
+// func (clusterPolicy *ClusterPolicy) Prepare() ([]byte, error) {
+// 	policyJSONBytes, err := json.Marshal(clusterPolicy.attributes)
+// 	if err != nil {
+// 		return nil, errors.Wrapf(err, "Problem serializing %s policy", clusterPolicy.Name)
+// 	}
+// 	clusterPolicy.Definition = string(policyJSONBytes)
+// }
+
+// MarshalJSON is called when json.Marshal is invoked
+func (clusterPolicy *ClusterPolicy) MarshalJSON() ([]byte, error) {
+	policyJSONBytes, err := json.Marshal(clusterPolicy.Attributes)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Problem serializing %s policy", clusterPolicy.Name)
+	}
+	clusterPolicy.Definition = string(policyJSONBytes)
+	return json.Marshal(&struct {
+		PolicyID   string `json:"policy_id,omitempty"`
+		Name       string `json:"name"`
+		Definition string `json:"definition"`
+	}{
+		clusterPolicy.PolicyID, clusterPolicy.Name, clusterPolicy.Definition,
+	})
+}
+
+// ToString returns debug JSON, ignoring errors
+func (clusterPolicy *ClusterPolicy) ToString() string {
+	j, err := clusterPolicy.MarshalJSON()
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("%s", j)
+}

--- a/client/service/apis.go
+++ b/client/service/apis.go
@@ -21,6 +21,11 @@ func (c *DBApiClient) Clusters() ClustersAPI {
 	return ClustersAPI{Client: c}
 }
 
+// ClusterPolicies returns an instance of ClusterPoliciesAPI
+func (c *DBApiClient) ClusterPolicies() ClusterPoliciesAPI {
+	return ClusterPoliciesAPI{Client: c}
+}
+
 // Secrets returns an instance of SecretsAPI
 func (c *DBApiClient) Secrets() SecretsAPI {
 	return SecretsAPI{Client: c}

--- a/client/service/cluster_policies.go
+++ b/client/service/cluster_policies.go
@@ -1,0 +1,59 @@
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/databrickslabs/databricks-terraform/client/model"
+)
+
+// ClusterPoliciesAPI  allows you to create, list, and edit cluster policies.
+//
+// Creation and editing is available to admins only.
+// Listing can be performed by any user and is limited to policies accessible by that user.
+type ClusterPoliciesAPI struct {
+	Client *DBApiClient
+}
+
+type policyIDWrapper struct {
+	PolicyID string `json:"policy_id,omitempty" url:"policy_id,omitempty"`
+}
+
+// Create creates new cluster policy and sets PolicyID
+func (a ClusterPoliciesAPI) Create(clusterPolicy *model.ClusterPolicy) error {
+	//clusterPolicyWrapper := &policyWrapper{clusterPolicy.Name, clusterPolicy.Definition}
+	resp, err := a.Client.performQuery(http.MethodPost, "/policies/clusters/create", "2.0", nil, clusterPolicy, nil)
+	if err != nil {
+		return err
+	}
+	var policyIDResponse = new(policyIDWrapper)
+	err = json.Unmarshal(resp, &policyIDResponse)
+	clusterPolicy.PolicyID = policyIDResponse.PolicyID
+	return err
+}
+
+// Edit will update an existing policy.
+// This may make some clusters governed by this policy invalid.
+// For such clusters the next cluster edit must provide a confirming configuration,
+// but otherwise they can continue to run.
+func (a ClusterPoliciesAPI) Edit(clusterPolicy *model.ClusterPolicy) error {
+	_, err := a.Client.performQuery(http.MethodPost, "/policies/clusters/edit", "2.0", nil, clusterPolicy, nil)
+	return err
+}
+
+// Get returns cluster policy
+func (a ClusterPoliciesAPI) Get(policyID string) (*model.ClusterPolicy, error) {
+	var clusterPolicy model.ClusterPolicy
+	resp, err := a.Client.performQuery(http.MethodGet, "/policies/clusters/get", "2.0", nil, policyIDWrapper{policyID}, nil)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(resp, &clusterPolicy)
+	return &clusterPolicy, err
+}
+
+// Delete removes cluster policy
+func (a ClusterPoliciesAPI) Delete(policyID string) error {
+	_, err := a.Client.performQuery(http.MethodPost, "/policies/clusters/delete", "2.0", nil, policyIDWrapper{policyID}, nil)
+	return err
+}

--- a/databricks/provider.go
+++ b/databricks/provider.go
@@ -39,6 +39,7 @@ func Provider(version string) terraform.ResourceProvider {
 			"databricks_group_member":           resourceGroupMember(),
 			"databricks_notebook":               resourceNotebook(),
 			"databricks_cluster":                resourceCluster(),
+			"databricks_cluster_policy":         resourceClusterPolicy(),
 			"databricks_job":                    resourceJob(),
 			"databricks_dbfs_file":              resourceDBFSFile(),
 			"databricks_dbfs_file_sync":         resourceDBFSFileSync(),

--- a/databricks/resource_databricks_cluster_policy.go
+++ b/databricks/resource_databricks_cluster_policy.go
@@ -1,0 +1,169 @@
+package databricks
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+	"github.com/databrickslabs/databricks-terraform/client/model"
+	"github.com/databrickslabs/databricks-terraform/client/service"
+)
+
+func parsePolicyFromData(d *schema.ResourceData) (*model.ClusterPolicy, error) {
+	clusterPolicy := new(model.ClusterPolicy)
+	clusterPolicy.PolicyID = d.Id()
+	if name, ok := d.GetOk("name"); ok {
+		clusterPolicy.Name = name.(string)
+	}
+	if data, ok := d.GetOk("definition"); ok {
+		err := clusterPolicy.ParseDefinition(data.(string))
+		if err != nil {
+			return nil, err
+		}
+	}
+	return clusterPolicy, nil
+}
+
+func resourceClusterPolicyCreate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*service.DBApiClient)
+	clusterPolicy, err := parsePolicyFromData(d)
+	if err != nil {
+		return err
+	}
+	err = client.ClusterPolicies().Create(clusterPolicy)
+	if err != nil {
+		return err
+	}
+	d.SetId(clusterPolicy.PolicyID)
+	return resourceClusterPolicyRead(d, m)
+}
+
+func resourceClusterPolicyRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(*service.DBApiClient)
+	clusterPolicy, err := client.ClusterPolicies().Get(d.Id())
+	if err != nil {
+		return err
+	}
+	err = d.Set("name", clusterPolicy.Name)
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("definition", clusterPolicy.Definition)
+	if err != nil {
+		return err
+	}
+
+	// err = clusterPolicy.ParseDefinition(clusterPolicy.Definition)
+	// if err != nil {
+	// 	return err
+	// }
+	// policies := clusterPolicy.AttributePoliciesState()
+	// err = d.Set("attribute_policy", policies)
+	// if err != nil {
+	// 	return err
+	// }
+	// TODO: add definitions!!!
+
+	return nil
+}
+
+func resourceClusterPolicyUpdate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*service.DBApiClient)
+	clusterPolicy, err := parsePolicyFromData(d)
+	if err != nil {
+		return err
+	}
+	err = client.ClusterPolicies().Edit(clusterPolicy)
+	if err != nil {
+		return err
+	}
+	return resourceClusterPolicyRead(d, m)
+}
+
+func resourceClusterPolicyDelete(d *schema.ResourceData, m interface{}) error {
+	id := d.Id()
+	client := m.(*service.DBApiClient)
+	return client.ClusterPolicies().Delete(id)
+}
+
+func resourceClusterPolicy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceClusterPolicyCreate,
+		Read:   resourceClusterPolicyRead,
+		Update: resourceClusterPolicyUpdate,
+		Delete: resourceClusterPolicyDelete,
+
+		Schema: map[string]*schema.Schema{
+			"policy_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				Description: "Cluster policy name. This must be unique.\n" +
+					"Length must be between 1 and 100 characters.",
+			},
+			"definition": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Description: "Policy definition JSON document expressed in\n" +
+					"Databricks Policy Definition Language.",
+				ConflictsWith: []string{"attribute_policy"},
+			},
+			"attribute_policy": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				MinItems:      1,
+				ConflictsWith: []string{"definition"},
+				ConfigMode:    schema.SchemaConfigModeAttr,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"path": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": { // type: fixed
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"default_value": { // type: limiting
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"values": { // type: limiting
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"hidden": { // type: fixed
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+						"is_optional": { // type: limiting
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+						"pattern": { // type: regex
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"min_value": { // type: range
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"max_value": { // type: range
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/databricks/resource_databricks_cluster_policy_test.go
+++ b/databricks/resource_databricks_cluster_policy_test.go
@@ -1,0 +1,105 @@
+package databricks
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	"github.com/databrickslabs/databricks-terraform/client/model"
+	"github.com/databrickslabs/databricks-terraform/client/service"
+)
+
+func TestAccClusterPolicyResourceFullLifecycle(t *testing.T) {
+	var policy model.ClusterPolicy
+	randomName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				// create a resource
+				Config: testExternalMetastore(randomName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccIDCallback(t, "databricks_cluster_policy.external_metastore",
+						func(client *service.DBApiClient, id string) error {
+							resp, err := client.ClusterPolicies().Get(id)
+							if err != nil {
+								return err
+							}
+							policy = *resp
+							return nil
+						}),
+					func(s *terraform.State) error {
+						if policy.Definition == "" {
+							return fmt.Errorf("Empty policy definition found")
+						}
+						return nil
+					},
+					resource.TestCheckResourceAttr("databricks_cluster_policy.external_metastore",
+						"name", fmt.Sprintf("Terraform policy %s", randomName)),
+				),
+			},
+			{
+				// add add the name for it
+				Config: testExternalMetastore(randomName + ": UPDATED"),
+				Check: resource.TestCheckResourceAttr("databricks_cluster_policy.external_metastore",
+					"name", fmt.Sprintf("Terraform policy %s", randomName+": UPDATED")),
+			},
+			{
+				Config:  testExternalMetastore(randomName + ": UPDATED"),
+				Destroy: true,
+				Check: testAccIDCallback(t, "databricks_cluster_policy.external_metastore",
+					func(client *service.DBApiClient, id string) error {
+						resp, err := client.ClusterPolicies().Get(id)
+						if err == nil {
+							return fmt.Errorf("Resource must have been deleted but: %v", resp)
+						}
+						return nil
+					}),
+			},
+		},
+	})
+}
+
+func testAccIDCallback(t *testing.T, name string, cb func(client *service.DBApiClient, id string) error) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+		client := testAccProvider.Meta().(*service.DBApiClient)
+		err := cb(client, rs.Primary.ID)
+		return err
+	}
+}
+
+func testExternalMetastore(name string) string {
+	return fmt.Sprintf(`
+	resource "databricks_cluster_policy" "external_metastore" {
+		name = "Terraform policy %s"
+		definition = jsonencode({
+			"spark_conf.spark.hadoop.javax.jdo.option.ConnectionURL": {
+				"type": "fixed",
+				"value": "jdbc:sqlserver://<jdbc-url>"
+			},
+			"spark_conf.spark.hadoop.javax.jdo.option.ConnectionDriverName": {
+				"type": "fixed",
+				"value": "com.microsoft.sqlserver.jdbc.SQLServerDriver"
+			},
+			"spark_conf.spark.databricks.delta.preview.enabled": {
+				"type": "fixed",
+				"value": true
+			},
+			"spark_conf.spark.hadoop.javax.jdo.option.ConnectionUserName": {
+				"type": "fixed",
+				"value": "<metastore-user>"
+			},
+			"spark_conf.spark.hadoop.javax.jdo.option.ConnectionPassword": {
+				"type": "fixed",
+				"value": "<metastore-password>"
+			}
+		  })
+	}`, name)
+}

--- a/databricks/testdata/policy01.json
+++ b/databricks/testdata/policy01.json
@@ -1,0 +1,22 @@
+{
+    "spark_conf.spark.hadoop.javax.jdo.option.ConnectionURL": {
+        "type": "fixed",
+        "value": "jdbc:sqlserver://<jdbc-url>"
+    },
+    "spark_conf.spark.hadoop.javax.jdo.option.ConnectionDriverName": {
+        "type": "fixed",
+        "value": "com.microsoft.sqlserver.jdbc.SQLServerDriver"
+    },
+    "spark_conf.spark.databricks.delta.preview.enabled": {
+        "type": "fixed",
+        "value": true
+    },
+    "spark_conf.spark.hadoop.javax.jdo.option.ConnectionUserName": {
+        "type": "fixed",
+        "value": "<metastore-user>"
+    },
+    "spark_conf.spark.hadoop.javax.jdo.option.ConnectionPassword": {
+        "type": "fixed",
+        "value": "<metastore-password>"
+    }
+}

--- a/docs/resources/cluster_policy.md
+++ b/docs/resources/cluster_policy.md
@@ -1,0 +1,66 @@
+# databricks_cluster_policy Resource
+
+This resource creates a cluster policy, which limits the ability to create clusters based on a set of rules. The policy rules limit the attributes or attribute values available for cluster creation. Cluster policies have ACLs that limit their use to specific users and groups. Only admin users can create, edit, and delete policies. Admin users also have access to all policies.
+
+Cluster policies let you:
+
+* Limit users to create clusters with prescribed settings.
+* Simplify the user interface and enable more users to create their own clusters (by fixing and hiding some values).
+* Control cost by limiting per cluster maximum cost (by setting limits on attributes whose values contribute to hourly price).
+
+Cluster policy permissions limit which policies a user can select in the Policy drop-down when the user creates a cluster:
+
+* If no policies have been created in the workspace, the Policy drop-down does not display.
+* A user who has cluster create permission can select the Free form policy and create fully-configurable clusters.
+* A user who has both cluster create permission and access to cluster policies can select the Free form policy and policies they have access to.
+* A user that has access to only cluster policies, can select the policies they have access to.
+
+## Example Usage
+
+The following example defines [external metastore](https://docs.databricks.com/administration-guide/clusters/policies.html#external-metastore-policy) policy:
+
+```hcl
+resource "databricks_cluster_policy" "external_metastore" {
+    name = "Use Enterprise Metastore"
+    definition = jsonencode({
+        "spark_conf.spark.hadoop.javax.jdo.option.ConnectionURL": {
+            "type": "fixed",
+            "value": "jdbc:sqlserver://<jdbc-url>"
+        },
+        "spark_conf.spark.hadoop.javax.jdo.option.ConnectionDriverName": {
+            "type": "fixed",
+            "value": "com.microsoft.sqlserver.jdbc.SQLServerDriver"
+        },
+        "spark_conf.spark.databricks.delta.preview.enabled": {
+            "type": "fixed",
+            "value": true
+        },
+        "spark_conf.spark.hadoop.javax.jdo.option.ConnectionUserName": {
+            "type": "fixed",
+            "value": "<metastore-user>"
+        },
+        "spark_conf.spark.hadoop.javax.jdo.option.ConnectionPassword": {
+            "type": "fixed",
+            "value": "<metastore-password>"
+        }
+        })
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `name` - (Required) Cluster policy name. This must be unique. Length must be between 1 and 100 characters.
+
+* `definition` - (Required) Policy definition JSON document expressed in [Databricks Policy Definition Language](https://docs.databricks.com/administration-guide/clusters/policies.html#cluster-policy-definition).
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `policy_id` - Canonical unique identifier for the cluster policy.
+
+## Import
+
+-> **Note** Importing this resource is not currently supported.

--- a/website/content/Resources/cluster_policy.md
+++ b/website/content/Resources/cluster_policy.md
@@ -1,0 +1,80 @@
++++
+title = "cluster_policy"
+date = 2020-06-21T23:34:03-04:00
+weight = 15
+chapter = false
+pre = ""
++++
+
+## Resource: `databricks_cluster_policy`
+
+This resource creates a cluster policy, which limits the ability to create clusters based on a set of rules. The policy rules limit the attributes or attribute values available for cluster creation. Cluster policies have ACLs that limit their use to specific users and groups. Only admin users can create, edit, and delete policies. Admin users also have access to all policies.
+
+Cluster policies let you:
+
+* Limit users to create clusters with prescribed settings.
+* Simplify the user interface and enable more users to create their own clusters (by fixing and hiding some values).
+* Control cost by limiting per cluster maximum cost (by setting limits on attributes whose values contribute to hourly price).
+
+Cluster policy permissions limit which policies a user can select in the Policy drop-down when the user creates a cluster:
+
+* If no policies have been created in the workspace, the Policy drop-down does not display.
+* A user who has cluster create permission can select the Free form policy and create fully-configurable clusters.
+* A user who has both cluster create permission and access to cluster policies can select the Free form policy and policies they have access to.
+* A user that has access to only cluster policies, can select the policies they have access to.
+
+## Example Usage
+
+The following example defines [external metastore](https://docs.databricks.com/administration-guide/clusters/policies.html#external-metastore-policy) policy:
+
+```hcl
+resource "databricks_cluster_policy" "external_metastore" {
+    name = "Use Enterprise Metastore"
+    definition = jsonencode({
+        "spark_conf.spark.hadoop.javax.jdo.option.ConnectionURL": {
+            "type": "fixed",
+            "value": "jdbc:sqlserver://<jdbc-url>"
+        },
+        "spark_conf.spark.hadoop.javax.jdo.option.ConnectionDriverName": {
+            "type": "fixed",
+            "value": "com.microsoft.sqlserver.jdbc.SQLServerDriver"
+        },
+        "spark_conf.spark.databricks.delta.preview.enabled": {
+            "type": "fixed",
+            "value": true
+        },
+        "spark_conf.spark.hadoop.javax.jdo.option.ConnectionUserName": {
+            "type": "fixed",
+            "value": "<metastore-user>"
+        },
+        "spark_conf.spark.hadoop.javax.jdo.option.ConnectionPassword": {
+            "type": "fixed",
+            "value": "<metastore-password>"
+        }
+        })
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+#### - `name`:
+> **(Required)** Cluster policy name. This must be unique. Length must be between 1 and 100 characters.
+
+#### - `definition`:
+> **(Required)** Policy definition JSON document expressed in [Databricks Policy Definition Language](https://docs.databricks.com/administration-guide/clusters/policies.html#cluster-policy-definition).
+
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+#### - `policy_id`:
+> Canonical unique identifier for the cluster policy.
+
+## Import
+
+{{% notice note %}}
+Importing this resource is not currently supported.
+{{% /notice %}}


### PR DESCRIPTION
Added new resource, that will allow administrators to limit cluster resource consumption and lock down certain security aspects:

```
resource "databricks_cluster_policy" "external_metastore" {
	name = "External Metastore Example"
	definition = jsonencode({
		"spark_conf.spark.hadoop.javax.jdo.option.ConnectionURL": {
			"type": "fixed",
			"value": "jdbc:sqlserver://<jdbc-url>"
		},
		"spark_conf.spark.hadoop.javax.jdo.option.ConnectionDriverName": {
			"type": "fixed",
			"value": "com.microsoft.sqlserver.jdbc.SQLServerDriver"
		},
		"spark_conf.spark.databricks.delta.preview.enabled": {
			"type": "fixed",
			"value": true
		},
		"spark_conf.spark.hadoop.javax.jdo.option.ConnectionUserName": {
			"type": "fixed",
			"value": "<metastore-user>"
		},
		"spark_conf.spark.hadoop.javax.jdo.option.ConnectionPassword": {
			"type": "fixed",
			"value": "<metastore-password>"
		}
	  })
}
```