### PR TITLE
Add support for PAT usage permissions

### DIFF
--- a/access/resource_permissions.go
+++ b/access/resource_permissions.go
@@ -296,6 +296,7 @@ func permissionsResourceIDFields() []permissionsIDFieldMapping {
 		{"notebook_path", "notebook", "notebooks", PATH},
 		{"directory_id", "directory", "directories", SIMPLE},
 		{"directory_path", "directory", "directories", PATH},
+		{"authorization", "authorization", "authorization", SIMPLE},
 	}
 }
 

--- a/access/resource_permissions.go
+++ b/access/resource_permissions.go
@@ -265,7 +265,7 @@ func ResourcePermissions() *schema.Resource {
 			return diag.FromErr(err)
 		}
 		if len(entity.AccessControlList) == 0 {
-			// empty "modifiable" access control list is the same as resource absense
+			// empty "modifiable" access control list is the same as resource absence
 			d.SetId("")
 			return nil
 		}

--- a/access/resource_permissions_test.go
+++ b/access/resource_permissions_test.go
@@ -144,6 +144,34 @@ func TestResourcePermissionsDelete(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.0/preview/permissions/clusters/abc",
+				Response: ObjectACL{
+					ObjectID:   "/clusters/abc",
+					ObjectType: "clusters",
+					AccessControlList: []AccessControl{
+						{
+							UserName: TestingUser,
+							AllPermissions: []Permission{
+								{
+									PermissionLevel: "CAN_READ",
+									Inherited:       false,
+								},
+							},
+						},
+						{
+							UserName: TestingAdminUser,
+							AllPermissions: []Permission{
+								{
+									PermissionLevel: "CAN_MANAGE",
+									Inherited:       false,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
 				Method:          http.MethodPut,
 				Resource:        "/api/2.0/preview/permissions/clusters/abc",
 				ExpectedRequest: ObjectACL{},
@@ -160,6 +188,34 @@ func TestResourcePermissionsDelete(t *testing.T) {
 func TestResourcePermissionsDelete_error(t *testing.T) {
 	_, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.0/preview/permissions/clusters/abc",
+				Response: ObjectACL{
+					ObjectID:   "/clusters/abc",
+					ObjectType: "clusters",
+					AccessControlList: []AccessControl{
+						{
+							UserName: TestingUser,
+							AllPermissions: []Permission{
+								{
+									PermissionLevel: "CAN_READ",
+									Inherited:       false,
+								},
+							},
+						},
+						{
+							UserName: TestingAdminUser,
+							AllPermissions: []Permission{
+								{
+									PermissionLevel: "CAN_MANAGE",
+									Inherited:       false,
+								},
+							},
+						},
+					},
+				},
+			},
 			{
 				Method:          http.MethodPut,
 				Resource:        "/api/2.0/preview/permissions/clusters/abc",
@@ -222,7 +278,7 @@ func TestResourcePermissionsCreate(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
-				Method:   http.MethodPatch,
+				Method:   http.MethodPut,
 				Resource: "/api/2.0/preview/permissions/clusters/abc",
 				ExpectedRequest: AccessControlChangeList{
 					AccessControlList: []AccessControlChange{
@@ -328,7 +384,7 @@ func TestResourcePermissionsCreate_NotebookPath(t *testing.T) {
 				},
 			},
 			{
-				Method:   http.MethodPatch,
+				Method:   http.MethodPut,
 				Resource: "/api/2.0/preview/permissions/notebooks/988765",
 				ExpectedRequest: AccessControlChangeList{
 					AccessControlList: []AccessControlChange{
@@ -398,7 +454,7 @@ func TestResourcePermissionsCreate_error(t *testing.T) {
 	_, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
-				Method:   http.MethodPatch,
+				Method:   http.MethodPut,
 				Resource: "/api/2.0/preview/permissions/clusters/abc",
 				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -221,6 +221,13 @@ In addition to all arguments above, the following attributes are exported:
 * `default_tags` - (map) Tags that are added by Databricks by default, regardless of any custom_tags that may have been added. These include: Vendor: Databricks, Creator: <username_of_creator>, ClusterName: <name_of_cluster>, ClusterId: <id_of_cluster>, Name: <Databricks internal use>
 * `state` - (string) State of the cluster.
 
+## Access Control
+
+* [databricks_group](group.md#allow_cluster_create) and [databricks_user](user.md#allow_cluster_create) can control which groups or individual users can create clusters.
+* [databricks_cluster_policy](cluster_policy.md) can control which kinds of clusters users can create.
+* Users, who have access to Cluster Policy, but do not have `allow_cluster_create` argument set would still be able to create clusters, but within the boundary of the policy.
+* [databricks_permissions](permissions.md#Cluster-usage) can control which groups or individual users can *Manage*, *Restart* or *Attach to* individual clusters.
+* `instance_profile_arn` can control which data given cluster can access through cloud-native controls.
 
 ## Import
 

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -44,8 +44,8 @@ resource "databricks_group_member" "vip_member" {
 The following arguments are supported:
 
 * `display_name` -  (Required) This is the display name for the given group.
-* `allow_cluster_create` -  (Optional) This is a field to allow the group to have [cluster](cluster.md) create priviliges.
-* `allow_instance_pool_create` -  (Optional) This is a field to allow the group to have [instance pool](instance_pool.md) create priviliges.
+* `allow_cluster_create` -  (Optional) This is a field to allow the group to have [cluster](cluster.md) create priviliges. More fine grained permissions could be assigned with [databricks_permissions](permissions.md#Cluster-usage) and [cluster_id](permissions.md#cluster_id) argument. Everyone without `allow_cluster_create` arugment set, but with [permission to use](permissions.md#Cluster-Policy-usage) Cluster Policy would be able to create clusters, but within boundaries of that specific policy.
+* `allow_instance_pool_create` -  (Optional) This is a field to allow the group to have [instance pool](instance_pool.md) create priviliges. More fine grained permissions could be assigned with [databricks_permissions](permissions.md#Instance-Pool-usage) and [instance_pool_id](permissions.md#instance_pool_id) argument.
 
 ## Attribute Reference
 

--- a/docs/resources/instance_pool.md
+++ b/docs/resources/instance_pool.md
@@ -72,6 +72,10 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - Canonical unique identifier for the instance pool.
 * `default_tags` - default tag map.
 
+## Access Control
+
+* [databricks_group](group.md#allow_instance_pool_create) and [databricks_user](user.md#allow_instance_pool_create) can control which groups or individual users can create instance pools.
+* [databricks_permissions](permissions.md#Instance-Pool-usage) can control which groups or individual users can *Manage* or *Attach to* individual instance pools.
 
 ## Import
 

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -13,7 +13,7 @@ resource "databricks_job" "this" {
     
     new_cluster  {
         num_workers   = 300
-        spark_version = "6.6.x-scala2.11
+        spark_version = "6.6.x-scala2.11"
         node_type_id  = "i3.xlarge"
     }
     

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -82,6 +82,13 @@ You can invoke Spark submit tasks only on new clusters. In the new_cluster speci
 * `on_start` - (Optional) (List) list of emails to notify on failure
 * `on_success` - (Optional) (List) list of emails to notify on failure
 
+## Access Control
+
+By default, all users can create and modify jobs unless an administrator [enables jobs access control](https://docs.databricks.com/administration-guide/access-control/jobs-acl.html). With jobs access control, individual permissions determine a user’s abilities. 
+
+* [databricks_permissions](permissions.md#Job-usage) can control which groups or individual users can *Can View*, *Can Manage Run*, and *Can Manage*.
+* [databricks_cluster_policy](cluster_policy.md) can control which kinds of clusters users can create for jobs.
+
 ## Import
 
 The resource job can be imported using the id of the job

--- a/docs/resources/notebook.md
+++ b/docs/resources/notebook.md
@@ -41,6 +41,10 @@ In addition to all arguments above, the following attributes are exported:
 * `object_id` -  Unique identifier for a NOTEBOOK or DIRECTORY.
 * `object_type` -  The type of the object. It could be NOTEBOOK, DIRECTORY or LIBRARY.
 
+## Access Control
+
+* [databricks_permissions](permissions.md#Notebook-usage) can control which groups or individual users can access notebooks or folders.
+
 ## Import
 
 The resource notebook can be imported using notebook id

--- a/docs/resources/permissions.md
+++ b/docs/resources/permissions.md
@@ -1,16 +1,66 @@
 # databricks_permissions Resource
 
--> **Note** This feature is not available to all customers. Please contact [sales@databricks.com](mailto:sales@databricks.com) in order to enable this feature. This resource has evolving API, which may change in future versions of provider.
+This resource allows you to generically manage permissions for other resources in Databricks workspace. It would guarantee, that only *admins*, *authenticated principal* and those declared within `access_control` blocks would have specified access. It is not possible to remove management rights from *admins* group.
 
-This resource allows you to generically manage permissions for other resources in Databricks workspace. 
+## Cluster usage
 
-## Example Usage
+It's possible to separate [cluster access control](https://docs.databricks.com/security/access-control/cluster-acl.html) to three different permission levels: `CAN_ATTACH_TO`, `CAN_RESTART` and `CAN_MANAGE`:
 
 ```hcl
-resource "databricks_group" "datascience" {
-    display_name = "Data scientists"
-    allow_cluster_create = false
-    allow_instance_pool_create = false
+resource "databricks_group" "auto" {
+    display_name = "Automation"
+}
+
+resource "databricks_group" "eng" {
+    display_name = "Engineering"
+}
+
+resource "databricks_group" "ds" {
+    display_name = "Data Science"
+}
+
+resource "databricks_cluster" "shared_autoscaling" {
+    cluster_name            = "Shared Autoscaling"
+    spark_version           = "6.6.x-scala2.11"
+    node_type_id            = "Standard_DS3_v2"
+    autotermination_minutes = 60
+    autoscale {
+        min_workers = 1
+        max_workers = 10
+    }
+}
+
+resource "databricks_permissions" "cluster_usage" {
+    cluster_id = databricks_cluster.shared_autoscaling.cluster_id
+
+    access_control {
+        group_name = databricks_group.auto.display_name
+        permission_level = "CAN_ATTACH_TO"
+    }
+
+    access_control {
+        group_name = databricks_group.eng.display_name
+        permission_level = "CAN_RESTART"
+    }
+
+    access_control {
+        group_name = databricks_group.ds.display_name
+        permission_level = "CAN_MANAGE"
+    }
+}
+```
+
+## Cluster Policy usage
+
+Cluster policies allow creation of [clusters](cluster.md), that match [given policy](https://docs.databricks.com/administration-guide/clusters/policies.html). It's possible to assign `CAN_USE` permission to users and groups:
+
+```hcl
+resource "databricks_group" "ds" {
+    display_name = "Data Science"
+}
+
+resource "databricks_group" "eng" {
+    display_name = "Engineering"
 }
 
 resource "databricks_cluster_policy" "something_simple" {
@@ -25,15 +75,258 @@ resource "databricks_cluster_policy" "something_simple" {
     })
 }
 
-resource "databricks_permissions" "grant policy usage" {
+resource "databricks_permissions" "policy_usage" {
     cluster_policy_id = databricks_cluster_policy.something_simple.id
 
     access_control {
-        group_name = databricks_scim_group.datascience.display_name
+        group_name = databricks_group.ds.display_name
+        permission_level = "CAN_USE"
+    }
+
+    access_control {
+        group_name = databricks_group.eng.display_name
         permission_level = "CAN_USE"
     }
 }
 ```
+
+## Instance Pool usage
+
+[Instance Pools](instance_pool.md) access control [allows to](https://docs.databricks.com/security/access-control/pool-acl.html) assign `CAN_ATTACH_TO` and `CAN_MANAGE` permissions to users and groups. It's also possible to grant creation of Instance Pools to individual [groups](group.md#allow_instance_pool_create) and [users](user.md#allow_instance_pool_create).
+
+```hcl
+resource "databricks_group" "auto" {
+    display_name = "Automation"
+}
+
+resource "databricks_group" "eng" {
+    display_name = "Engineering"
+}
+
+resource "databricks_instance_pool" "this" {
+    instance_pool_name = "Reserved Instances"
+    min_idle_instances = 0
+    max_capacity       = 10
+    node_type_id       = "i3.xlarge"
+}
+
+resource "databricks_permissions" "pool_usage" {
+    instance_pool_id = databricks_instance_pool.this.id
+
+    access_control {
+        group_name = databricks_group.auto.display_name
+        permission_level = "CAN_ATTACH_TO"
+    }
+
+    access_control {
+        group_name = databricks_group.eng.display_name
+        permission_level = "CAN_MANAGE"
+    }
+}
+```
+
+## Job usage
+
+There are four assignable [permission levels](https://docs.databricks.com/security/access-control/jobs-acl.html#job-permissions) for [databricks_job](job.md): `CAN_VIEW`, `CAN_MANAGE_RUN`, `IS_OWNER`, and `CAN_MANAGE`. Admins are granted the `CAN_MANAGE` permission by default, and they can assign that permission to non-admin users.
+
+* The creator of a job has `IS_OWNER` permission. Destroying `databricks_permissions` resource for a job would revert ownership to creator.
+* A job cannot have more than one owner.
+* A job cannot have a group as an owner.
+* Jobs triggered through *Run Now* assume the permissions of the job owner and not the user who issued Run Now. 
+* Read [main documentation](https://docs.databricks.com/security/access-control/jobs-acl.html) for additional detail.
+
+```hcl
+resource "databricks_group" "auto" {
+    display_name = "Automation"
+}
+
+resource "databricks_group" "eng" {
+    display_name = "Engineering"
+}
+
+resource "databricks_job" "this" {
+    name = "Featurization"
+
+    new_cluster  {
+        num_workers   = 300
+        spark_version = "6.6.x-scala2.11
+        node_type_id  = "i3.xlarge"
+    }
+    
+    notebook_task {
+        notebook_path = "/Production/MakeFeatures"
+    }
+}
+
+resource "databricks_permissions" "job_usage" {
+    job_id = databricks_job.this.id
+
+    access_control {
+        group_name = "users"
+        permission_level = "CAN_VIEW"
+    }
+
+    access_control {
+        group_name = databricks_group.auto.display_name
+        permission_level = "CAN_MANAGE_RUN"
+    }
+
+    access_control {
+        group_name = databricks_group.eng.display_name
+        permission_level = "CAN_MANAGE"
+    }
+}
+```
+
+## Notebook usage
+
+Valid [permission levels](https://docs.databricks.com/security/access-control/workspace-acl.html#notebook-permissions) for [databricks_notebook](notebook.md) are: `CAN_READ`, `CAN_RUN`, `CAN_EDIT`, and `CAN_MANAGE`.
+
+```hcl
+resource "databricks_group" "auto" {
+    display_name = "Automation"
+}
+
+resource "databricks_group" "eng" {
+    display_name = "Engineering"
+}
+
+resource "databricks_notebook" "this" {
+    content = base64encode("# Welcome to your Python notebook")
+    path = "/Production/ETL/Features"
+    overwrite = true
+    mkdirs = true
+    language = "PYTHON"
+    format = "SOURCE"
+}
+
+resource "databricks_permissions" "notebook_usage" {
+    notebook_path = databricks_notebook.this.path
+
+    access_control {
+        group_name = "users"
+        permission_level = "CAN_VIEW"
+    }
+
+    access_control {
+        group_name = databricks_group.auto.display_name
+        permission_level = "CAN_RUN"
+    }
+
+    access_control {
+        group_name = databricks_group.eng.display_name
+        permission_level = "CAN_EDIT"
+    }
+}
+```
+
+## Folder usage
+
+Valid [permission levels](https://docs.databricks.com/security/access-control/workspace-acl.html#folder-permissions) for folders of [databricks_notebook](notebook.md) are: `CAN_READ`, `CAN_RUN`, `CAN_EDIT`, and `CAN_MANAGE`. Notebooks and experiments in a folder inherit all permissions settings of that folder. For example, a user that has `CAN_RUN` permission on a folder has `CAN_RUN` permission on the notebooks in that folder. 
+
+* All users can list items in the folder without any permissions.
+* All users have `CAN_MANAGE` permission for items in the Workspace > Shared Icon Shared folder. You can grant `CAN_MANAGE` permission to notebooks and folders by moving them to the Shared Icon Shared folder.
+* All users have `CAN_MANAGE` permission for objects the user creates.
+* User home directory - The user has `CAN_MANAGE` permission. All other users can list their directories.
+
+```hcl
+resource "databricks_group" "auto" {
+    display_name = "Automation"
+}
+
+resource "databricks_group" "eng" {
+    display_name = "Engineering"
+}
+
+resource "databricks_notebook" "this" {
+    content = base64encode("# Welcome to your Python notebook")
+    path = "/Production/ETL/Features"
+    overwrite = true
+    mkdirs = true
+    language = "PYTHON"
+    format = "SOURCE"
+}
+
+resource "databricks_permissions" "folder_usage" {
+    directory_path = "/Production/ETL"
+    depends_on = [databricks_notebook.this]
+
+    access_control {
+        group_name = "users"
+        permission_level = "CAN_VIEW"
+    }
+
+    access_control {
+        group_name = databricks_group.auto.display_name
+        permission_level = "CAN_RUN"
+    }
+
+    access_control {
+        group_name = databricks_group.eng.display_name
+        permission_level = "CAN_EDIT"
+    }
+}
+```
+
+## Passwords usage
+
+By default on AWS deployments, all admin users can sign in to Databricks using either SSO or their username and password, and all API users can authenticate to the Databricks REST APIs using their username and password. As an admin, you [can limit](https://docs.databricks.com/administration-guide/users-groups/single-sign-on/index.html#optional-configure-password-access-control) admin users’ and API users’ ability to authenticate with their username and password by configuring `CAN_USE` permissions using password access control.
+ign-On.
+
+```hcl
+resource "databricks_group" "guests" {
+    display_name = "Guest Users"
+}
+
+resource "databricks_permissions" "password_usage" {
+    authorization = "passwords"
+
+    access_control {
+        group_name = databricks_group.guests.display_name
+        permission_level = "CAN_USE"
+    }
+}
+```
+
+## Token usage
+
+Only [possible permission](https://docs.databricks.com/administration-guide/access-control/tokens.html) to assign to non-admin group is `CAN_USE`, where *admins* `CAN_MANAGE` all tokens: 
+
+```hcl
+resource "databricks_group" "auto" {
+    display_name = "Automation"
+}
+
+resource "databricks_group" "eng" {
+    display_name = "Engineering"
+}
+
+resource "databricks_permissions" "token_usage" {
+    authorization = "tokens"
+
+    access_control {
+        group_name = databricks_group.auto.display_name
+        permission_level = "CAN_USE"
+    }
+
+    access_control {
+        group_name = databricks_group.eng.display_name
+        permission_level = "CAN_USE"
+    }
+}
+```
+
+## Instance Profiles
+
+[Instance Profiles](instance_profile.md) are not managed by General Permissions API and therefore [databricks_group_instance_profile](group_instance_profile.md) and [databricks_user_instance_profile](user_instance_profile.md) should be used to allow usage of specific AWS EC2 IAM roles to users or groups.
+
+## Secrets
+
+One can control access to [databricks_secret](secret.md) through `initial_manage_principal` argument on [databricks_secret_scope](secret_scope.md) or [databricks_secret_acl](secret_acl.md), so that users can `READ`, `WRITE` or `MANAGE` entries within secret scope.
+
+## Tables, Views and Databases
+
+General Permissions API does not apply to access control for tables and permissions have to be managed separately. Though, terraform integration is coming in the future versions.
 
 ## Argument Reference
 
@@ -60,14 +353,21 @@ access_control {
 
 Attributes are:
 
-* `permission_level` - (Required) (String) permission level according to [specific resource](https://docs.databricks.com/security/access-control/workspace-acl.html) 
-* `user_name` - (Optional) (String) name of the user, which should be used if group name is not used
-* `group_name` - (Optional) (String) name of the group, which should be used if user name is not used. We recommend setting permissions on groups.
-
+* `permission_level` - (Required) permission level according to specific resource. See examples above for the reference.
+* `user_name` - (Optional) name of the [user](user.md), which should be used if group name is not used
+* `group_name` - (Optional) name of the [group](group.md), which should be used if user name is not used. We recommend setting permissions on groups.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - Canonical unique identifier for the permissions.
-* `object_type` - (String) type of permissions.
+* `object_type` - type of permissions.
+
+## Import
+
+The resource permissions can be imported using the object id
+
+```bash
+$ terraform import databricks_permissions.this /<object type>/<object id>
+```

--- a/docs/resources/permissions.md
+++ b/docs/resources/permissions.md
@@ -47,6 +47,7 @@ Exactly one of the following attribues is required:
 * `notebook_path` - path of notebook
 * `cluster_policy_id` - [cluster policy](cluster_policy.md) id
 * `instance_pool_id` - [instance pool](instance_pool.md) id
+* `authorization` - either [`tokens`](https://docs.databricks.com/administration-guide/access-control/tokens.html) or [`passwords`](https://docs.databricks.com/administration-guide/users-groups/single-sign-on/index.html#configure-password-permission).
 
 One or more `access_control` blocks are required to actually set the permission levels:
 

--- a/docs/resources/secret_acl.md
+++ b/docs/resources/secret_acl.md
@@ -1,6 +1,6 @@
 # databricks_secret_acl Resource
 
-Create or overwrite the ACL associated with the given principal (user or group) on the specified scope point. Please consult [Secrets User Guide](https://docs.databricks.com/security/secrets/index.html#secrets-user-guide) for more details.
+Create or overwrite the ACL associated with the given principal (user or group) on the specified [databricks_secret_scope](secret_scope.md). Please consult [Secrets User Guide](https://docs.databricks.com/security/secrets/index.html#secrets-user-guide) for more details.
 
 ## Example Usage
 

--- a/docs/resources/secret_scope.md
+++ b/docs/resources/secret_scope.md
@@ -23,7 +23,7 @@ resource "databricks_secret_scope" "my-scope" {
 The following arguments are supported:
 
 * `name` - (Required) Scope name requested by the user. Scope names are unique. This field is required.
-* `initial_manage_principal` - (Optional) The principal that is initially granted MANAGE permission to the created scope.
+* `initial_manage_principal` - (Optional) The principal that is initially granted `MANAGE` permission to the created scope. Defaults to `users`. Additional principals can be added with [databricks_secret_acl](secret_acl.md)
 
 ## Attribute Reference
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -45,8 +45,8 @@ The following arguments are available:
 
 * `user_name` - (Required) This is the username of the given user and will be their form of access and identity.
 * `display_name` - (Optional) This is an alias for the username can be the full name of the user.
-* `allow_cluster_create` -  (Optional) Allow the user to have [cluster](cluster.md) create priviliges. Defaults to false.
-* `allow_instance_pool_create` -  (Optional) Allow the user to have [instance pool](instance_pool.md) create priviliges. Defaults to false.
+* `allow_cluster_create` -  (Optional) Allow the user to have [cluster](cluster.md) create priviliges. Defaults to false. More fine grained permissions could be assigned with [databricks_permissions](permissions.md#Cluster-usage) and `cluster_id` argument. Everyone without `allow_cluster_create` arugment set, but with [permission to use](permissions.md#Cluster-Policy-usage) Cluster Policy would be able to create clusters, but within boundaries of that specific policy.
+* `allow_instance_pool_create` -  (Optional) Allow the user to have [instance pool](instance_pool.md) create priviliges. Defaults to false. More fine grained permissions could be assigned with [databricks_permissions](permissions.md#Instance-Pool-usage) and [instance_pool_id](permissions.md#instance_pool_id) argument.
 * `active` - (Optional) Either user is active or not. True by default, but can be set to false in case of user deactivation with preserving user assets.
 
 ## Attribute Reference

--- a/identity/users.go
+++ b/identity/users.go
@@ -25,7 +25,7 @@ type UsersAPI struct {
 // UserEntity entity from which resource schema is made
 type UserEntity struct {
 	UserName                string `json:"user_name"`
-	DisplayName             string `json:"display_name,omitempty"`
+	DisplayName             string `json:"display_name,omitempty" tf:"computed"`
 	Active                  bool   `json:"active,omitempty"`
 	AllowClusterCreate      bool   `json:"allow_cluster_create,omitempty"`
 	AllowInstancePoolCreate bool   `json:"allow_instance_pool_create,omitempty"`


### PR DESCRIPTION
Fix #185 

# Tokens

```hcl
resource "databricks_permissions" "token_usage" {
    authorization = "tokens"

    access_control {
        group_name = "Automation"
        permission_level = "CAN_USE"
    }

    access_control {
        group_name = "Engineering"
        permission_level = "CAN_MANAGE"
    }
}
```

# Passwords

```hcl
resource "databricks_permissions" "password_usage" {
    authorization = "passwords"

    access_control {
        group_name = "Invited Users"
        permission_level = "CAN_USE"
    }
}
```