### PR TITLE
FIX node type of auto generated cluster for mounts

### DIFF
--- a/client/service/apis.go
+++ b/client/service/apis.go
@@ -200,7 +200,7 @@ func (c *DatabricksClient) configureHTTPCLient() {
 
 // IsAzure returns true if Azure is configured
 func (c *DatabricksClient) IsAzure() bool {
-	return c.AzureAuth.resourceID() != ""
+	return strings.Contains(strings.ToLower(c.Host), "azure")
 }
 
 // Clusters returns an instance of ClustersAPI

--- a/client/service/apis.go
+++ b/client/service/apis.go
@@ -198,9 +198,9 @@ func (c *DatabricksClient) configureHTTPCLient() {
 	}
 }
 
-// IsAzure returns true if Azure is configured
-func (c *DatabricksClient) IsAzure() bool {
-	return strings.Contains(strings.ToLower(c.Host), "azure")
+// UsingAzureAuth returns true if Azure authentication is configured, this is not a valid check to determine if we are running on Azure
+func (c *DatabricksClient) UsingAzureAuth() bool {
+	return c.AzureAuth.resourceID() != ""
 }
 
 // Clusters returns an instance of ClustersAPI

--- a/client/service/clusters.go
+++ b/client/service/clusters.go
@@ -236,10 +236,15 @@ func (a ClustersAPI) GetOrCreateRunningCluster(name string, custom ...model.Clus
 			return cl, nil
 		}
 	}
-	instanceType := "m4.large"
-	if a.client.IsAzure() {
-		instanceType = "Standard_DS3_v2"
+
+	nodeTypes, err := a.ListNodeTypes()
+	if err != nil {
+		return
 	}
+
+	instanceType := nodeTypes[0].NodeTypeID
+	log.Printf("[INFO] Creating an autoterminating cluster with node type %s", instanceType)
+
 	r := model.Cluster{
 		NumWorkers:             1,
 		ClusterName:            name,

--- a/client/service/instance_pools_test.go
+++ b/client/service/instance_pools_test.go
@@ -249,7 +249,7 @@ func TestAccInstancePools(t *testing.T) {
 			"6.3.x-scala2.11",
 		},
 	}
-	if !client.IsAzure() {
+	if !client.UsingAzureAuth() {
 		pool.DiskSpec = &model.InstancePoolDiskSpec{
 			DiskType: &model.InstancePoolDiskType{
 				EbsVolumeType: model.EbsVolumeTypeGeneralPurposeSsd,
@@ -289,7 +289,7 @@ func TestAccInstancePools(t *testing.T) {
 			"6.3.x-scala2.11",
 		},
 	}
-	if !client.IsAzure() {
+	if !client.UsingAzureAuth() {
 		u.DiskSpec = &model.InstancePoolDiskSpec{
 			DiskType: &model.InstancePoolDiskType{
 				EbsVolumeType: model.EbsVolumeTypeGeneralPurposeSsd,

--- a/client/service/main_test.go
+++ b/client/service/main_test.go
@@ -44,7 +44,7 @@ func compare(t *testing.T, a interface{}, b interface{}) {
 }
 
 func GetCloudInstanceType(c *DatabricksClient) string {
-	if c.IsAzure() {
+	if c.UsingAzureAuth() {
 		return "Standard_DS3_v2"
 	}
 	// TODO: create a method on ClustersAPI to give

--- a/client/service/test_util.go
+++ b/client/service/test_util.go
@@ -104,7 +104,7 @@ func CommonInstancePoolID() string {
 			MaxCapacity:                        10,
 			IdleInstanceAutoTerminationMinutes: 15,
 		}
-		if !client.IsAzure() {
+		if !client.UsingAzureAuth() {
 			instancePool.DiskSpec = &model.InstancePoolDiskSpec{
 				DiskType: &model.InstancePoolDiskType{
 					EbsVolumeType: model.EbsVolumeTypeGeneralPurposeSsd,

--- a/databricks/resource_databricks_azure_adls_gen1_mount_test.go
+++ b/databricks/resource_databricks_azure_adls_gen1_mount_test.go
@@ -14,7 +14,7 @@ func TestAzureAccADLSv1Mount(t *testing.T) {
 		t.Skip("Acceptance tests skipped unless env 'CLOUD_ENV' is set")
 	}
 	client := service.CommonEnvironmentClient()
-	if !client.IsAzure() {
+	if !client.UsingAzureAuth() {
 		t.Skip("Test is meant only for Azure")
 	}
 	if !client.AzureAuth.IsClientSecretSet() {

--- a/databricks/resource_databricks_azure_adls_gen2_mount_test.go
+++ b/databricks/resource_databricks_azure_adls_gen2_mount_test.go
@@ -50,7 +50,7 @@ func TestAzureAccAdlsGen2Mount_capture_error(t *testing.T) {
 		t.Skip("Acceptance tests skipped unless env 'CLOUD_ENV' is set")
 	}
 	client := service.CommonEnvironmentClient()
-	if !client.IsAzure() {
+	if !client.UsingAzureAuth() {
 		t.Skip("Test is meant only for Azure")
 	}
 	resource.Test(t, resource.TestCase{
@@ -91,7 +91,7 @@ func TestAzureAccADLSv2Mount(t *testing.T) {
 		t.Skip("Acceptance tests skipped unless env 'CLOUD_ENV' is set")
 	}
 	client := service.CommonEnvironmentClient()
-	if !client.IsAzure() {
+	if !client.UsingAzureAuth() {
 		t.Skip("Test is meant only for Azure")
 	}
 	if !client.AzureAuth.IsClientSecretSet() {

--- a/databricks/resource_databricks_azure_blob_mount_test.go
+++ b/databricks/resource_databricks_azure_blob_mount_test.go
@@ -300,7 +300,7 @@ func TestAzureAccBlobMount(t *testing.T) {
 		t.Skip("Acceptance tests skipped unless env 'CLOUD_ENV' is set")
 	}
 	client := service.CommonEnvironmentClient()
-	if !client.IsAzure() {
+	if !client.UsingAzureAuth() {
 		t.Skip("Test is meant only for Azure")
 	}
 	if !client.AzureAuth.IsClientSecretSet() {


### PR DESCRIPTION
* Use one of the available node types from the API
* Rename method so that it is clear that Azure auth does not automatically mean the environment is located on Azure