### PR TITLE
Prepare version 0.2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ terraform {
   required_providers {
     databricks = {
       source = "databrickslabs/databricks"
-      version = ... # replace dots with latest version
+      version = "0.2.5"
     }
   }
 }

--- a/access/acceptance/secret_acl_test.go
+++ b/access/acceptance/secret_acl_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/databrickslabs/databricks-terraform/common"
 	"github.com/databrickslabs/databricks-terraform/internal/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/assert"
@@ -22,12 +23,7 @@ func TestAccSecretAclResource(t *testing.T) {
 	}
 	//var secretScope Secre
 	var secretACL ACLItem
-	// generate a random name for each tokenInfo test run, to avoid
-	// collisions from multiple concurrent tests.
-	// the acctest package includes many helpers such as RandStringFromCharSet
-	// See https://godoc.org/github.com/hashicorp/terraform-plugin-sdk/helper/acctest
-	//scope := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	scope := "terraform_acc_test_acl"
+	scope := fmt.Sprintf("tf-scope-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 	principal := "users"
 	permission := "READ"
 

--- a/access/acceptance/secret_scope_test.go
+++ b/access/acceptance/secret_scope_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/databrickslabs/databricks-terraform/common"
 	"github.com/databrickslabs/databricks-terraform/internal/acceptance"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/assert"
@@ -22,7 +23,7 @@ func TestAccSecretScopeResource(t *testing.T) {
 	}
 	var secretScope SecretScope
 
-	scope := "terraform_acc_test_scope"
+	scope := fmt.Sprintf("tf-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
 
 	acceptance.AccTest(t, resource.TestCase{
 		CheckDestroy: testSecretScopeResourceDestroy,

--- a/compute/acceptance/cluster_policy_test.go
+++ b/compute/acceptance/cluster_policy_test.go
@@ -40,30 +40,6 @@ func TestAccClusterPolicyResourceFullLifecycle(t *testing.T) {
 				Check: resource.TestCheckResourceAttr("databricks_cluster_policy.external_metastore",
 					"name", fmt.Sprintf("Terraform policy %s", randomName+": UPDATED")),
 			},
-			{
-				Config:  testExternalMetastore(randomName + ": UPDATED"),
-				Destroy: true,
-				Check: acceptance.ResourceCheck("databricks_cluster_policy.external_metastore",
-					func(client *common.DatabricksClient, id string) error {
-						resp, err := NewClusterPoliciesAPI(client).Get(id)
-						if err == nil {
-							return fmt.Errorf("Resource must have been deleted but: %v", resp)
-						}
-						return nil
-					}),
-			},
-			{
-				// and create it again
-				Config: testExternalMetastore(randomName + ": UPDATED"),
-				Check: acceptance.ResourceCheck("databricks_cluster_policy.external_metastore",
-					func(client *common.DatabricksClient, id string) error {
-						_, err := NewClusterPoliciesAPI(client).Get(id)
-						if err != nil {
-							return err
-						}
-						return nil
-					}),
-			},
 		},
 	})
 }

