### PR TITLE
update adls_gen_2 document example

### DIFF
--- a/docs/resources/azure_adls_gen2_mount.md
+++ b/docs/resources/azure_adls_gen2_mount.md
@@ -50,7 +50,7 @@ resource "databricks_azure_adls_gen2_mount" "marketing" {
     tenant_id              = data.azurerm_client_config.current.tenant_id
     client_id              = data.azurerm_client_config.current.client_id
     client_secret_scope    = databricks_secret_scope.terraform.name
-    client_secret_key      = databricks_secret.client_secret.key
+    client_secret_key      = databricks_secret.service_principal_key.key
     initialize_file_system = true
 }
 ```

--- a/docs/resources/azure_adls_gen2_mount.md
+++ b/docs/resources/azure_adls_gen2_mount.md
@@ -44,7 +44,7 @@ resource "azurerm_storage_container" "this" {
 }
 
 resource "databricks_azure_adls_gen2_mount" "marketing" {
-    container_name         = azurerm_storage_container.adlsexample.name
+    container_name         = azurerm_storage_container.this.name
     storage_account_name   = azurerm_storage_account.this.name
     mount_name             = "marketing"
     tenant_id              = data.azurerm_client_config.current.tenant_id


### PR DESCRIPTION
Typo in the documentation for the use of the `databricks_azure_adls_gent2_mount` example.