### PR TITLE
DBFS Refactor & Fixes to support larger files

### DIFF
--- a/client/model/dbfs.go
+++ b/client/model/dbfs.go
@@ -1,8 +1,47 @@
 package model
 
-// FileInfo contains information when listing files or fetching files from DBFS api
-type FileInfo struct {
+// DBFSFileInfo contains information when listing files or fetching files from DBFS api
+type DBFSFileInfo struct {
 	Path     string `json:"path,omitempty"`
 	IsDir    bool   `json:"is_dir,omitempty"`
 	FileSize int64  `json:"file_size,omitempty"`
+}
+
+// DBFSHandleRequest contains the payload to create a handle which is a connection for uploading blocks of file data
+type DBFSHandleRequest struct {
+	Path      string `json:"path,omitempty" url:"path,omitempty"`
+	Overwrite bool   `json:"overwrite,omitempty" url:"overwrite,omitempty"`
+}
+
+// DBFSHandleResponse contains the response from making an handle request
+type DBFSHandleResponse struct {
+	Handle int64 `json:"handle,omitempty" url:"handle,omitempty"`
+}
+
+// DBFSBlockRequest contains the payload to upload a block of base64 data to a handle
+type DBFSBlockRequest struct {
+	Data   string `json:"data,omitempty" url:"data,omitempty"`
+	Handle int64  `json:"handle,omitempty" url:"handle,omitempty"`
+}
+
+// DBFSCloseRequest contains the payload close an opened connection (handle) to a dbfs path
+type DBFSCloseRequest struct {
+	Handle int64 `json:"handle,omitempty" url:"handle,omitempty"`
+}
+
+// DBFSReadResponse contains the response from reading a portion of a file in DBFS
+type DBFSReadResponse struct {
+	BytesRead int64  `json:"bytes_read,omitempty" url:"bytes_read,omitempty"`
+	Data      string `json:"data,omitempty" url:"data,omitempty"`
+}
+
+// DBFSMkdirRequest contains the payload to make a directory in dbfs
+type DBFSMkdirRequest struct {
+	Path string `json:"path,omitempty" url:"path,omitempty"`
+}
+
+// DBFSDeleteRequest contains the payload to delete a file/directory in dbfs
+type DBFSDeleteRequest struct {
+	Path      string `json:"path,omitempty" url:"path,omitempty"`
+	Recursive bool   `json:"recursive,omitempty" url:"recursive,omitempty"`
 }

--- a/client/service/dbfs_integration_test.go
+++ b/client/service/dbfs_integration_test.go
@@ -78,32 +78,3 @@ func TestCreateFile(t *testing.T) {
 	assert.NoError(t, err, err)
 	assert.True(t, len(items) == 4)
 }
-
-////15500000
-////15500000
-//func TestReadFile(t *testing.T) {
-//	if testing.Short() {
-//		t.Skip("skipping integration test in short mode.")
-//	}
-//
-//	path := "/sri/randomfile"
-//	client := GetIntegrationDBAPIClient()
-//
-//	data, err := client.DBFS().Status(path)
-//	assert.NoError(t, err, err)
-//	t.Log(data)
-//
-//}
-//
-//func TestListRecursive(t *testing.T) {
-//	if testing.Short() {
-//		t.Skip("skipping integration test in short mode.")
-//	}
-//
-//	path := "/andre_mesarovic/mlflow"
-//	client := GetIntegrationDBAPIClient()
-//	data, err := client.DBFS().List(path, true)
-//	assert.NoError(t, err, err)
-//
-//	t.Log(data)
-//}

--- a/client/service/dbfs_test.go
+++ b/client/service/dbfs_test.go
@@ -549,7 +549,7 @@ func TestDBFSAPI_Status(t *testing.T) {
 			args: args{
 				Path: "mypath",
 			},
-			want: model.FileInfo{
+			want: model.DBFSFileInfo{
 				Path:     "/a.cpp",
 				IsDir:    false,
 				FileSize: 261,
@@ -564,7 +564,7 @@ func TestDBFSAPI_Status(t *testing.T) {
 			args: args{
 				Path: "mypath",
 			},
-			want:    model.FileInfo{},
+			want:    model.DBFSFileInfo{},
 			wantErr: true,
 		},
 	}
@@ -589,7 +589,7 @@ func TestDBFSAPI_ListNonRecursive(t *testing.T) {
 		responseStatus int
 		args           args
 		wantURI        string
-		want           []model.FileInfo
+		want           []model.DBFSFileInfo
 		wantErr        bool
 	}{
 		{
@@ -615,7 +615,7 @@ func TestDBFSAPI_ListNonRecursive(t *testing.T) {
 				Recursive: false,
 			},
 			wantURI: "/api/2.0/dbfs/list?path=%2F",
-			want: []model.FileInfo{
+			want: []model.DBFSFileInfo{
 				{
 					Path:     "/a.cpp",
 					IsDir:    false,
@@ -664,7 +664,7 @@ func TestDBFSAPI_ListRecursive(t *testing.T) {
 		responseStatus []int
 		args           []interface{}
 		wantURI        []string
-		want           []model.FileInfo
+		want           []model.DBFSFileInfo
 		wantErr        bool
 	}{
 		{
@@ -701,7 +701,7 @@ func TestDBFSAPI_ListRecursive(t *testing.T) {
 				},
 			},
 			wantURI: []string{"/api/2.0/dbfs/list?path=%2F", "/api/2.0/dbfs/list?path=%2Ffoldera"},
-			want: []model.FileInfo{
+			want: []model.DBFSFileInfo{
 				{
 					Path:     "/a.cpp",
 					IsDir:    false,

--- a/databricks/resource_databricks_dbfs_file_test.go
+++ b/databricks/resource_databricks_dbfs_file_test.go
@@ -1,0 +1,614 @@
+package databricks
+
+import (
+	"bytes"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+	"github.com/databrickslabs/databricks-terraform/client/model"
+	"github.com/databrickslabs/databricks-terraform/client/service"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/stretchr/testify/assert"
+)
+
+func GetIntegrationDBAPIClient() *service.DBApiClient {
+	var config service.DBApiClientConfig
+	config.Token = os.Getenv("DATABRICKS_TOKEN")
+	config.Host = os.Getenv("DATABRICKS_HOST")
+	config.Setup()
+
+	var c service.DBApiClient
+	c.SetConfig(&config)
+	return &c
+}
+
+func getTestDBFSFileData() (string, error) {
+	return notebookToB64("testdata/tf-test-python.py")
+}
+
+func getBaseDBFSMkdirFixtures(path string) []HTTPFixture {
+	return []HTTPFixture{
+		{
+			Method:   http.MethodPost,
+			Resource: "/api/2.0/dbfs/mkdirs",
+			ExpectedRequest: model.DBFSMkdirRequest{
+				Path: path,
+			},
+		},
+	}
+}
+
+func getBaseDBFSDeleteFixtures(path string, recursive bool) []HTTPFixture {
+	return []HTTPFixture{
+		{
+			Method:   http.MethodPost,
+			Resource: "/api/2.0/dbfs/delete",
+			ExpectedRequest: model.DBFSDeleteRequest{
+				Path:      path,
+				Recursive: recursive,
+			},
+		},
+	}
+}
+
+func getBaseDBFSFileGetStatusFixtures(path string, fileSize int64, isDir bool, isMissing bool) []HTTPFixture {
+	if isMissing {
+		return []HTTPFixture{
+			{
+				Method:   http.MethodGet,
+				Resource: fmt.Sprintf("/api/2.0/dbfs/get-status?path=%s", url.PathEscape(path)),
+				Status:   http.StatusNotFound,
+			},
+		}
+	}
+	return []HTTPFixture{
+		{
+			Method:   http.MethodGet,
+			Resource: fmt.Sprintf("/api/2.0/dbfs/get-status?path=%s", url.PathEscape(path)),
+			Response: model.DBFSFileInfo{
+				Path:     path,
+				IsDir:    isDir,
+				FileSize: fileSize,
+			},
+		},
+	}
+}
+
+func getBaseDBFSFileReadFixtures(path string, content string, fileSize int64) []HTTPFixture {
+	return []HTTPFixture{
+		{
+			Method:   http.MethodGet,
+			Resource: fmt.Sprintf("/api/2.0/dbfs/read?length=1000000\u0026path=%s", url.PathEscape(path)),
+			Response: model.DBFSReadResponse{
+				BytesRead: fileSize,
+				Data:      content,
+			},
+		},
+	}
+}
+
+func getBaseDBFSFileCreateFixtures(path string, overwrite bool, handleId int64, content string, fileSize int64) []HTTPFixture {
+	return []HTTPFixture{
+		{
+			Method:   http.MethodPost,
+			Resource: "/api/2.0/dbfs/create",
+			ExpectedRequest: model.DBFSHandleRequest{
+				Path:      path,
+				Overwrite: overwrite,
+			},
+			Response: model.DBFSHandleResponse{Handle: handleId},
+		},
+		{
+			Method:   http.MethodPost,
+			Resource: "/api/2.0/dbfs/add-block",
+			Response: model.DBFSBlockRequest{
+				Data:   content,
+				Handle: handleId,
+			},
+		},
+		{
+			Method:   http.MethodPost,
+			Resource: "/api/2.0/dbfs/close",
+			Response: model.DBFSCloseRequest{
+				Handle: handleId,
+			},
+		},
+		{
+			Method:   http.MethodGet,
+			Resource: fmt.Sprintf("/api/2.0/dbfs/get-status?path=%s", url.PathEscape(path)),
+			Response: model.DBFSFileInfo{
+				Path:     path,
+				IsDir:    false,
+				FileSize: fileSize,
+			},
+		},
+	}
+}
+
+func TestDBFSFileCreate(t *testing.T) {
+	handleId := int64(acctest.RandInt())
+
+	randomDir := "/" + acctest.RandString(5)
+	randomPath := "/" + acctest.RandString(5)
+	randomPathWithDir := randomDir + randomPath
+	content, err := getTestDBFSFileData()
+	assert.NoError(t, err, err)
+	checksum, err := getMD5(content)
+	assert.NoError(t, err, err)
+	fileSize := int64(100)
+
+	tests := []struct {
+		name               string
+		fixtures           []HTTPFixture
+		content            string
+		contentB64MD5      string
+		mkdirs             bool
+		overwrite          bool
+		fileSize           int64
+		validateRemoteFile bool
+		path               string
+		expectedError      error
+	}{
+		{
+			name: "TestDBFSFileCreate_NoMkdirs",
+			fixtures: UnionFixturesLists(
+				getBaseDBFSFileCreateFixtures(randomPath, true, handleId, content, fileSize),
+				getBaseDBFSFileGetStatusFixtures(randomPath, fileSize, false, false),
+				getBaseDBFSFileReadFixtures(randomPath, content, fileSize),
+			),
+			content:            content,
+			mkdirs:             false,
+			contentB64MD5:      checksum,
+			overwrite:          true,
+			fileSize:           fileSize,
+			validateRemoteFile: true,
+			path:               randomPath,
+		},
+		{
+			name: "TestDBFSFileCreate_Mkdirs_RootDir",
+			fixtures: UnionFixturesLists(
+				getBaseDBFSFileCreateFixtures(randomPath, true, handleId, content, fileSize),
+				getBaseDBFSFileGetStatusFixtures(randomPath, fileSize, false, false),
+				getBaseDBFSFileReadFixtures(randomPath, content, fileSize),
+			),
+			content:            content,
+			contentB64MD5:      checksum,
+			mkdirs:             true,
+			overwrite:          true,
+			fileSize:           fileSize,
+			validateRemoteFile: true,
+			path:               randomPath,
+		},
+		{
+			name: "TestDBFSFileCreate_Mkdirs_NonRootDir_Exists",
+			fixtures: UnionFixturesLists(
+				getBaseDBFSFileGetStatusFixtures(randomDir, fileSize, true, false),
+				getBaseDBFSFileCreateFixtures(randomPathWithDir, true, handleId, content, fileSize),
+				getBaseDBFSFileGetStatusFixtures(randomPathWithDir, fileSize, false, false),
+				getBaseDBFSFileReadFixtures(randomPathWithDir, content, fileSize),
+			),
+			content:            content,
+			contentB64MD5:      checksum,
+			mkdirs:             true,
+			overwrite:          true,
+			fileSize:           fileSize,
+			validateRemoteFile: true,
+			path:               randomPathWithDir,
+		},
+		{
+			name: "TestDBFSFileCreate_Mkdirs_NonRootDir_DoesNotExist",
+			fixtures: UnionFixturesLists(
+				getBaseDBFSFileGetStatusFixtures(randomDir, fileSize, true, true),
+				getBaseDBFSMkdirFixtures(randomDir),
+				getBaseDBFSFileCreateFixtures(randomPathWithDir, true, handleId, content, fileSize),
+				getBaseDBFSFileGetStatusFixtures(randomPathWithDir, fileSize, false, false),
+				getBaseDBFSFileReadFixtures(randomPathWithDir, content, fileSize),
+			),
+			content:            content,
+			contentB64MD5:      checksum,
+			mkdirs:             true,
+			overwrite:          true,
+			fileSize:           fileSize,
+			validateRemoteFile: true,
+			path:               randomPathWithDir,
+		},
+		{
+			name: "TestDBFSFileCreate_Mkdirs_ParentDirIsNotDir",
+			fixtures: UnionFixturesLists(
+				getBaseDBFSFileGetStatusFixtures(randomDir, fileSize, false, false),
+				getBaseDBFSFileCreateFixtures(randomPathWithDir, true, handleId, content, fileSize),
+				getBaseDBFSFileGetStatusFixtures(randomPathWithDir, fileSize, false, false),
+				getBaseDBFSFileReadFixtures(randomPathWithDir, content, fileSize),
+			),
+			content:            content,
+			contentB64MD5:      checksum,
+			mkdirs:             true,
+			overwrite:          true,
+			fileSize:           fileSize,
+			validateRemoteFile: true,
+			path:               randomPathWithDir,
+			expectedError:      ParentPathIsFileError,
+		},
+		{
+			name: "TestDBFSFileCreate_NoValidateRemote",
+			fixtures: UnionFixturesLists(
+				getBaseDBFSFileCreateFixtures(randomPathWithDir, true, handleId, content, fileSize),
+				getBaseDBFSFileGetStatusFixtures(randomPathWithDir, fileSize, false, false),
+			),
+			content:            content,
+			contentB64MD5:      checksum,
+			mkdirs:             false,
+			overwrite:          true,
+			fileSize:           fileSize,
+			validateRemoteFile: false,
+			path:               randomPathWithDir,
+			expectedError:      ParentPathIsFileError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d, err := ResourceTester(t, tt.fixtures, resourceDBFSFile, map[string]interface{}{
+				"content":              tt.content,
+				"content_b64_md5":      tt.contentB64MD5,
+				"path":                 tt.path,
+				"overwrite":            tt.overwrite,
+				"mkdirs":               tt.mkdirs,
+				"validate_remote_file": tt.validateRemoteFile,
+			}, resourceDBFSFileCreate)
+			if tt.expectedError == nil {
+				assert.NoError(t, err, err)
+				assert.Equal(t, tt.path, d.Id())
+				assert.Equal(t, tt.content, d.Get("content"))
+				assert.Equal(t, tt.path, d.Get("path"))
+				assert.Equal(t, int(tt.fileSize), d.Get("file_size"))
+			} else {
+				assert.Error(t, tt.expectedError, err)
+			}
+		})
+	}
+}
+
+func TestDBFSFileCreate_ViaSource(t *testing.T) {
+	handleId := int64(acctest.RandInt())
+	randomDir := "/" + acctest.RandString(5)
+	randomPath := "/" + acctest.RandString(5)
+	randomPathWithDir := randomDir + randomPath
+	content, err := getTestDBFSFileData()
+	assert.NoError(t, err, err)
+	source := testCreateTempFile(t, content)
+	defer os.Remove(source)
+	sourceB64, err := getLocalFileB64(source)
+	assert.NoError(t, err, err)
+	sourceMD5, err := getMD5(sourceB64)
+	assert.NoError(t, err, err)
+	fileSize := int64(100)
+
+	d, err := ResourceTester(t, UnionFixturesLists(
+		getBaseDBFSFileGetStatusFixtures(randomDir, fileSize, true, false),
+		getBaseDBFSFileCreateFixtures(randomPathWithDir, true, handleId, sourceB64, fileSize),
+		getBaseDBFSFileGetStatusFixtures(randomPathWithDir, fileSize, false, false),
+		getBaseDBFSFileReadFixtures(randomPathWithDir, sourceB64, fileSize),
+	), resourceDBFSFile, map[string]interface{}{
+		"source":               source,
+		"content_b64_md5":      sourceMD5,
+		"path":                 randomPathWithDir,
+		"overwrite":            true,
+		"mkdirs":               true,
+		"validate_remote_file": true,
+	}, resourceDBFSFileCreate)
+	assert.NoError(t, err, err)
+	assert.Equal(t, randomPathWithDir, d.Id())
+	assert.Equal(t, source, d.Get("source"))
+	assert.Equal(t, randomPathWithDir, d.Get("path"))
+	assert.Equal(t, sourceMD5, d.Get("content_b64_md5"))
+}
+
+func TestDBFSFileUpdate(t *testing.T) {
+	randomPath := "/" + acctest.RandString(5)
+	content, err := getTestDBFSFileData()
+	assert.NoError(t, err, err)
+	checksum, err := getMD5(content)
+	assert.NoError(t, err, err)
+	fileSize := int64(100)
+	fixtures := UnionFixturesLists(
+		getBaseDBFSFileGetStatusFixtures(randomPath, fileSize, false, false),
+		getBaseDBFSFileReadFixtures(randomPath, content, fileSize),
+	)
+	d, err := ResourceTester(t, fixtures, resourceDBFSFile, map[string]interface{}{
+		"content":              content,
+		"content_b64_md5":      checksum,
+		"path":                 randomPath,
+		"overwrite":            true,
+		"mkdirs":               true,
+		"validate_remote_file": true,
+	}, func(d *schema.ResourceData, c interface{}) error {
+		d.SetId(randomPath)
+		return resourceDBFSFileUpdate(d, c)
+	})
+
+	assert.NoError(t, err, err)
+	assert.Equal(t, randomPath, d.Id())
+	assert.Equal(t, true, d.Get("overwrite"))
+	assert.Equal(t, true, d.Get("mkdirs"))
+	assert.Equal(t, true, d.Get("validate_remote_file"))
+}
+
+func TestDBFSFileDelete(t *testing.T) {
+	content, err := getTestDBFSFileData()
+	assert.NoError(t, err, err)
+	checksum, err := getMD5(content)
+	assert.NoError(t, err, err)
+	randomPath := "/" + acctest.RandString(5)
+	fixtures := UnionFixturesLists(
+		getBaseDBFSDeleteFixtures(randomPath, false),
+	)
+	d, err := ResourceTester(t, fixtures, resourceDBFSFile, map[string]interface{}{
+		"content":              content,
+		"content_b64_md5":      checksum,
+		"path":                 randomPath,
+		"overwrite":            true,
+		"mkdirs":               true,
+		"validate_remote_file": true,
+	}, func(d *schema.ResourceData, c interface{}) error {
+		d.SetId(randomPath)
+		return resourceDBFSFileDelete(d, c)
+	})
+
+	assert.NoError(t, err, err)
+	assert.Equal(t, randomPath, d.Id())
+	assert.Equal(t, true, d.Get("overwrite"))
+	assert.Equal(t, true, d.Get("mkdirs"))
+	assert.Equal(t, true, d.Get("validate_remote_file"))
+}
+
+func TestDBFSFileRead_IsMissingResource(t *testing.T) {
+	randomPath := "/" + acctest.RandString(5)
+	content, err := getTestDBFSFileData()
+	assert.NoError(t, err, err)
+	checksum, err := getMD5(content)
+	assert.NoError(t, err, err)
+	fileSize := int64(100)
+	fixtures := UnionFixturesLists(
+		getBaseDBFSFileGetStatusFixtures(randomPath, fileSize, false, true),
+	)
+	d, err := ResourceTester(t, fixtures, resourceDBFSFile, map[string]interface{}{
+		"content":              content,
+		"content_b64_md5":      checksum,
+		"path":                 randomPath,
+		"overwrite":            true,
+		"mkdirs":               true,
+		"validate_remote_file": false,
+	}, func(d *schema.ResourceData, c interface{}) error {
+		d.SetId(randomPath)
+		return resourceDBFSFileRead(d, c)
+	})
+
+	assert.NoError(t, err, err)
+	assert.Equal(t, "", d.Id())
+}
+
+func TestAccDatabricksDBFSFile_CreateViaContent(t *testing.T) {
+	content := acctest.RandString(10000)
+	base64Str := base64.StdEncoding.EncodeToString([]byte(content))
+	path := "/tmp/tf-test/file-content1"
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testDBFSFileResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:  testDBFSFileContentResource(base64Str, 1),
+				Destroy: false,
+			},
+			{
+				//Deleting and recreating the token
+				PreConfig: func() {
+					client := testAccProvider.Meta().(*service.DBApiClient)
+					err := client.DBFS().Delete(path, false)
+					assert.NoError(t, err, err)
+				},
+				Config:             testDBFSFileContentResource(base64Str, 1),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config:  testDBFSFileContentResource(base64Str, 1),
+				Destroy: false,
+			},
+		},
+	})
+}
+
+func TestAccDatabricksDBFSFile_CreateVeryBigFiles(t *testing.T) {
+	// Creating via content this will fail, needs to be uploaded via source
+	content := acctest.RandString(5000000)
+	base64Str := base64.StdEncoding.EncodeToString([]byte(content))
+	source := testCreateTempFile(t, content)
+	defer os.Remove(source)
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testDBFSFileResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testDBFSFileContentResource(base64Str, 1),
+				Destroy:     false,
+				ExpectError: regexp.MustCompile(`.*rpc error.*`),
+			},
+			{
+				Config:  testDBFSFileSourceResource(source, 1),
+				Destroy: false,
+			},
+		},
+	})
+}
+
+func TestAccDatabricksDBFSFile_CreateViaSource(t *testing.T) {
+	content := acctest.RandString(10)
+	source := testCreateTempFile(t, content)
+	defer os.Remove(source)
+	b64, err := getLocalFileB64(source)
+	assert.NoError(t, err, err)
+	md5, err := getMD5(b64)
+	assert.NoError(t, err, err)
+
+	content2 := acctest.RandString(10)
+	source2 := testCreateTempFile(t, content2)
+	defer os.Remove(source2)
+	source2B64, err := getLocalFileB64(source2)
+	assert.NoError(t, err, err)
+	source2Md5, err := getMD5(source2B64)
+	assert.NoError(t, err, err)
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testDBFSFileResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testDBFSFileSourceResource(source, 1),
+				Check: resource.ComposeTestCheckFunc(
+					// query the API to retrieve the tokenInfo object
+					testCheckDBFSFileResourceExists("databricks_dbfs_file.file_1", b64, t),
+					resource.TestCheckResourceAttr("databricks_dbfs_file.file_1", "content_b64_md5", md5),
+				),
+				Destroy: false,
+			},
+			{
+				Config: testDBFSFileSourceResource(source2, 1),
+				Check: resource.ComposeTestCheckFunc(
+					// query the API to retrieve the tokenInfo object
+					testCheckDBFSFileResourceExists("databricks_dbfs_file.file_1", source2B64, t),
+					resource.TestCheckResourceAttr("databricks_dbfs_file.file_1", "content_b64_md5", source2Md5),
+				),
+				Destroy: false,
+			},
+		},
+	})
+}
+
+// testAccAzureCheckTokenResourceExists queries the API and retrieves the matching Widget.
+func testCheckDBFSFileResourceExists(n string, b64 string, t *testing.T) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// find the corresponding state object
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		// retrieve the configured client from the test setup
+		conn := testAccProvider.Meta().(*service.DBApiClient)
+		resp, err := conn.DBFS().Read(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		// If no error, assign the response Widget attribute to the widget pointer
+		assert.Equal(t, resp, b64)
+		// If no error, assign the response Widget attribute to the widget pointer
+		respCheckSum, err := getMD5(resp)
+		assert.NoError(t, err, err)
+		expectedCheckSum, err := getMD5(b64)
+		assert.NoError(t, err, err)
+		assert.Equal(t, expectedCheckSum, respCheckSum)
+		return nil
+		//return fmt.Errorf("Token (%s) not found", rs.Primary.ID)
+	}
+}
+
+func testDBFSFileResourceDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*service.DBApiClient)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "databricks_dbfs_file" {
+			continue
+		}
+		_, err := client.DBFS().Read(rs.Primary.ID)
+		if err != nil {
+			return nil
+		}
+		return errors.New("resource dbfs file is not cleaned up")
+	}
+	return nil
+}
+
+func testDBFSFileContentResource(content string, count int) string {
+	var strBuffer bytes.Buffer
+	for i := 1; i <= count; i++ {
+		strBuffer.WriteString(fmt.Sprintf(`
+								resource "databricks_dbfs_file" "file_%[2]v" {
+								  content = "%[1]s"
+								  content_b64_md5 = md5("%[1]s")
+								  path = "/tmp/tf-test/file-content%[2]v"
+								  overwrite = "false"
+								  mkdirs = "true"
+								  validate_remote_file = "true"
+								}
+		`, content, i))
+	}
+	return strBuffer.String()
+}
+
+func testDBFSFileSourceResource(source string, count int) string {
+	var strBuffer bytes.Buffer
+	for i := 1; i <= count; i++ {
+		strBuffer.WriteString(fmt.Sprintf(`
+								resource "databricks_dbfs_file" "file_%[2]v" {
+								  source = "%[1]s"
+								  content_b64_md5 = md5(filebase64("%[1]s"))
+								  path = "/tmp/tf-test/file-source%[2]v"
+								  overwrite = "false"
+								  mkdirs = "true"
+								  validate_remote_file = "true"
+								}
+		`, source, i))
+	}
+	return strBuffer.String()
+}
+
+func testCreateTempFile(t *testing.T, data string) string {
+	tmpFile, err := ioutil.TempFile("", "tf-test-create-dbfs-file")
+	if err != nil {
+		t.Fatal(err)
+	}
+	filename := tmpFile.Name()
+
+	err = ioutil.WriteFile(filename, []byte(data), 0644)
+	if err != nil {
+		os.Remove(filename)
+		t.Fatal(err)
+	}
+
+	return filename
+}
+
+func TestDatabricksFile_Base64(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode.")
+	}
+
+	client := GetIntegrationDBAPIClient()
+	pythonNotebookDataB64, err := getLocalFileB64("testdata/tf-test-python.py")
+	assert.NoError(t, err, err)
+	expected, err := getMD5(pythonNotebookDataB64)
+	assert.NoError(t, err, err)
+	t.Log(expected)
+	t.Log(pythonNotebookDataB64)
+	err = client.DBFS().Create("/tmp/tf-test/testfile.txt", true, pythonNotebookDataB64)
+	assert.NoError(t, err, err)
+	data, err := client.DBFS().Read("/tmp/tf-test/testfile.txt")
+	t.Log(data)
+	assert.NoError(t, err, err)
+	actual, err := getMD5(data)
+	assert.NoError(t, err, err)
+	assert.Equal(t, expected, actual)
+}

