### PR TITLE
mounts patch

### DIFF
--- a/compute/acceptance/job_test.go
+++ b/compute/acceptance/job_test.go
@@ -78,7 +78,7 @@ func TestAccJobResource(t *testing.T) {
 	})
 }
 
-func TestAccJobResource_NoInstancePool(t *testing.T) {
+func TestAwsAccJobResource_NoInstancePool(t *testing.T) {
 	if _, ok := os.LookupEnv("CLOUD_ENV"); !ok {
 		t.Skip("Acceptance tests skipped unless env 'CLOUD_ENV' is set")
 	}

--- a/compute/clusters.go
+++ b/compute/clusters.go
@@ -250,7 +250,8 @@ func (a ClustersAPI) GetOrCreateRunningCluster(name string, custom ...Cluster) (
 			return cl, nil
 		}
 	}
-	instanceType := "m4.large"
+	// Non nvme based instance types require ebs configurations
+	instanceType := "i3.xlarge"
 	if a.client.IsAzure() {
 		instanceType = "Standard_DS3_v2"
 	}

--- a/compute/commands.go
+++ b/compute/commands.go
@@ -144,7 +144,7 @@ func (a CommandsAPI) deleteContext(contextID, clusterID string) error {
 
 func (a CommandsAPI) getContext(contextID, clusterID string) (string, error) {
 	var contextStatus Command // internal hack, yes
-	err := a.client.OldAPI("POST", "/contexts/status", genericCommandRequest{
+	err := a.client.OldAPI("GET", "/contexts/status", genericCommandRequest{
 		ContextID: contextID,
 		ClusterID: clusterID,
 	}, &contextStatus)

--- a/compute/commands_test.go
+++ b/compute/commands_test.go
@@ -41,13 +41,9 @@ func TestSomeCommands(t *testing.T) {
 			},
 		},
 		{
-			Method:       "POST",
-			Resource:     "/api/1.2/contexts/status",
+			Method:       "GET",
+			Resource:     "/api/1.2/contexts/status?clusterId=abc&contextId=123",
 			ReuseRequest: true,
-			ExpectedRequest: map[string]interface{}{
-				"clusterId": "abc",
-				"contextId": "123",
-			},
 			Response: Command{
 				Status: "Running",
 			},

--- a/internal/qa/testing.go
+++ b/internal/qa/testing.go
@@ -281,10 +281,19 @@ func fixHCL(v interface{}) interface{} {
 }
 
 // For writing a unit test to intercept the errors (t.Fatalf literally ends the test in failure)
-func environmentTemplate(t *testing.T, template string) (string, error) {
+func environmentTemplate(t *testing.T, template string, otherVars ...map[string]string) (string, error) {
 	vars := map[string]string{
 		"RANDOM": acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum),
 	}
+	if len(otherVars) > 1 {
+		return "", errors.New("Cannot have more than one customer variable map!")
+	}
+	if len(otherVars) == 1 {
+		for k, v := range otherVars[0] {
+			vars[k] = v
+		}
+	}
+	// pullAll otherVars
 	missing := 0
 	var varType, varName, value string
 	r := regexp.MustCompile(`{(env|var).([^{}]*)}`)
@@ -312,8 +321,8 @@ func environmentTemplate(t *testing.T, template string) (string, error) {
 }
 
 // EnvironmentTemplate asserts existence and fills in {env.VAR} & {var.RANDOM} placeholders in template
-func EnvironmentTemplate(t *testing.T, template string) string {
-	resp, err := environmentTemplate(t, template)
+func EnvironmentTemplate(t *testing.T, template string, otherVars ...map[string]string) string {
+	resp, err := environmentTemplate(t, template, otherVars...)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/internal/qa/testing_test.go
+++ b/internal/qa/testing_test.go
@@ -22,6 +22,15 @@ func TestEnvironmentTemplate(t *testing.T) {
 	assert.Equal(t, os.Getenv("USER"), FirstKeyValue(t, res, "name"))
 }
 
+func TestEnvironmentTemplate_other_vars(t *testing.T) {
+	otherVar := map[string]string{"TEST": "value"}
+	res := EnvironmentTemplate(t, `
+	resource "user" "me" {
+		name  = "{var.TEST}"
+	}`, otherVar)
+	assert.Equal(t, otherVar["TEST"], FirstKeyValue(t, res, "name"))
+}
+
 func TestEnvironmentTemplate_unset_env(t *testing.T) {
 	res, err := environmentTemplate(t, `
 	resource "user" "me" {

--- a/internal/qa/testing_test.go
+++ b/internal/qa/testing_test.go
@@ -1,0 +1,33 @@
+package qa
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/databrickslabs/databricks-terraform/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnvironmentTemplate(t *testing.T) {
+	defer common.CleanupEnvironment()
+	err := os.Setenv("USER", RandomName())
+	assert.NoError(t, err)
+
+	res := EnvironmentTemplate(t, `
+	resource "user" "me" {
+		name  = "{env.USER}"
+		email = "{env.USER}+{var.RANDOM}@example.com"
+	}`)
+	assert.Equal(t, os.Getenv("USER"), FirstKeyValue(t, res, "name"))
+}
+
+func TestEnvironmentTemplate_unset_env(t *testing.T) {
+	res, err := environmentTemplate(t, `
+	resource "user" "me" {
+		name  = "{env.USER}"
+		email = "{env.USER}+{var.RANDOM}@example.com"
+	}`)
+	assert.Equal(t, "", res)
+	assert.Errorf(t, err, fmt.Sprintf("please set %d variables and restart.", 2))
+}

--- a/storage/acceptance/aws_s3_mount_test.go
+++ b/storage/acceptance/aws_s3_mount_test.go
@@ -1,0 +1,74 @@
+package acceptance
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/databrickslabs/databricks-terraform/common"
+	"github.com/databrickslabs/databricks-terraform/compute"
+	"github.com/databrickslabs/databricks-terraform/internal/acceptance"
+	. "github.com/databrickslabs/databricks-terraform/storage"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/databrickslabs/databricks-terraform/internal/qa"
+)
+
+func getAwsS3MountConfig(t *testing.T, mountName string) string {
+	if os.Getenv("TEST_AWS_MOUNT_CLUSTER_ID") != "" {
+		return qa.EnvironmentTemplate(t, fmt.Sprintf(`
+	resource "databricks_aws_s3_mount" "mount" {
+		cluster_id			 = "{env.TEST_AWS_MOUNT_CLUSTER_ID}"
+		mount_name           = %q
+		s3_bucket_name       = "{env.TEST_S3_BUCKET_NAME}"
+	}`, mountName))
+	}
+	return qa.EnvironmentTemplate(t, fmt.Sprintf(`
+	resource "databricks_aws_s3_mount" "mount" {
+		mount_name           = %q
+		s3_bucket_name       = "{env.TEST_S3_BUCKET_NAME}"
+	}`, mountName))
+}
+
+func TestAWSS3IamMount_correctly_mounts(t *testing.T) {
+	if _, ok := os.LookupEnv("CLOUD_ENV"); !ok {
+		t.Skip("Acceptance tests skipped unless env 'CLOUD_ENV' is set")
+	}
+	randomMountName := fmt.Sprintf("tf-mount-test-%s", qa.RandomName())
+	expectedS3Bucket := os.Getenv("TEST_S3_BUCKET_NAME")
+	config := getAwsS3MountConfig(t, randomMountName)
+
+	acceptance.AccTest(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: acceptance.ResourceCheck("databricks_aws_s3_mount.mount", func(client *common.DatabricksClient, id string) error {
+					clusterInfo, err := compute.NewClustersAPI(client).GetOrCreateRunningCluster("TerraformIntegrationTest")
+					assert.NoError(t, err)
+					mp := NewMountPoint(client, id, clusterInfo.ClusterID)
+					source, err := mp.Source()
+					assert.NoError(t, err)
+					assert.Equal(t, fmt.Sprintf("s3a://%s", expectedS3Bucket), source)
+					return nil
+				}),
+			},
+			{
+				PreConfig: func() {
+					client := common.CommonEnvironmentClient()
+					clusterInfo := compute.NewTinyClusterInCommonPoolPossiblyReused()
+					mp := NewMountPoint(client, randomMountName, clusterInfo.ClusterID)
+					err := mp.Delete()
+					assert.NoError(t, err)
+				},
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				// Prior PreConfig deleted the mount so this one should attempt to recreate the mount
+				Config: config,
+			},
+		},
+	})
+}

--- a/storage/aws_s3_mount.go
+++ b/storage/aws_s3_mount.go
@@ -17,8 +17,8 @@ func (m AWSIamMount) Source() string {
 }
 
 // Config ...
-func (m AWSIamMount) Config() (c map[string]string) {
-	return //no extra config for S3 mounts here...
+func (m AWSIamMount) Config() map[string]string {
+	return make(map[string]string) // return empty map so nil map does not marshal to null
 }
 
 func ResourceAWSS3Mount() *schema.Resource {

--- a/storage/aws_s3_mount_test.go
+++ b/storage/aws_s3_mount_test.go
@@ -1,8 +1,14 @@
 package storage
 
 import (
-	"fmt"
+	"errors"
+	"strings"
 	"testing"
+
+	"github.com/databrickslabs/databricks-terraform/compute"
+	"github.com/databrickslabs/databricks-terraform/internal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/databrickslabs/databricks-terraform/internal/qa"
 )
@@ -10,11 +16,197 @@ import (
 // Test interface compliance via compile time error
 var _ Mount = (*AWSIamMount)(nil)
 
-func TestAwsS3Mount_mount(t *testing.T) {
-	randomBucketName := qa.RandomName()
-	awsMount := AWSIamMount{
-		S3BucketName: randomBucketName,
-	}
-	expSource := fmt.Sprintf("s3a://%s", randomBucketName)
-	testMountPointCreateHelper(t, awsMount, expSource, "{}")
+const testS3BucketName = "test-s3-bucket"
+const testS3BucketPath = "s3a://" + testS3BucketName
+
+func TestResourceAwsS3MountCreate(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/clusters/get?cluster_id=this_cluster",
+				Response: compute.ClusterInfo{
+					State: compute.ClusterStateRunning,
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/clusters/get?cluster_id=this_cluster",
+				Response: compute.ClusterInfo{
+					State: compute.ClusterStateRunning,
+				},
+			},
+		},
+		Resource: ResourceAWSS3Mount(),
+		CommandMock: func(commandStr string) (string, error) {
+			trunc := internal.TrimLeadingWhitespace(commandStr)
+			t.Logf("Received command:\n%s", trunc)
+			if strings.HasPrefix(trunc, "def safe_mount") {
+				assert.Contains(t, trunc, testS3BucketPath) // bucketname
+				assert.Contains(t, trunc, `{}`)             // empty brackets for empty config
+			}
+			assert.Contains(t, trunc, "/mnt/this_mount")
+			return testS3BucketPath, nil
+		},
+		State: map[string]interface{}{
+			"cluster_id":     "this_cluster",
+			"mount_name":     "this_mount",
+			"s3_bucket_name": testS3BucketName,
+		},
+		Create: true,
+	}.Apply(t)
+	require.NoError(t, err, err) // TODO: global search-replace for NoError
+	assert.Equal(t, "this_mount", d.Id())
+	assert.Equal(t, testS3BucketPath, d.Get("source"))
+}
+
+func TestResourceAwsS3MountCreate_Error(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/clusters/get?cluster_id=this_cluster",
+				Response: compute.ClusterInfo{
+					State: compute.ClusterStateRunning,
+				},
+			},
+		},
+		Resource: ResourceAWSS3Mount(),
+		CommandMock: func(commandStr string) (string, error) {
+			return "", errors.New("Some error")
+		},
+		State: map[string]interface{}{
+			"cluster_id":     "this_cluster",
+			"mount_name":     "this_mount",
+			"s3_bucket_name": testS3BucketName,
+		},
+		Create: true,
+	}.Apply(t)
+	require.EqualError(t, err, "Some error")
+	assert.Equal(t, "this_mount", d.Id())
+	assert.Equal(t, "", d.Get("source"))
+}
+
+func TestResourceAwsS3MountRead(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/clusters/get?cluster_id=this_cluster",
+				Response: compute.ClusterInfo{
+					State: compute.ClusterStateRunning,
+				},
+			},
+		},
+		Resource: ResourceAWSS3Mount(),
+		CommandMock: func(commandStr string) (string, error) {
+			trunc := internal.TrimLeadingWhitespace(commandStr)
+			t.Logf("Received command:\n%s", trunc)
+			assert.Contains(t, trunc, "dbutils.fs.mounts()")
+			assert.Contains(t, trunc, `mount.mountPoint == "/mnt/this_mount"`)
+			return testS3BucketPath, nil
+		},
+		State: map[string]interface{}{
+			"cluster_id":     "this_cluster",
+			"mount_name":     "this_mount",
+			"s3_bucket_name": testS3BucketName,
+		},
+		ID:   "this_mount",
+		Read: true,
+	}.Apply(t)
+	require.NoError(t, err)
+	assert.Equal(t, "this_mount", d.Id())
+	assert.Equal(t, testS3BucketPath, d.Get("source"))
+}
+
+func TestResourceAwsS3MountRead_NotFound(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/clusters/get?cluster_id=this_cluster",
+				Response: compute.ClusterInfo{
+					State: compute.ClusterStateRunning,
+				},
+			},
+		},
+		Resource: ResourceAWSS3Mount(),
+		CommandMock: func(commandStr string) (string, error) {
+			trunc := internal.TrimLeadingWhitespace(commandStr)
+			t.Logf("Received command:\n%s", trunc)
+			return "", errors.New("Mount not found")
+		},
+		State: map[string]interface{}{
+			"cluster_id":     "this_cluster",
+			"mount_name":     "this_mount",
+			"s3_bucket_name": testS3BucketName,
+		},
+		ID:   "this_mount",
+		Read: true,
+	}.Apply(t)
+	require.NoError(t, err)
+	assert.Equal(t, "", d.Id())
+	assert.Equal(t, "", d.Get("source"))
+}
+
+func TestResourceAwsS3MountRead_Error(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/clusters/get?cluster_id=this_cluster",
+				Response: compute.ClusterInfo{
+					State: compute.ClusterStateRunning,
+				},
+			},
+		},
+		Resource: ResourceAWSS3Mount(),
+		CommandMock: func(commandStr string) (string, error) {
+			trunc := internal.TrimLeadingWhitespace(commandStr)
+			t.Logf("Received command:\n%s", trunc)
+			return "", errors.New("Some error")
+		},
+		State: map[string]interface{}{
+			"cluster_id":     "this_cluster",
+			"mount_name":     "this_mount",
+			"s3_bucket_name": testS3BucketName,
+		},
+		ID:   "this_mount",
+		Read: true,
+	}.Apply(t)
+	require.EqualError(t, err, "Some error")
+	assert.Equal(t, "this_mount", d.Id())
+	assert.Equal(t, "", d.Get("source"))
+}
+
+func TestResourceAwsS3MountDelete(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/clusters/get?cluster_id=this_cluster",
+				Response: compute.ClusterInfo{
+					State: compute.ClusterStateRunning,
+				},
+			},
+		},
+		Resource: ResourceAWSS3Mount(),
+		CommandMock: func(commandStr string) (string, error) {
+			trunc := internal.TrimLeadingWhitespace(commandStr)
+			t.Logf("Received command:\n%s", trunc)
+			assert.Contains(t, trunc, "/mnt/this_mount")
+			assert.Contains(t, trunc, "dbutils.fs.unmount(mount_point)")
+			return "", nil
+		},
+		State: map[string]interface{}{
+			"cluster_id":     "this_cluster",
+			"mount_name":     "this_mount",
+			"s3_bucket_name": testS3BucketName,
+		},
+		ID:     "this_mount",
+		Delete: true,
+	}.Apply(t)
+	require.NoError(t, err)
+	assert.Equal(t, "this_mount", d.Id())
+	assert.Equal(t, "", d.Get("source"))
 }

--- a/storage/aws_s3_mount_test.go
+++ b/storage/aws_s3_mount_test.go
@@ -1,0 +1,20 @@
+package storage
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/databrickslabs/databricks-terraform/internal/qa"
+)
+
+// Test interface compliance via compile time error
+var _ Mount = (*AWSIamMount)(nil)
+
+func TestAwsS3Mount_mount(t *testing.T) {
+	randomBucketName := qa.RandomName()
+	awsMount := AWSIamMount{
+		S3BucketName: randomBucketName,
+	}
+	expSource := fmt.Sprintf("s3a://%s", randomBucketName)
+	testMountPointCreateHelper(t, awsMount, expSource, "{}")
+}

--- a/storage/mounts_test.go
+++ b/storage/mounts_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"github.com/databrickslabs/databricks-terraform/internal"
 	"testing"
 
 	"github.com/databrickslabs/databricks-terraform/common"
@@ -39,7 +40,7 @@ func testMountFuncHelper(t *testing.T, mountFunc func(mp MountPoint, mount Mount
 
 	c.WithCommandMock(func(commandStr string) (s string, e error) {
 		called = true
-		assert.Equal(t, expectedCommand, commandStr)
+		assert.Equal(t, internal.TrimLeadingWhitespace(expectedCommand), internal.TrimLeadingWhitespace(commandStr))
 		return expectedCommandResp, nil
 	})
 

--- a/storage/mounts_test.go
+++ b/storage/mounts_test.go
@@ -2,8 +2,9 @@ package storage
 
 import (
 	"fmt"
-	"github.com/databrickslabs/databricks-terraform/internal"
 	"testing"
+
+	"github.com/databrickslabs/databricks-terraform/internal"
 
 	"github.com/databrickslabs/databricks-terraform/common"
 	"github.com/stretchr/testify/assert"

--- a/storage/mounts_test.go
+++ b/storage/mounts_test.go
@@ -1,7 +1,11 @@
 package storage
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/databrickslabs/databricks-terraform/common"
+	"github.com/databrickslabs/databricks-terraform/internal/qa"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -20,4 +24,93 @@ func TestValidateMountDirectory(t *testing.T) {
 
 		assert.Lenf(t, errs, tc.errorCount, "directory '%s' does not generate the expected error count", tc.directory)
 	}
+}
+
+var expectedCommandResp = "done"
+
+func testMountFuncHelper(t *testing.T, mountName, expectedCommand string, mount Mount,
+	mountFunc func(mp MountPoint, mount Mount) (string, error)) {
+	c := common.DatabricksClient{
+		Host:  ".",
+		Token: ".",
+	}
+	err := c.Configure()
+	assert.NoError(t, err)
+
+	var called bool
+
+	c.WithCommandMock(func(commandStr string) (s string, e error) {
+		called = true
+		assert.Equal(t, expectedCommand, commandStr)
+		return expectedCommandResp, nil
+	})
+
+	mp := MountPoint{
+		exec:      c.CommandExecutor(),
+		clusterID: "random_cluster_id",
+		name:      mountName,
+	}
+
+	resp, err := mountFunc(mp, mount)
+	assert.NoError(t, err)
+	assert.True(t, called, "mocked command was not invoked")
+	assert.Equal(t, expectedCommandResp, resp)
+}
+
+func testMountPointCreateHelper(t *testing.T, mount Mount, expectedMountSource, expectedMountConfig string) {
+	randomMountName := qa.RandomName()
+	expectedCommand := fmt.Sprintf(`
+		def safe_mount(mount_point, mount_source, configs):
+			for mount in dbutils.fs.mounts():
+				if mount.mountPoint == mount_point and mount.source == mount_source:
+					return
+			try:
+				dbutils.fs.mount(mount_source, mount_point, extra_configs=configs)
+				dbutils.fs.refreshMounts()
+				dbutils.fs.ls(mount_point)
+				return mount_source
+			except Exception as e:
+				try:
+					dbutils.fs.unmount(mount_point)
+				except Exception as e2:
+					print("Failed to unmount", e2)
+				raise e
+		mount_source = safe_mount("/mnt/%s", %q, %s)
+		dbutils.notebook.exit(mount_source)
+	`, randomMountName, expectedMountSource, expectedMountConfig)
+	testMountFuncHelper(t, randomMountName, expectedCommand, mount, func(mp MountPoint, mount Mount) (s string, e error) {
+		return mp.Mount(mount)
+	})
+}
+
+func TestMountPoint_Source(t *testing.T) {
+	randomMountName := qa.RandomName()
+	expectedCommand := fmt.Sprintf(`
+		dbutils.fs.refreshMounts()
+		for mount in dbutils.fs.mounts():
+			if mount.mountPoint == "/mnt/%s":
+				dbutils.notebook.exit(mount.source)
+		raise Exception("Mount not found")
+	`, randomMountName)
+	testMountFuncHelper(t, randomMountName, expectedCommand, nil,
+		func(mp MountPoint, mount Mount) (s string, e error) {
+			return mp.Source()
+		})
+}
+
+func TestMountPoint_Delete(t *testing.T) {
+	randomMountName := qa.RandomName()
+	expectedCommand := fmt.Sprintf(`
+		mount_point = "/mnt/%s"
+		dbutils.fs.unmount(mount_point)
+		dbutils.fs.refreshMounts()
+		for mount in dbutils.fs.mounts():
+			if mount.mountPoint == mount_point:
+				raise Exception("Failed to unmount")
+		dbutils.notebook.exit("success")
+	`, randomMountName)
+	testMountFuncHelper(t, randomMountName, expectedCommand, nil,
+		func(mp MountPoint, mount Mount) (s string, e error) {
+			return expectedCommandResp, mp.Delete()
+		})
 }


### PR DESCRIPTION
changes made
1. fixed contexts/status to get request
2. refactored EnvironmentTemplate and added unit tests for it
3. added acc test for IamMount
4. awsiammount struct config method returns empty map
5. NewMount creates an instance of the CommandsAPI if executor in the client is nil (both tests and prod path works) IMO this suffices for now. Not sure if we would ever mock some calls and let it actually "production" apis in the other half but dont really need that at the moment.