--- a/compute/acceptance/cluster_test.go
+++ b/compute/acceptance/cluster_test.go
@@ -299,25 +299,18 @@ func TestAwsAccClusterResource_CreateClusterViaInstancePool(t *testing.T) {
 }
 
 func TestAzureAccClusterResource_CreateClusterViaInstancePool(t *testing.T) {
-	randomInstancePoolName := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	randomInstancePoolInterpolation := fmt.Sprintf("databricks_instance_pool.%s.id", randomInstancePoolName)
-	randomClusterSuffix := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-	randomClusterName := fmt.Sprintf("cluster-%s", randomClusterSuffix)
-	randomClusterId := fmt.Sprintf("databricks_cluster.%s", randomClusterName)
-	defaultAzureInstancePoolClusterTest :=
-		newInstancePoolHCLBuilder(randomInstancePoolName).
-			withCloudEnv().
-			build() +
-			newClusterHCLBuilder(randomClusterName).
-				withInstancePool(randomInstancePoolInterpolation).
-				build()
-
+	randomInstancePoolName := fmt.Sprintf("pool_%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	randomClusterName := fmt.Sprintf("cluster_%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	defaultAzureInstancePoolClusterTest := newInstancePoolHCLBuilder(randomInstancePoolName).withCloudEnv().build() +
+		newClusterHCLBuilder(randomClusterName).withInstancePool(
+			fmt.Sprintf("databricks_instance_pool.%s.id", randomInstancePoolName)).build()
 	acceptance.AccTest(t, resource.TestCase{
 		Steps: []resource.TestStep{
 			{
 				Config: defaultAzureInstancePoolClusterTest,
 				Check: resource.ComposeTestCheckFunc(
-					testClusterCheckAndTerminateForFutureTests(randomClusterId, t),
+					testClusterCheckAndTerminateForFutureTests(
+						fmt.Sprintf("databricks_cluster.%s", randomClusterName), t),
 				),
 			},
 		},

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,15 @@
 # Version changelog
 
+## 0.2.5
+
+* Added support for [local disk encryption](https://github.com/databrickslabs/terraform-provider-databricks/pull/313)
+* Added more reliable [indication about Azure environment](https://github.com/databrickslabs/terraform-provider-databricks/pull/312) and fixed azure auth issue for Terraform 0.13
+* Updated [databricks_aws_crossaccount_policy](https://github.com/databrickslabs/terraform-provider-databricks/pull/311) to latest rules
+* Fixed missing importers for [databricks_scim_*](https://github.com/databrickslabs/terraform-provider-databricks/pull/290) resources
+* Updated [Terraform Plugin SDK](https://github.com/databrickslabs/terraform-provider-databricks/pull/279) to latest version along with transitive dependencies.
+* Added support disclaimers
+* Increased code coverage to 65%
+
 ## 0.2.4
 
 * Added [Azure CLI authentication](https://github.com/databrickslabs/terraform-provider-databricks/blob/master/docs/index.md#authenticating-with-azure-cli) to bridge the gap of local development workflows and let more people use the provider.

--- a/docs/data-sources/aws_crossaccount_policy.md
+++ b/docs/data-sources/aws_crossaccount_policy.md
@@ -1,6 +1,8 @@
 # databricks_aws_crossaccount_policy Data Source
 
-This data source constructs necessary AWS cross-account policy for you, which is based on [official documentation](https://docs.databricks.com/administration-guide/account-settings/aws-accounts.html).
+-> **Note** This resource has evolving API, which may change in future versions of provider. Please always consult [latest documentation](https://docs.databricks.com/administration-guide/account-api/iam-role.html#language-Your%C2%A0VPC,%C2%A0default) in case of any questions.
+
+This data source constructs necessary AWS cross-account policy for you, which is based on [official documentation](https://docs.databricks.com/administration-guide/account-api/iam-role.html#language-Your%C2%A0VPC,%C2%A0default).
 
 ## Example Usage
 

--- a/internal/sanity/utils_test.go
+++ b/internal/sanity/utils_test.go
@@ -136,6 +136,12 @@ func TestAccMissingResourcesInWorkspace(t *testing.T) {
 			},
 		},
 		{
+			Name: "Cluster Policies Delete",
+			ReadFunc: func() error {
+				return compute.NewClusterPoliciesAPI(client).Delete(randStringID)
+			},
+		},
+		{
 			Name: "Jobs",
 			ReadFunc: func() error {
 				_, err := compute.NewJobsAPI(client).Read(strconv.Itoa(randIntID))

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -124,6 +124,16 @@ function go_test {
 if [[ $@ == *"--tee"* ]]; then
     go_test $2 2>&1 | tee out.log
     echo "✓ To output of existing tests: less $PWD/out.log"
+
+    FAILURES=$(grep "\-\-\- FAIL" out.log | sed 's/--- FAIL: /\* \[ \]/g' | sort)
+    PASSES=$(grep PASS out.log | grep Test | sort | sed 's/PASS/ \* \[x\]/')
+
+cat <<-EOF > test-report.log
+$1
+---
+${FAILURES}
+${PASSES}
+EOF
 else 
     go_test $2
 fi

--- a/storage/acceptance/adls_gen2_test.go
+++ b/storage/acceptance/adls_gen2_test.go
@@ -2,7 +2,6 @@ package acceptance
 
 import (
 	"os"
-	"regexp"
 	"testing"
 
 	"github.com/databrickslabs/databricks-terraform/common"
@@ -41,45 +40,6 @@ func TestAzureAccAdlsGen2Mount_correctly_mounts(t *testing.T) {
 					client_secret_key      = databricks_secret.client_secret.key
 					initialize_file_system = true
 				}`),
-			},
-		},
-	})
-}
-
-func TestAzureAccAdlsGen2Mount_capture_error(t *testing.T) {
-	if _, ok := os.LookupEnv("CLOUD_ENV"); !ok {
-		t.Skip("Acceptance tests skipped unless env 'CLOUD_ENV' is set")
-	}
-	client := common.CommonEnvironmentClient()
-	if !client.AzureAuth.IsClientSecretSet() {
-		t.Skip("Test is meant only for SP Azure")
-	}
-	acceptance.AccTest(t, resource.TestCase{
-		Steps: []resource.TestStep{
-			{
-				Config: qa.EnvironmentTemplate(t, `
-				resource "databricks_secret_scope" "terraform" {
-					name                     = "terraform-{var.RANDOM}"
-					initial_manage_principal = "users"
-				}
-				resource "databricks_secret" "client_secret" {
-					key          = "datalake_sp_secret"
-					string_value = "{env.ARM_CLIENT_SECRET}"
-					scope        = databricks_secret_scope.terraform.name
-				}
-				resource "databricks_azure_adls_gen2_mount" "mount" {
-					storage_account_name   = "{env.TEST_STORAGE_V2_ACCOUNT}"
-					container_name         = "{env.TEST_STORAGE_V2_ABFSS}"
-					mount_name             = "localdir{var.RANDOM}"
-					tenant_id              = "{env.ARM_TENANT_ID}"
-					client_id              = "{env.ARM_CLIENT_ID}"
-					client_secret_scope    = databricks_secret_scope.terraform.name
-					client_secret_key      = "SECRET_KEY_WRONG_ON_PURPOSE"
-					initialize_file_system = true
-				}`),
-				ExpectNonEmptyPlan: true,
-				ExpectError:        regexp.MustCompile("Secret does not exist with scope"),
-				Destroy:            false,
 			},
 		},
 	})

--- a/storage/mounts.go
+++ b/storage/mounts.go
@@ -156,19 +156,19 @@ func mountCluster(tpl interface{}, d *schema.ResourceData, m interface{},
 
 // returns resource create mount for object store on workspace
 func mountCreate(tpl interface{}, r *schema.Resource) func(*schema.ResourceData, interface{}) error {
-	return func(d *schema.ResourceData, m interface{}) (err error) {
+	return func(d *schema.ResourceData, m interface{}) error {
 		mountConfig, mountPoint, err := mountCluster(tpl, d, m, r)
 		if err != nil {
-			return
+			return err
 		}
 		log.Printf("[INFO] Mounting %s at /mnt/%s", mountConfig.Source(), d.Id())
 		source, err := mountPoint.Mount(mountConfig)
 		if err != nil {
-			return
+			return err
 		}
 		err = d.Set("source", source)
 		if err != nil {
-			return
+			return err
 		}
 		return readMountSource(mountPoint, d)
 	}


### PR DESCRIPTION
# Version changelog

## 0.2.5

* Added support for [local disk encryption](https://github.com/databrickslabs/terraform-provider-databricks/pull/313)
* Added more reliable [indication about Azure environment](https://github.com/databrickslabs/terraform-provider-databricks/pull/312) and fixed azure auth issue for Terraform 0.13
* Updated [databricks_aws_crossaccount_policy](https://github.com/databrickslabs/terraform-provider-databricks/pull/311) to latest rules
* Fixed missing importers for [databricks_scim_*](https://github.com/databrickslabs/terraform-provider-databricks/pull/290) resources
* Updated [Terraform Plugin SDK](https://github.com/databrickslabs/terraform-provider-databricks/pull/279) to latest version along with transitive dependencies.
* Added support disclaimers
* Increased code coverage to 65%

# Accounts API

 * [x] mws.TestMwsAccCreds (2.66s)
 * [x] mws.TestMwsAccCustomerManagedKeys (1.26s)
 * [x] mws.TestMwsAccMissingResources (2.55s)
 * [x] mws.TestMwsAccMissingResources/Credential (0.32s)
 * [x] mws.TestMwsAccMissingResources/Network (0.72s)
 * [x] mws.TestMwsAccMissingResources/Storage (0.71s)
 * [x] mws.TestMwsAccMissingResources/Workspace (0.79s)
 * [x] mws.TestMwsAccStorageConfigurations (2.11s)
 * [x] mws.TestMwsAccWorkspace (0.60s)
 * [x] mws/acceptance.TestMwsAccCredentials (19.16s)
 * [x] mws/acceptance.TestMwsAccNetworks (21.17s)
 * [x] mws/acceptance.TestMwsAccStorageConfigurations (27.13s)
 * [x] mws/acceptance.TestMwsAccWorkspaces (99.54s)

# Azure CLI

~FAIL: TestAccGroupResource_verify_entitlements (25.17s) - test runner error, will check if it repeats~ PASSED
 * [x] access/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (70.72s)
 * [x] access/acceptance.TestAccSecretAclResource (39.85s)
 * [x] access/acceptance.TestAccSecretResource (71.34s)
 * [x] access/acceptance.TestAccSecretScopeResource (37.10s)
 * [x] compute.TestAccContext (22.93s)
 * [x] compute.TestAccInstancePools (6.56s)
 * [x] compute.TestAccLibraryCreate (44.54s)
 * [x] compute.TestAccListClustersIntegration (54.86s)
 * [x] compute/acceptance.TestAccClusterPolicyResourceFullLifecycle (49.23s)
 * [x] compute/acceptance.TestAccClusterResource_CreateClusterWithLibraries (165.31s)
 * [x] compute/acceptance.TestAccJobResource (54.95s)
 * [x] compute/acceptance.TestAzureAccClusterResource_CreateClusterViaInstancePool (281.19s)
 * [x] identity.TestAccCreateAdminUser (18.25s)
 * [x] identity.TestAccCreateToken (5.64s)
 * [x] identity.TestAccCreateUser (12.50s)
 * [x] identity.TestAccGetAdminGroup (5.36s)
 * [x] identity.TestAccGroup (29.32s)
 * [x] identity.TestAccRoleDifferences (8.11s)
 * [x] identity/acceptance.TestAccGroupMemberResource (117.42s)
 * [x] identity/acceptance.TestAccGroupResource (57.16s)
 * [x] identity/acceptance.TestAccScimGroupResource (259.25s)
 * [x] identity/acceptance.TestAccScimUserResource (472.78s)
 * [x] identity/acceptance.TestAccTokenResource (46.50s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace (3.15s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies (0.50s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies_Delete (0.44s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Clusters (0.17s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/DBFS_Files (0.25s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Groups (0.20s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Instance_Pools (0.19s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Jobs (0.18s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Notebooks (0.19s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_ACLs (0.18s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_Scopes (0.21s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secrets (0.12s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Tokens (0.35s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Users (0.19s)
 * [x] internal/sanity.TestAccMutiworkspaceUsedFromNormalMode (9.38s)
 * [x] storage.TestAccCreateFile (7.67s)
 * [x] storage.TestAccDeleteInvalidMountFails (4.03s)
 * [x] storage.TestAccInvalidSecretScopeFails (3.74s)
 * [x] storage.TestAccSourceOnInvalidMountFails (26.75s)
 * [x] storage.TestAzureAccBlobMount (136.09s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (48.82s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (122.26s)
 * [x] storage/acceptance.TestAzureAccBlobMount_correctly_mounts (422.27s)
 * [x] workspace/acceptance.TestAccNotebookResourceMultipleFormats (95.94s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (123.80s)

# Azure Service Principal

~* FAIL: TestAccTokenResource (65.78s)~ PASSED
~* FAIL: TestAzureAccAdlsGen2Mount_capture_error (11.87s)~ Removed, as we already test this flow
 * [x] access/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (36.62s)
 * [x] access/acceptance.TestAccSecretAclResource (20.99s)
 * [x] access/acceptance.TestAccSecretResource (27.38s)
 * [x] access/acceptance.TestAccSecretScopeResource (16.68s)
 * [x] compute.TestAccContext (21.33s)
 * [x] compute.TestAccInstancePools (2.80s)
 * [x] compute.TestAccLibraryCreate (40.37s)
 * [x] compute.TestAccListClustersIntegration (260.57s)
 * [x] compute/acceptance.TestAccClusterPolicyResourceFullLifecycle (21.30s)
 * [x] compute/acceptance.TestAccClusterResource_CreateClusterWithLibraries (244.67s)
 * [x] compute/acceptance.TestAccJobResource (6.88s)
 * [x] compute/acceptance.TestAzureAccClusterResource_CreateClusterViaInstancePool (292.28s)
 * [x] identity.TestAccCreateAdminUser (9.44s)
 * [x] identity.TestAccCreateToken (1.00s)
 * [x] identity.TestAccCreateUser (5.04s)
 * [x] identity.TestAccGetAdminGroup (1.38s)
 * [x] identity.TestAccGroup (18.75s)
 * [x] identity.TestAccRoleDifferences (3.07s)
 * [x] identity/acceptance.TestAccGroupMemberResource (64.83s)
 * [x] identity/acceptance.TestAccGroupResource (27.08s)
 * [x] identity/acceptance.TestAccGroupResource_verify_entitlements (18.34s)
 * [x] identity/acceptance.TestAccScimGroupResource (150.09s)
 * [x] identity/acceptance.TestAccScimUserResource (177.54s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace (2.39s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies (0.33s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies_Delete (0.36s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Clusters (0.08s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/DBFS_Files (0.51s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Groups (0.09s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Instance_Pools (0.11s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Jobs (0.11s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Notebooks (0.15s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_ACLs (0.08s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_Scopes (0.04s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secrets (0.04s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Tokens (0.37s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Users (0.12s)
 * [x] internal/sanity.TestAccMutiworkspaceUsedFromNormalMode (3.62s)
 * [x] storage.TestAccCreateFile (2.41s)
 * [x] storage.TestAccDeleteInvalidMountFails (2.92s)
 * [x] storage.TestAccInvalidSecretScopeFails (2.69s)
 * [x] storage.TestAccSourceOnInvalidMountFails (26.71s)
 * [x] storage.TestAzureAccADLSv1Mount (373.55s)
 * [x] storage.TestAzureAccADLSv2Mount (129.64s)
 * [x] storage.TestAzureAccBlobMount (129.03s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (15.56s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (12.53s)
 * [x] storage/acceptance.TestAzureAccAdlsGen1Mount_correctly_mounts (701.36s)
 * [x] storage/acceptance.TestAzureAccAdlsGen2Mount_correctly_mounts (167.68s)
 * [x] storage/acceptance.TestAzureAccBlobMount_correctly_mounts (375.40s)
 * [x] workspace/acceptance.TestAccNotebookResourceMultipleFormats (52.75s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (111.59s)