--- a/databricks/resource_databricks_notebook.go
+++ b/databricks/resource_databricks_notebook.go
@@ -101,13 +101,13 @@ func resourceNotebookCreate(d *schema.ResourceData, m interface{}) error {
 	mkdirs := d.Get("mkdirs").(bool)
 
 	if mkdirs {
-		parentDir, err := getNotebookParentDirPath(path)
+		parentDir, err := GetParentDirPath(path)
 		switch err {
 		// Notebook path is root directory so no need to make directory and there is no parent
-		case notebookDirPathRootDirError:
+		case DirPathRootDirError:
 			break
 		// Notebook path is empty thus a valid error
-		case notebookPathEmptyError:
+		case PathEmptyError:
 			return err
 		//	Notebook path is valid and has a parent directory
 		case nil:
@@ -283,28 +283,4 @@ func ValidateNotebookPath(val interface{}, key string) (warns []string, errs []e
 	}
 
 	return nil, errs
-}
-
-var notebookPathEmptyError error = errors.New("notebook path is empty")
-
-// we would never want to handle root directories in regards to creating them
-var notebookDirPathRootDirError error = errors.New("dir path is root directory")
-
-// Os libraries behave bizarely on windows as they will replace slashes with other values.
-// This causes issues & errors when submitting the request
-func getNotebookParentDirPath(filePath string) (string, error) {
-	if filePath == "" {
-		return "", notebookPathEmptyError
-	}
-
-	pathParts := strings.Split(filePath, "/")
-
-	// if length of pathParts is just two items then the parent should be the root directory
-	if len(pathParts) == 2 {
-		return "", notebookDirPathRootDirError
-	}
-
-	dirPath := strings.Join(pathParts[0:len(pathParts)-1], "/")
-
-	return dirPath, nil
 }

--- a/databricks/resource_databricks_notebook_test.go
+++ b/databricks/resource_databricks_notebook_test.go
@@ -20,42 +20,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDatabricksNotebook_GetDirPath(t *testing.T) {
-	tests := []struct {
-		name            string
-		path            string
-		expectedDirPath string
-		expectedError   error
-	}{
-		{
-			name:            "basic_path",
-			path:            "/test/abc/file.py",
-			expectedDirPath: "/test/abc",
-			expectedError:   nil,
-		},
-		{
-			name:            "root_path",
-			path:            "/file.py",
-			expectedDirPath: "",
-			expectedError:   notebookDirPathRootDirError,
-		},
-		{
-			name:            "empty_path",
-			path:            "",
-			expectedDirPath: "",
-			expectedError:   notebookPathEmptyError,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			dirPath, err := getNotebookParentDirPath(tt.path)
-			assert.Equal(t, tt.expectedDirPath, dirPath, "dirPath values should match")
-			assert.Equal(t, tt.expectedError, err, "err values should match")
-		})
-	}
-}
-
 func TestValidateNotebookPath(t *testing.T) {
 	testCases := []struct {
 		name         string
@@ -407,7 +371,7 @@ func testNotebookResourceDestroy(s *terraform.State) error {
 		if err != nil {
 			return nil
 		}
-		return errors.New("resource Scim Group is not cleaned up")
+		return errors.New("resource notebook is not cleaned up")
 	}
 	return nil
 }

--- a/databricks/utils.go
+++ b/databricks/utils.go
@@ -1,6 +1,7 @@
 package databricks
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -114,4 +115,28 @@ func ValidateInstanceProfileARN(val interface{}, key string) (warns []string, er
 			key, instanceProfileArn.Resource, v)}
 	}
 	return nil, nil
