### PR TITLE
Cluster instance pool fix

### DIFF
--- a/databricks/resource_databricks_cluster_test.go
+++ b/databricks/resource_databricks_cluster_test.go
@@ -126,7 +126,7 @@ func TestAccAwsClusterResource_CreateClusterViaInstancePool(t *testing.T) {
 
 	resourceEmptyAttrConfig := testDefaultZones() +
 		testAWSDatabricksInstanceProfile(instanceProfile) +
-		testDefaultAwsInstancePoolResource("aws_attributes {}", randomInstancePoolName) +
+		testDefaultAwsInstancePoolResource(testGetAwsAttributes(awsAttrInstancePool), randomInstancePoolName) +
 		testDefaultClusterResource(instancePoolLine, "aws_attributes {}")
 
 	resource.Test(t, resource.TestCase{

--- a/databricks/resource_databricks_cluster_test.go
+++ b/databricks/resource_databricks_cluster_test.go
@@ -3,12 +3,13 @@ package databricks
 import (
 	"bytes"
 	"fmt"
+	"reflect"
+	"testing"
+
 	"github.com/databrickslabs/databricks-terraform/client/model"
 	"github.com/databrickslabs/databricks-terraform/client/service"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"reflect"
-	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )

--- a/databricks/resource_databricks_cluster_test.go
+++ b/databricks/resource_databricks_cluster_test.go
@@ -1,0 +1,222 @@
+package databricks
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/databrickslabs/databricks-terraform/client/model"
+	"github.com/databrickslabs/databricks-terraform/client/service"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func testGetAwsAttributes(attributesMap map[string]string) string {
+	var awsAttr bytes.Buffer
+	awsAttr.WriteString("aws_attributes {\n")
+	for attr, value := range attributesMap {
+		awsAttr.WriteString(fmt.Sprintf("%s = \"%s\"\n", attr, value))
+	}
+	awsAttr.WriteString("}")
+	return awsAttr.String()
+}
+
+func testGetClusterInstancePoolConfig(instancePoolId string) string {
+	if reflect.ValueOf(instancePoolId).IsZero() {
+		return ""
+	}
+	return fmt.Sprintf("instance_pool_id = \"%s\"\n", instancePoolId)
+}
+
+func testDefaultZones() string {
+	return fmt.Sprintf(`
+data "databricks_zones" "default_zones" {}
+`)
+}
+
+func testDefaultAwsInstancePoolResource(awsAttributes, name string) string {
+	return fmt.Sprintf(`
+resource "databricks_instance_pool" "my_pool" {
+  instance_pool_name = "%s"
+  min_idle_instances = 0
+  max_capacity = 5
+  node_type_id = "i3.xlarge"
+  %s
+  idle_instance_autotermination_minutes = 10
+  disk_spec {
+    ebs_volume_type = "GENERAL_PURPOSE_SSD"
+    disk_size = 80
+    disk_count = 1
+  }
+}
+`, name, awsAttributes)
+}
+
+func testDefaultClusterResource(instancePool, awsAttributes string) string {
+	return fmt.Sprintf(`
+								resource "databricks_cluster" "test_cluster" {
+								  cluster_name = "test-cluster-browser"
+								  %s
+								  spark_version = "6.6.x-scala2.11"
+								  autoscale {
+									min_workers = 1
+									max_workers = 2
+								  }
+								  %s
+								  autotermination_minutes = 10
+								  spark_conf = {
+									"spark.databricks.cluster.profile" = "serverless"
+									"spark.databricks.repl.allowedLanguages" = "sql,python,r"
+									"spark.hadoop.fs.s3a.canned.acl" = "BucketOwnerFullControl"
+									"spark.hadoop.fs.s3a.acl.default" = "BucketOwnerFullControl"
+								  }
+								  custom_tags = {
+									"ResourceClass" = "Serverless"
+								  }
+								}`, instancePool, awsAttributes)
+}
+
+func TestAccAwsClusterResource_ValidatePlan(t *testing.T) {
+	awsAttrNoZoneId := map[string]string{}
+	awsAttrInstanceProfile := map[string]string{
+		"instance_profile_arn": "my_instance_profile_arn",
+	}
+	instancePoolLine := testGetClusterInstancePoolConfig("demo_instance_pool_id")
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:             testDefaultClusterResource(instancePoolLine, testGetAwsAttributes(awsAttrNoZoneId)),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config:             testDefaultClusterResource(instancePoolLine, testGetAwsAttributes(awsAttrInstanceProfile)),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsClusterResource_CreateClusterViaInstancePool(t *testing.T) {
+	awsAttrInstancePool := map[string]string{
+		"zone_id":      "${data.databricks_zones.default_zones.default_zone}",
+		"availability": "SPOT",
+	}
+	randomInstancePoolName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	randomStr := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+	instanceProfile := fmt.Sprintf("arn:aws:iam::999999999999:instance-profile/%s", randomStr)
+	var clusterInfo model.ClusterInfo
+	awsAttrCluster := map[string]string{
+		"instance_profile_arn": "${databricks_instance_profile.my_instance_profile.id}",
+	}
+	instancePoolLine := testGetClusterInstancePoolConfig("${databricks_instance_pool.my_pool.id}")
+	resourceConfig := testDefaultZones() +
+		testAWSDatabricksInstanceProfile(instanceProfile) +
+		testDefaultAwsInstancePoolResource(testGetAwsAttributes(awsAttrInstancePool), randomInstancePoolName) +
+		testDefaultClusterResource(instancePoolLine, "")
+
+	resourceInstanceProfileConfig := testDefaultZones() +
+		testAWSDatabricksInstanceProfile(instanceProfile) +
+		testDefaultAwsInstancePoolResource(testGetAwsAttributes(awsAttrInstancePool), randomInstancePoolName) +
+		testDefaultClusterResource(instancePoolLine, testGetAwsAttributes(awsAttrCluster))
+
+	resourceEmptyAttrConfig := testDefaultZones() +
+		testAWSDatabricksInstanceProfile(instanceProfile) +
+		testDefaultAwsInstancePoolResource("aws_attributes {}", randomInstancePoolName) +
+		testDefaultClusterResource(instancePoolLine, "aws_attributes {}")
+
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: resourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					// query the API to retrieve the tokenInfo object
+					testClusterExistsAndTerminateForFutureTests("databricks_cluster.test_cluster", &clusterInfo, t),
+				),
+			},
+			{
+				Config: resourceInstanceProfileConfig,
+				Check: resource.ComposeTestCheckFunc(
+					// query the API to retrieve the tokenInfo object
+					testClusterExistsAndTerminateForFutureTests("databricks_cluster.test_cluster", &clusterInfo, t),
+				),
+			},
+			{
+				Config: resourceEmptyAttrConfig,
+				Check: resource.ComposeTestCheckFunc(
+					// query the API to retrieve the tokenInfo object
+					testClusterExistsAndTerminateForFutureTests("databricks_cluster.test_cluster", &clusterInfo, t),
+				),
+			},
+		},
+	})
+}
+
+func testDefaultAzureInstancePoolResource(awsAttributes, name string) string {
+	return fmt.Sprintf(`
+resource "databricks_instance_pool" "my_pool" {
+  instance_pool_name = "%s"
+  min_idle_instances = 0
+  max_capacity = 5
+  node_type_id = "Standard_DS3_v2"
+  %s
+  idle_instance_autotermination_minutes = 10
+}
+`, name, awsAttributes)
+}
+
+func TestAccAzureClusterResource_CreateClusterViaInstancePool(t *testing.T) {
+	randomInstancePoolName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	randomStr := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+	instanceProfile := fmt.Sprintf("arn:aws:iam::999999999999:instance-profile/%s", randomStr)
+	var clusterInfo model.ClusterInfo
+
+	instancePoolLine := testGetClusterInstancePoolConfig("${databricks_instance_pool.my_pool.id}")
+	resourceConfig := testAWSDatabricksInstanceProfile(instanceProfile) +
+		testDefaultAzureInstancePoolResource("", randomInstancePoolName) +
+		testDefaultClusterResource(instancePoolLine, "")
+
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: resourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					// query the API to retrieve the tokenInfo object
+					testClusterExistsAndTerminateForFutureTests("databricks_cluster.test_cluster", &clusterInfo, t),
+				),
+			},
+		},
+	})
+}
+
+func testClusterExistsAndTerminateForFutureTests(n string, cluster *model.ClusterInfo, t *testing.T) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// find the corresponding state object
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		// retrieve the configured client from the test setup
+		conn := testAccProvider.Meta().(*service.DBApiClient)
+		resp, err := conn.Clusters().Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		err = conn.Clusters().Terminate(resp.ClusterID)
+		if err != nil {
+			return err
+		}
+		err = conn.Clusters().WaitForClusterTerminated(resp.ClusterID, 10, 10)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+}

