### PR TITLE
Update data_aws_policies.go

### DIFF
--- a/access/data_aws_policies.go
+++ b/access/data_aws_policies.go
@@ -99,6 +99,7 @@ func DataAwsCrossAccountRolicy() *schema.Resource {
 							"ec2:DescribeNatGateways",
 							"ec2:DisassociateRouteTable",
 							"ec2:ReleaseAddress",
+							"ec2:DetachVolume",
 						},
 						Resources: "*",
 					},

--- a/access/data_aws_policies.go
+++ b/access/data_aws_policies.go
@@ -89,6 +89,16 @@ func DataAwsCrossAccountRolicy() *schema.Resource {
 							"ec2:CreatePlacementGroup",
 							"ec2:DeletePlacementGroup",
 							"ec2:DescribePlacementGroups",
+							"ec2:DeleteVpcEndpoints,"
+							"ec2:DeleteNatGateway,"
+							"ec2:AllocateAddress,"
+							"ec2:CreateNatGateway,"
+							"ec2:ReleaseAddress,"
+							"ec2:CreateVpcEndpoint,"
+							"ec2:CreateRouteTable,"
+							"ec2:DeleteDhcpOptions,"
+							"ec2:DisassociateRouteTable,"
+							"ec2:DescribeNatGateways,"
 						},
 						Resources: "*",
 					},

--- a/access/data_aws_policies.go
+++ b/access/data_aws_policies.go
@@ -89,16 +89,16 @@ func DataAwsCrossAccountRolicy() *schema.Resource {
 							"ec2:CreatePlacementGroup",
 							"ec2:DeletePlacementGroup",
 							"ec2:DescribePlacementGroups",
-							"ec2:DeleteVpcEndpoints,"
-							"ec2:DeleteNatGateway,"
-							"ec2:AllocateAddress,"
-							"ec2:CreateNatGateway,"
-							"ec2:ReleaseAddress,"
-							"ec2:CreateVpcEndpoint,"
-							"ec2:CreateRouteTable,"
-							"ec2:DeleteDhcpOptions,"
-							"ec2:DisassociateRouteTable,"
-							"ec2:DescribeNatGateways,"
+							"ec2:AllocateAddress",
+							"ec2:CreateNatGateway",
+							"ec2:CreateRouteTable",
+							"ec2:CreateVpcEndpoint",
+							"ec2:DeleteDhcpOptions",
+							"ec2:DeleteNatGateway",
+							"ec2:DeleteVpcEndpoints",
+							"ec2:DescribeNatGateways",
+							"ec2:DisassociateRouteTable",
+							"ec2:ReleaseAddress",
 						},
 						Resources: "*",
 					},

--- a/access/data_aws_policies_test.go
+++ b/access/data_aws_policies_test.go
@@ -1,6 +1,7 @@
 package access
 
 import (
+	"log"
 	"testing"
 
 	"github.com/databrickslabs/databricks-terraform/internal/qa"
@@ -16,7 +17,7 @@ func TestDataAwsCrossAccountRolicy(t *testing.T) {
 	}.Apply(t)
 	assert.NoError(t, err)
 	j := d.Get("json")
-	assert.Lenf(t, j, 2401, "Strange length for policy: %s", j)
+	assert.Lenf(t, j, 2759, "Strange length for policy: %s", j)
 }
 
 func TestDataAwsCrossAccountRolicy_WithPassRoles(t *testing.T) {
@@ -29,7 +30,8 @@ func TestDataAwsCrossAccountRolicy_WithPassRoles(t *testing.T) {
 	}.Apply(t)
 	assert.NoError(t, err)
 	j := d.Get("json")
-	assert.Lenf(t, j, 2537, "Strange length for policy: %s", j)
+	log.Println(len(j.(string)))
+	assert.Lenf(t, j, 2895, "Strange length for policy: %s", j)
 }
 
 func TestDataAwsAssumeRolePolicy(t *testing.T) {

--- a/access/data_aws_policies_test.go
+++ b/access/data_aws_policies_test.go
@@ -1,7 +1,6 @@
 package access
 
 import (
-	"log"
 	"testing"
 
 	"github.com/databrickslabs/databricks-terraform/internal/qa"
@@ -30,7 +29,6 @@ func TestDataAwsCrossAccountRolicy_WithPassRoles(t *testing.T) {
 	}.Apply(t)
 	assert.NoError(t, err)
 	j := d.Get("json")
-	log.Println(len(j.(string)))
 	assert.Lenf(t, j, 2895, "Strange length for policy: %s", j)
 }
 


### PR DESCRIPTION
The new default for E2 is to support NPIP for when not bringing your own VPC. For this, there is a requirement to support creation of 
1. NatGateway
2. RouteTables
3. AllocatingAddress to allocate the EIP for Natgateway
4. VPC endpoints
5. DHCP options

This additions was created using the information provided in the docs and existing policy in the code and performing 
set(<actions in public doc>) - set(<actions in the code>) = 
```
 "ec2:ReleaseAddress",
"ec2:CreateRouteTable",
"ec2:CreateNatGateway",
"ec2:DeleteNatGateway",
"ec2:DeleteDhcpOptions",
"ec2:DescribeNatGateways",
"ec2:DeleteVpcEndpoints",
"ec2:CreateVpcEndpoint",
"ec2:DisassociateRouteTable",
"ec2:AllocateAddress",
```

I also noticed that two items were removed that are required for BYOVPC:
```
"ec2:DescribeVpcAttribute",
"ec2:DescribeNetworkAcls",
```

I did not remove them to keep the superset between both BYOVPC and Databricks Managed VPC

I also added the field to allow the policy to be a superset of the BYOVPC:

```
"ec2:DetachVolume",
```