+}
+
+var PathEmptyError error = errors.New("provided path is empty")
+
+// we would never want to handle root directories in regards to creating them
+var DirPathRootDirError error = errors.New("dir path is root directory")
+
+// Os libraries behave bizarely on windows as they will replace slashes with other values.
+// This causes issues & errors when submitting the request
+func GetParentDirPath(filePath string) (string, error) {
+	if filePath == "" {
+		return "", PathEmptyError
+	}
+
+	pathParts := strings.Split(filePath, "/")
+
+	// if length of pathParts is just two items then the parent should be the root directory
+	if len(pathParts) == 2 {
+		return "", DirPathRootDirError
+	}
+
+	dirPath := strings.Join(pathParts[0:len(pathParts)-1], "/")
+
+	return dirPath, nil
 }

--- a/databricks/utils_test.go
+++ b/databricks/utils_test.go
@@ -270,6 +270,42 @@ func testVerifyResourceIsMissing(t *testing.T, readFunc func() error) {
 	}
 }
 
+func TestGetParentDirPath(t *testing.T) {
+	tests := []struct {
+		name            string
+		path            string
+		expectedDirPath string
+		expectedError   error
+	}{
+		{
+			name:            "basic_path",
+			path:            "/test/abc/file.py",
+			expectedDirPath: "/test/abc",
+			expectedError:   nil,
+		},
+		{
+			name:            "root_path",
+			path:            "/file.py",
+			expectedDirPath: "",
+			expectedError:   DirPathRootDirError,
+		},
+		{
+			name:            "empty_path",
+			path:            "",
+			expectedDirPath: "",
+			expectedError:   PathEmptyError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dirPath, err := GetParentDirPath(tt.path)
+			assert.Equal(t, tt.expectedDirPath, dirPath, "dirPath values should match")
+			assert.Equal(t, tt.expectedError, err, "err values should match")
+		})
+	}
+}
+
 type errorSlice []error
 
 func (a errorSlice) Len() int           { return len(a) }