--- a/website/content/Resources/cluster.md
+++ b/website/content/Resources/cluster.md
@@ -96,7 +96,7 @@ resource "databricks_cluster" "my-cluster" {
 }
 ```
 
-* `zone_id` - **(Required)** Identifier for the availability zone/datacenter in which the cluster resides. 
+* `zone_id` - **(Optional)** Identifier for the availability zone/datacenter in which the cluster resides. 
 This string will be of a form like “us-west-2a”. The provided availability zone must be in the same region as the 
 Databricks deployment. For example, “us-west-2a” is not a valid zone ID if the Databricks deployment resides in the 
 “us-east-1” region. 

--- a/website/content/Resources/instance_pool.md
+++ b/website/content/Resources/instance_pool.md
@@ -38,14 +38,14 @@ resource "databricks_instance_pool" "my-pool" {
     spot_bid_price_percent = "100"
   }
   idle_instance_autotermination_minutes = 10
-  disk_spec = {
+  disk_spec {
     ebs_volume_type = "GENERAL_PURPOSE_SSD"
     disk_size = 80
     disk_count = 1
   }
   custom_tags = {
-    "creator": "Sriharsha Tikkireddy"
-    "testChange": "Sri Tikkireddy"
+    "creator" = "Sriharsha Tikkireddy"
+    "testChange" = "Sri Tikkireddy"
   }
 }
 ```
