### PR TITLE
FIX instance_pool max_capacity should be optional

### DIFF
--- a/compute/resource_instance_pool.go
+++ b/compute/resource_instance_pool.go
@@ -74,7 +74,7 @@ func ResourceInstancePool() *schema.Resource {
 			},
 			"max_capacity": {
 				Type:     schema.TypeInt,
-				Required: true,
+				Optional: true,
 			},
 			"idle_instance_autotermination_minutes": {
 				Type:     schema.TypeInt,
@@ -217,8 +217,11 @@ func resourceInstancePoolCreate(d *schema.ResourceData, m interface{}) error {
 	var instancePoolDiskSpecDiskType InstancePoolDiskType
 	instancePool.InstancePoolName = d.Get("instance_pool_name").(string)
 	instancePool.MinIdleInstances = int32(d.Get("min_idle_instances").(int))
-	instancePool.MaxCapacity = int32(d.Get("max_capacity").(int))
 	instancePool.IdleInstanceAutoTerminationMinutes = int32(d.Get("idle_instance_autotermination_minutes").(int))
+
+	if maxCapacity, ok := d.GetOk("max_capacity"); ok {
+		instancePool.MaxCapacity = int32(maxCapacity.(int))
+	}
 
 	if awsAttributesSchema, ok := d.GetOk("aws_attributes"); ok {
 		awsAttributesMap := getMapFromOneItemList(awsAttributesSchema)
@@ -303,10 +306,12 @@ func resourceInstancePoolRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
+
 	err = d.Set("max_capacity", int(instancePoolInfo.MaxCapacity))
 	if err != nil {
 		return err
 	}
+
 	err = d.Set("idle_instance_autotermination_minutes", int(instancePoolInfo.IdleInstanceAutoTerminationMinutes))
 	if err != nil {
 		return err
@@ -386,10 +391,13 @@ func resourceInstancePoolUpdate(d *schema.ResourceData, m interface{}) error {
 	var instancePoolInfo InstancePoolAndStats
 	instancePoolInfo.InstancePoolName = d.Get("instance_pool_name").(string)
 	instancePoolInfo.MinIdleInstances = int32(d.Get("min_idle_instances").(int))
-	instancePoolInfo.MaxCapacity = int32(d.Get("max_capacity").(int))
 	instancePoolInfo.IdleInstanceAutoTerminationMinutes = int32(d.Get("idle_instance_autotermination_minutes").(int))
 	instancePoolInfo.InstancePoolID = id
 	instancePoolInfo.NodeTypeID = d.Get("node_type_id").(string)
+
+	if maxCapacity, ok := d.GetOk("max_capacity"); ok {
+		instancePoolInfo.MaxCapacity = int32(maxCapacity.(int))
+	}
 
 	err := NewInstancePoolsAPI(client).Update(instancePoolInfo)
 	if err != nil {

--- a/compute/resource_instance_pool_test.go
+++ b/compute/resource_instance_pool_test.go
@@ -243,11 +243,10 @@ func TestAccInstancePools(t *testing.T) {
 	pool := InstancePool{
 		InstancePoolName:                   "Terraform Integration Test",
 		MinIdleInstances:                   0,
-		MaxCapacity:                        10,
 		NodeTypeID:                         qa.GetCloudInstanceType(client),
 		IdleInstanceAutoTerminationMinutes: 20,
 		PreloadedSparkVersions: []string{
-			"6.3.x-scala2.11",
+			"7.1.x-scala2.12",
 		},
 	}
 	if !client.IsAzure() {
@@ -287,7 +286,7 @@ func TestAccInstancePools(t *testing.T) {
 		NodeTypeID:                         qa.GetCloudInstanceType(client),
 		IdleInstanceAutoTerminationMinutes: 20,
 		PreloadedSparkVersions: []string{
-			"6.3.x-scala2.11",
+			"7.1.x-scala2.12",
 		},
 	}
 	if !client.IsAzure() {

--- a/docs/stubs/instance_pool.md
+++ b/docs/stubs/instance_pool.md
@@ -20,7 +20,7 @@ The following arguments are required:
 
 * `custom_tags` - (Optional) (Map) 
 
-* `max_capacity` - (Required) (Integer) 
+* `max_capacity` - (Optional) (Integer) 
 
 * `idle_instance_autotermination_minutes` - (Required) (Integer) 
 


### PR DESCRIPTION
Max capacity is now optional as in the API. Added this case to the acceptance test and validated that the test succeeds.
Fixes #195 

Sidenote:
It looks like this is not using the new reflection based approach. It might be useful to have some roadmap somewhere (on CONTRIBUTING.md or in the issues) to mark the resources that should be converted.