@@ -283,6 +319,13 @@ type HTTPFixture struct {
 	Response        interface{}
 	Status          int
 	ExpectedRequest interface{}
+}
+
+func UnionFixturesLists(fixturesLists ...[]HTTPFixture) (fixtureList []HTTPFixture) {
+	for _, v := range fixturesLists {
+		fixtureList = append(fixtureList, v...)
+	}
+	return
 }
 
 // ResourceTester helps testing HTTP resources with fixtures

--- a/docs/resources/dbfs_file.md
+++ b/docs/resources/dbfs_file.md
@@ -1,12 +1,4 @@
-+++
-title = "dbfs_file"
-date = 2020-04-20T23:34:03-04:00
-weight = 15
-chapter = false
-pre = ""
-+++
-
-## Resource: `databricks_dbfs_file`
+# databricks_dbfs_file Resource`
 
 This is a resource that lets you create, get and delete files in DBFS (Databricks File System).
 
@@ -38,6 +30,7 @@ resource "databricks_dbfs_file" "my_dbfs_file" {
 }
 ```
 
+    
 ## Argument Reference
 
 The following arguments are supported:

--- a/docs/resources/dbfs_file.md
+++ b/docs/resources/dbfs_file.md
@@ -35,29 +35,19 @@ resource "databricks_dbfs_file" "my_dbfs_file" {
 
 The following arguments are supported:
 
-#### - `content`:
-> **(Optional)** The content of the file as a base64 encoded string.
+* `content` - (Optional) The content of the file as a base64 encoded string.
 
-#### - `source`:
-> **(Optional)** The full absolute path to the file. Please use [pathexpand](https://www.terraform.io/docs/configuration/functions/pathexpand.html).
+* `source` - (Optional) The full absolute path to the file. Please use [pathexpand](https://www.terraform.io/docs/configuration/functions/pathexpand.html).
 
-#### - `content_b64_md5`:
-> **(Optional)** The checksum for the content please use the [md5](https://www.terraform.io/docs/configuration/functions/md5.html) and [filebase64](https://www.terraform.io/docs/configuration/functions/filebase64.html) functions in terraform to retrieve the checksum.
+* `content_b64_md5` - (Required) The checksum for the content please use the [md5](https://www.terraform.io/docs/configuration/functions/md5.html) and [filebase64](https://www.terraform.io/docs/configuration/functions/filebase64.html) functions in terraform to retrieve the checksum.
 
-#### - `path`:
-> **(Required)** The path of the file in which you wish to save.
+* `path` - (Required) The path of the file in which you wish to save.
 
-#### - `overwrite`:
-> **(Optional)** This is used to determine whether it should delete the 
-existing file when with the same name when it writes. The default is set to false.
+* `overwrite` - (Optional) This is used to determine whether it should delete the existing file when with the same name when it writes. The default is set to false.
 
-#### - `mkdirs`:
-> **(Optional)** When the resource is created, this field is used to determine
-if it needs to make the parent directories. The default value is set to true.
+* `mkdirs` - (Optional) When the resource is created, this field is used to determine if it needs to make the parent directories. The default value is set to true.
 
-#### - `validate_remote_file`:
-> **(Optional)** This is used to compare the 
-actual contents of the file to determine if the remote file is valid or not. If the base64 content is different 
+* `validate_remote_file` - (Optional) This is used to compare the actual contents of the file to determine if the remote file is valid or not. If the base64 content is different 
 it will attempt to do a delete, create.
 
 
@@ -65,11 +55,9 @@ it will attempt to do a delete, create.
 
 In addition to all arguments above, the following attributes are exported:
 
-#### - `id`:
-> The id for the dbfs file object.
+* `id` - The id for the dbfs file object.
 
-#### - `file_size`:
-> The file size of the file that is being tracked by this resource in bytes.
+* `file_size` - The file size of the file that is being tracked by this resource in bytes.
 
 
 ## Import

--- a/docs/resources/notebook.md
+++ b/docs/resources/notebook.md
@@ -27,46 +27,36 @@ resource "databricks_notebook" "notebook" {
 
 The following arguments are supported:
 
-#### - `content`:
-> **(Required)** The base64-encoded content. If the limit (10MB) is exceeded, 
+* `content` - (Required) The base64-encoded content. If the limit (10MB) is exceeded, 
 exception with error code MAX_NOTEBOOK_SIZE_EXCEEDED will be thrown.
 
-#### - `path`:
-> **(Required)** The absolute path of the notebook or directory, beginning with "/", e.g. "/mynotebook"
+* `path` -  (Required) The absolute path of the notebook or directory, beginning with "/", e.g. "/mynotebook"
 Exporting a directory is supported only for DBC. This field is **required**.
 
-#### - `language`:
-> **(Required)** The language. If format is set to SOURCE, 
+* `language` -  (Required) The language. If format is set to SOURCE, 
 this field is required; otherwise, it will be ignored. Possible choices are SCALA, PYTHON, SQL, R.
 
-#### - `overwrite`:
-> **(Required)** The flag that specifies whether to overwrite existing object. 
+* `overwrite` - (Required) The flag that specifies whether to overwrite existing object. 
 It is false by default. For DBC format, overwrite is not supported since it may contain a directory.
 
-#### - `mkdirs`:
-> **(Deprecated)** **(Required)** Create the given directory and necessary parent directories 
+* `mkdirs` - (Required) Create the given directory and necessary parent directories 
 if they do not exists. If there exists an object (not a directory) at any prefix of the input path, this call 
 returns an error RESOURCE_ALREADY_EXISTS. If this operation fails it may have succeeded in creating some of the necessary parent directories.
 
-#### - `format`:
-> **(Required)** This specifies the format of the file to be imported. 
-This resource currently only supports SOURCE. The value is case sensitive. 
->SOURCE is suitable for .scala, .py, .r, .sql extension based files, HTML for .html files, JUPYTER for .ipynb files, 
->and DBC for .dbc files. Though the API supports DBC, HTML, and JUPYTER currently we do not support them as effectively 
->identifying DIFF is currently not feasible.
+* `format` -  (Required) This specifies the format of the file to be imported. 
+This resource currently only supports SOURCE. The value is case sensitive. SOURCE is suitable for .scala, .py, .r, .sql extension based files, HTML for .html files, JUPYTER for .ipynb files, 
+and DBC for .dbc files. Though the API supports DBC, HTML, and JUPYTER currently we do not support them as effectively 
+identifying DIFF is currently not feasible.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-#### - `id`:
-> The id for the notebook object.
+* `id` -  The id for the notebook object.
 
-#### - `object_id`:
-> Unique identifier for a NOTEBOOK or DIRECTORY.
+* `object_id` -  Unique identifier for a NOTEBOOK or DIRECTORY.
 
-#### - `object_type`:
-> The type of the object. It could be NOTEBOOK, DIRECTORY or LIBRARY.
+* `object_type` -  The type of the object. It could be NOTEBOOK, DIRECTORY or LIBRARY.
 
 ## Import
 

--- a/website/content/Resources/dbfs_file.md
+++ b/website/content/Resources/dbfs_file.md
@@ -49,7 +49,7 @@ The following arguments are supported:
 > **(Optional)** The full absolute path to the file. Please use [pathexpand](https://www.terraform.io/docs/configuration/functions/pathexpand.html).
 
 #### - `content_b64_md5`:
-> **(Optional)** The checksum for the content please use the [md5](https://www.terraform.io/docs/configuration/functions/md5.html) and [filebase64](https://www.terraform.io/docs/configuration/functions/filebase64.html) functions in terraform to retrieve the checksum.
+> **(Required)** The checksum for the content please use the [md5](https://www.terraform.io/docs/configuration/functions/md5.html) and [filebase64](https://www.terraform.io/docs/configuration/functions/filebase64.html) functions in terraform to retrieve the checksum.
 
 #### - `path`:
 > **(Required)** The path of the file in which you wish to save.

--- a/website/content/Resources/notebook.md
+++ b/website/content/Resources/notebook.md
@@ -63,7 +63,7 @@ this field is required; otherwise, it will be ignored. Possible choices are SCAL
 It is false by default. For DBC format, overwrite is not supported since it may contain a directory.
 
 #### - `mkdirs`:
-> **(Deprecated)** **(Required)** Create the given directory and necessary parent directories 
+> **(Required)** Create the given directory and necessary parent directories 
 if they do not exists. If there exists an object (not a directory) at any prefix of the input path, this call 
 returns an error RESOURCE_ALREADY_EXISTS. If this operation fails it may have succeeded in creating some of the necessary parent directories.
 


### PR DESCRIPTION
DBFS File had a few issues. This will be refactoring these issues:

1. Introduces two new fields: `source`, `content_b64_md5`
2. The new field `content_b64_md5` is required and it is used for determining differences and changes.
3. Updated documentation
4. Added unit testing and integration testing
5. Gives way forward for not clogging up state file with "content" data by using `source` field and also allows to go over the 4mb limit problem of GRPC limitations created by terraform. You can find the test here: `TestAccDatabricksDBFSFile_CreateVeryBigFiles`
6. Updated documentation to include new fields.