@@ -58,14 +58,14 @@ resource "databricks_instance_pool" "my-pool" {
   max_capacity = 5
   node_type_id = "Standard_DS3_v2"
   idle_instance_autotermination_minutes = 10
-  disk_spec = {
+  disk_spec {
     azure_disk_volume_type = "PREMIUM_LRS"
     disk_size = 80
     disk_count = 1
   }
   custom_tags = {
-    "creator": "demo user"
-    "testChange": "demo user"
+    "creator" = "demo user"
+    "testChange" = "demo user"
   }
 }
 ```


### PR DESCRIPTION
1. aws_attrbiutes (availability, zone_id, spot_bid_price_percent, first_on_demand, ebs_volume_type, ebs_volume_count, ebs_volume_size) are now Optional and Computed
2. instance_type_id now conflicts with "aws_attributes.0.availability", "aws_attributes.0.zone_id", "aws_attributes.0.spot_bid_price_percent", "aws_attributes.0.first_on_demand", "aws_attributes.0.ebs_volume_type", "aws_attributes.0.ebs_volume_count", "aws_attributes.0.ebs_volume_size".
3. `node_type_id` is now optional and computed
4. handleInstancePoolClusterRequest removes all attributes from model.Cluster that is not allowed when InstancePoolId is configured when making create/update request.
5. Added Integration Tests
6. TODO: Update and fix docs