### PR TITLE
Add databricks_node_type data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,14 @@ provider "databricks" {
   token = "<your PAT token>"
 }
 
+data "databricks_node_type" "smallest" {
+  local_disk = true
+}
+
 resource "databricks_cluster" "shared_autoscaling" {
   cluster_name            = "Shared Autoscaling"
   spark_version           = "6.6.x-scala2.11"
-  node_type_id            = "i3.xlarge"
+  node_type_id            = databricks_node_type.smallest.id
   autotermination_minutes = 20
 
   autoscale {

--- a/access/resource_permissions_test.go
+++ b/access/resource_permissions_test.go
@@ -669,7 +669,11 @@ func TestAccPermissionsInstancePool(t *testing.T) {
 		poolsAPI := compute.NewInstancePoolsAPI(permissionsAPI.client)
 		ips, err := poolsAPI.Create(compute.InstancePool{
 			InstancePoolName: group,
-			NodeTypeID:       compute.NewClustersAPI(permissionsAPI.client).GetSmallestNodeTypeWithStorage(),
+			NodeTypeID: compute.NewClustersAPI(
+				permissionsAPI.client).GetSmallestNodeType(
+				compute.NodeTypeRequest{
+					LocalDisk: true,
+				}),
 		})
 		require.NoError(t, err)
 		defer func() {
@@ -766,7 +770,11 @@ func TestAccPermissionsJobs(t *testing.T) {
 			NewCluster: &compute.Cluster{
 				NumWorkers:   2,
 				SparkVersion: "6.4.x-scala2.11",
-				NodeTypeID:   compute.NewClustersAPI(permissionsAPI.client).GetSmallestNodeTypeWithStorage(),
+				NodeTypeID: compute.NewClustersAPI(
+					permissionsAPI.client).GetSmallestNodeType(
+					compute.NodeTypeRequest{
+						LocalDisk: true,
+					}),
 			},
 			NotebookTask: &compute.NotebookTask{
 				NotebookPath: "/Production/Featurize",

--- a/compute/clusters.go
+++ b/compute/clusters.go
@@ -3,7 +3,6 @@ package compute
 import (
 	"fmt"
 	"log"
-	"sort"
 	"strings"
 	"time"
 
@@ -235,11 +234,10 @@ func (a ClustersAPI) List() ([]ClusterInfo, error) {
 	return clusterList.Clusters, err
 }
 
-// ListNodeTypes returns a list of supported Spark node types
-func (a ClustersAPI) ListNodeTypes() ([]NodeType, error) {
-	var nodeTypeList = &NodeTypeList{}
-	err := a.client.Get("/clusters/list-node-types", nil, nodeTypeList)
-	return nodeTypeList.NodeTypes, err
+// ListNodeTypes returns a sorted list of supported Spark node types
+func (a ClustersAPI) ListNodeTypes() (l NodeTypeList, err error) {
+	err = a.client.Get("/clusters/list-node-types", nil, &l)
+	return
 }
 
 // GetOrCreateRunningCluster creates an autoterminating cluster if it doesn't exist
@@ -270,7 +268,9 @@ func (a ClustersAPI) GetOrCreateRunningCluster(name string, custom ...Cluster) (
 			}
 		}
 	}
-	smallestNodeType := a.GetSmallestNodeTypeWithStorage()
+	smallestNodeType := a.GetSmallestNodeType(NodeTypeRequest{
+		LocalDisk: true,
+	})
 	log.Printf("[INFO] Creating an autoterminating cluster with node type %s", smallestNodeType)
 	r := Cluster{
 		NumWorkers:             1,
@@ -290,59 +290,54 @@ func (a ClustersAPI) GetOrCreateRunningCluster(name string, custom ...Cluster) (
 	return a.Create(r)
 }
 
-// GetSmallestNodeTypeWithStorage returns smallest runtime node type
-func (a ClustersAPI) GetSmallestNodeTypeWithStorage() string {
-	nodeTypes, err := a.ListNodeTypes()
-	if err != nil || len(nodeTypes) == 0 {
+// NodeTypeRequest is a wrapper for local filtering of node types
+type NodeTypeRequest struct {
+	MinMemoryGB int32  `json:"min_memory_gb,omitempty"`
+	GBPerCore   int32  `json:"gb_per_core,omitempty"`
+	MinCores    int32  `json:"min_cores,omitempty"`
+	MinGPUs     int32  `json:"min_gpus,omitempty"`
+	LocalDisk   bool   `json:"local_disk,omitempty"`
+	Category    string `json:"category,omitempty"`
+}
+
+// GetSmallestNodeType returns smallest (or default) node type id given the criteria
+func (a ClustersAPI) GetSmallestNodeType(r NodeTypeRequest) string {
+	list, _ := a.ListNodeTypes()
+	// error is explicitly ingored here, because Azure returns
+	// apparently too big of a JSON for Go to parse
+	if len(list.NodeTypes) == 0 {
 		if a.client.IsAzure() {
 			return "Standard_D3_v2"
 		}
 		return "i3.xlarge"
 	}
-	nodesWithLocalDisk := []NodeType{}
-	for _, nt := range nodeTypes {
-		if nt.IsDeprecated {
+	list.Sort()
+	for _, nt := range list.NodeTypes {
+		gbs := (nt.MemoryMB / 1024)
+		if r.MinMemoryGB > 0 && gbs < r.MinMemoryGB {
 			continue
 		}
-		if nt.NodeInstanceType.LocalDisks > 0 {
-			nodesWithLocalDisk = append(nodesWithLocalDisk, nt)
+		if r.GBPerCore > 0 && (gbs/int32(nt.NumCores)) < r.GBPerCore {
+			continue
 		}
+		if r.MinCores > 0 && int32(nt.NumCores) < r.MinCores {
+			continue
+		}
+		if r.MinGPUs > 0 && nt.NumGPUs < r.MinGPUs {
+			continue
+		}
+		if r.LocalDisk && nt.NodeInstanceType != nil &&
+			(nt.NodeInstanceType.LocalDisks < 1 &&
+				nt.NodeInstanceType.LocalNVMeDisks < 1) {
+			continue
+		}
+		if r.Category != "" && nt.Category != r.Category {
+			continue
+		}
+		return nt.NodeTypeID
 	}
-	nodeType := getSmallestNodeType(nodesWithLocalDisk)
-	return nodeType.NodeTypeID
-}
-
-// getSmallestNodeType returns the smallest node type in a list of node types
-func getSmallestNodeType(nodeTypes []NodeType) NodeType {
-	sortedNodeTypes := nodeTypes
-	sort.Slice(sortedNodeTypes, func(i, j int) bool {
-		if sortedNodeTypes[i].IsDeprecated != sortedNodeTypes[j].IsDeprecated {
-			return !sortedNodeTypes[i].IsDeprecated
-		}
-		if sortedNodeTypes[i].MemoryMB != sortedNodeTypes[j].MemoryMB {
-			return sortedNodeTypes[i].MemoryMB < sortedNodeTypes[j].MemoryMB
-		}
-		if sortedNodeTypes[i].NumCores != sortedNodeTypes[j].NumCores {
-			return sortedNodeTypes[i].NumCores < sortedNodeTypes[j].NumCores
-		}
-		if sortedNodeTypes[i].NumGPUs != sortedNodeTypes[j].NumGPUs {
-			return sortedNodeTypes[i].NumGPUs < sortedNodeTypes[j].NumGPUs
-		}
-		if sortedNodeTypes[i].NodeInstanceType != nil && sortedNodeTypes[j].NodeInstanceType != nil {
-			if sortedNodeTypes[i].NodeInstanceType.LocalNVMeDisks != sortedNodeTypes[j].NodeInstanceType.LocalNVMeDisks {
-				return sortedNodeTypes[i].NodeInstanceType.LocalNVMeDisks < sortedNodeTypes[j].NodeInstanceType.LocalNVMeDisks
-			}
-
-			if sortedNodeTypes[i].NodeInstanceType.LocalDisks != sortedNodeTypes[j].NodeInstanceType.LocalDisks {
-				return sortedNodeTypes[i].NodeInstanceType.LocalDisks < sortedNodeTypes[j].NodeInstanceType.LocalDisks
-			}
-
-			if sortedNodeTypes[i].NodeInstanceType.LocalDiskSizeGB != sortedNodeTypes[j].NodeInstanceType.LocalDiskSizeGB {
-				return sortedNodeTypes[i].NodeInstanceType.LocalDiskSizeGB < sortedNodeTypes[j].NodeInstanceType.LocalDiskSizeGB
-			}
-		}
-		return sortedNodeTypes[i].InstanceTypeID < sortedNodeTypes[j].InstanceTypeID
-	})
-	nodeType := sortedNodeTypes[0]
-	return nodeType
+	if a.client.IsAzure() {
+		return "Standard_D3_v2"
+	}
+	return "i3.xlarge"
 }

--- a/compute/clusters_test.go
+++ b/compute/clusters_test.go
@@ -574,163 +574,6 @@ func TestAccListClustersIntegration(t *testing.T) {
 	assert.True(t, clusterReadInfo.State == ClusterStateRunning)
 }
 
-func TestClusters_SortNodeTypes_Deprecated(t *testing.T) {
-	nodeTypes := []NodeType{
-		{
-			IsDeprecated: true,
-			NodeTypeID:   "deprecated1",
-		},
-		{
-			IsDeprecated: false,
-			NodeTypeID:   "not deprecated",
-		},
-		{
-			IsDeprecated: true,
-			NodeTypeID:   "deprecated2",
-		},
-	}
-
-	smallestNodeType := getSmallestNodeType(nodeTypes)
-	assert.Equal(t, "not deprecated", smallestNodeType.NodeTypeID)
-}
-
-func TestClusters_SortNodeTypes_Memory(t *testing.T) {
-	nodeTypes := []NodeType{
-		{
-			MemoryMB:   3,
-			NodeTypeID: "3",
-		},
-		{
-			MemoryMB:   1,
-			NodeTypeID: "1",
-		},
-		{
-			MemoryMB:   2,
-			NodeTypeID: "2",
-		},
-		{
-			MemoryMB:   2,
-			NodeTypeID: "another 2",
-		},
-	}
-
-	smallestNodeType := getSmallestNodeType(nodeTypes)
-	assert.Equal(t, "1", smallestNodeType.NodeTypeID)
-}
-
-func TestClusters_SortNodeTypes_CPU(t *testing.T) {
-	nodeTypes := []NodeType{
-		{
-			NumCores:   3,
-			NodeTypeID: "3",
-		},
-		{
-			NumCores:   1,
-			NodeTypeID: "1",
-		},
-		{
-			NumCores:   2,
-			NodeTypeID: "2",
-		},
-		{
-			NumCores:   1,
-			NodeTypeID: "another 1",
-		},
-	}
-
-	smallestNodeType := getSmallestNodeType(nodeTypes)
-	assert.Equal(t, "1", smallestNodeType.NodeTypeID)
-}
-
-func TestClusters_SortNodeTypes_GPU(t *testing.T) {
-	nodeTypes := []NodeType{
-		{
-			NumGPUs:    3,
-			NodeTypeID: "3",
-		},
-		{
-			NumGPUs:    1,
-			NodeTypeID: "1",
-		},
-		{
-			NumGPUs:    2,
-			NodeTypeID: "2",
-		},
-		{
-			NumGPUs:    1,
-			NodeTypeID: "another 1",
-		},
-	}
-
-	smallestNodeType := getSmallestNodeType(nodeTypes)
-	assert.Equal(t, "1", smallestNodeType.NodeTypeID)
-}
-
-func TestClusters_SortNodeTypes_CPU_Deprecated(t *testing.T) {
-	nodeTypes := []NodeType{
-		{
-			NumCores:     3,
-			IsDeprecated: false,
-			NodeTypeID:   "3 not deprecated",
-		},
-		{
-			NumCores:     1,
-			IsDeprecated: true,
-			NodeTypeID:   "1 deprecated",
-		},
-		{
-			NumCores:     2,
-			IsDeprecated: false,
-			NodeTypeID:   "2 not deprecated",
-		},
-		{
-			NumCores:     1,
-			IsDeprecated: false,
-			NodeTypeID:   "1 not deprecated",
-		},
-		{
-			NumCores:     2,
-			IsDeprecated: true,
-			NodeTypeID:   "2 deprecated",
-		},
-	}
-
-	smallestNodeType := getSmallestNodeType(nodeTypes)
-	assert.Equal(t, "1 not deprecated", smallestNodeType.NodeTypeID)
-}
-
-func TestClusters_SortNodeTypes_LocalDisks(t *testing.T) {
-	nodeTypes := []NodeType{
-		{
-			NodeInstanceType: &NodeInstanceType{
-				LocalDisks: 3,
-			},
-			NodeTypeID: "3",
-		},
-		{
-			NodeInstanceType: &NodeInstanceType{
-				LocalDisks: 1,
-			},
-			NodeTypeID: "1",
-		},
-		{
-			NodeInstanceType: &NodeInstanceType{
-				LocalDisks: 2,
-			},
-			NodeTypeID: "2",
-		},
-		{
-			NodeInstanceType: &NodeInstanceType{
-				LocalDisks: 3,
-			},
-			NodeTypeID: "another 3",
-		},
-	}
-
-	smallestNodeType := getSmallestNodeType(nodeTypes)
-	assert.Equal(t, "1", smallestNodeType.NodeTypeID)
-}
-
 func TestAwsAccSmallestNodeType(t *testing.T) {
 	cloudEnv := os.Getenv("CLOUD_ENV")
 	if cloudEnv == "" {
@@ -738,6 +581,27 @@ func TestAwsAccSmallestNodeType(t *testing.T) {
 	}
 
 	client := common.CommonEnvironmentClient()
-	nodeType := NewClustersAPI(client).GetSmallestNodeTypeWithStorage()
+	nodeType := NewClustersAPI(client).GetSmallestNodeType(NodeTypeRequest{
+		LocalDisk: true,
+	})
 	assert.Equal(t, "m5d.large", nodeType)
+}
+
+func TestAzureAccNodeTypes(t *testing.T) {
+	cloudEnv := os.Getenv("CLOUD_ENV")
+	if cloudEnv == "" {
+		t.Skip("Acceptance tests skipped unless env 'CLOUD_ENV' is set")
+	}
+
+	clustersAPI := NewClustersAPI(common.CommonEnvironmentClient())
+	m := map[string]NodeTypeRequest{
+		"Standard_F4s":     {},
+		"Standard_L8s_v2":  {LocalDisk: true},
+		"Standard_NC6s_v3": {MinGPUs: 1},
+		"Standard_L32s_v2": {MinCores: 32, GBPerCore: 8},
+	}
+
+	for k, v := range m {
+		assert.Equal(t, k, clustersAPI.GetSmallestNodeType(v))
+	}
 }

--- a/compute/common_instances.go
+++ b/compute/common_instances.go
@@ -58,10 +58,13 @@ func CommonInstancePoolID() string {
 			}
 		}
 		instancePool := InstancePool{
-			PreloadedSparkVersions:             []string{CommonRuntimeVersion()},
-			NodeTypeID:                         clusters.GetSmallestNodeTypeWithStorage(),
-			InstancePoolName:                   currentUserPool,
-			MaxCapacity:                        10,
+			PreloadedSparkVersions: []string{CommonRuntimeVersion()},
+			NodeTypeID: clusters.GetSmallestNodeType(NodeTypeRequest{
+				LocalDisk: true,
+			}),
+			InstancePoolName: currentUserPool,
+			MaxCapacity:      10,
+
 			IdleInstanceAutoTerminationMinutes: 15,
 		}
 		if !client.IsAzure() {

--- a/compute/data_node_type.go
+++ b/compute/data_node_type.go
@@ -1,0 +1,31 @@
+package compute
+
+import (
+	"context"
+
+	"github.com/databrickslabs/databricks-terraform/internal"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// DataSourceNodeType returns smallest node depedning on the cloud
+func DataSourceNodeType() *schema.Resource {
+	s := internal.StructToSchema(NodeTypeRequest{}, func(
+		s map[string]*schema.Schema) map[string]*schema.Schema {
+		return s
+	})
+	return &schema.Resource{
+		Schema: s,
+		ReadContext: func(ctx context.Context, d *schema.ResourceData,
+			m interface{}) diag.Diagnostics {
+			var this NodeTypeRequest
+			err := internal.DataToStructPointer(d, s, &this)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			clustersAPI := NewClustersAPI(m)
+			d.SetId(clustersAPI.GetSmallestNodeType(this))
+			return nil
+		},
+	}
+}

--- a/compute/data_node_type_test.go
+++ b/compute/data_node_type_test.go
@@ -1,0 +1,111 @@
+package compute
+
+import (
+	"testing"
+
+	"github.com/databrickslabs/databricks-terraform/internal/qa"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNodeType(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				ReuseRequest: true,
+				Resource:     "/api/2.0/clusters/list-node-types",
+				Response: NodeTypeList{
+					[]NodeType{
+						{
+							NodeTypeID:     "Random_05",
+							InstanceTypeID: "Random_05",
+							MemoryMB:       1024,
+							NumCores:       32,
+							NodeInstanceType: &NodeInstanceType{
+								LocalDisks:      3,
+								LocalDiskSizeGB: 100,
+							},
+						},
+						{
+							NodeTypeID:     "Standard_L80s_v2",
+							InstanceTypeID: "Standard_L80s_v2",
+							MemoryMB:       655360,
+							NumCores:       80,
+							NodeInstanceType: &NodeInstanceType{
+								LocalDisks:      2,
+								InstanceTypeID:  "Standard_L80s_v2",
+								LocalDiskSizeGB: 160,
+								LocalNVMeDisks:  1,
+							},
+						},
+						{
+							NodeTypeID:     "Random_01",
+							InstanceTypeID: "Random_01",
+							MemoryMB:       8192,
+							NumCores:       8,
+							NodeInstanceType: &NodeInstanceType{
+								InstanceTypeID: "_",
+							},
+						},
+						{
+							NodeTypeID:     "Random_02",
+							InstanceTypeID: "Random_02",
+							MemoryMB:       8192,
+							NumCores:       8,
+							NumGPUs:        2,
+							NodeInstanceType: &NodeInstanceType{
+								InstanceTypeID: "_",
+							},
+						},
+						{
+							NodeTypeID:     "Random_03",
+							InstanceTypeID: "Random_03",
+							MemoryMB:       8192,
+							NumCores:       8,
+							NumGPUs:        1,
+							NodeInstanceType: &NodeInstanceType{
+								InstanceTypeID:      "_",
+								LocalNVMeDisks:      15,
+								LocalNVMeDiskSizeGB: 235,
+							},
+						},
+						{
+							NodeTypeID:     "Random_04",
+							InstanceTypeID: "Random_04",
+							MemoryMB:       32000,
+							NumCores:       32,
+							IsDeprecated:   true,
+							NodeInstanceType: &NodeInstanceType{
+								LocalDisks:      2,
+								LocalDiskSizeGB: 20,
+							},
+						},
+						{
+							NodeTypeID:     "Standard_F4s",
+							InstanceTypeID: "Standard_F4s",
+							MemoryMB:       8192,
+							NumCores:       4,
+							NodeInstanceType: &NodeInstanceType{
+								LocalDisks:      1,
+								LocalDiskSizeGB: 16,
+								LocalNVMeDisks:  0,
+							},
+						},
+					},
+				},
+			},
+		},
+		Read:        true,
+		Resource:    DataSourceNodeType(),
+		NonWritable: true,
+		State: map[string]interface{}{
+			"local_disk":    true,
+			"min_memory_gb": 8,
+			"min_cores":     8,
+			"min_gpus":      1,
+		},
+		ID: ".",
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, "Random_03", d.Id())
+}

--- a/compute/model.go
+++ b/compute/model.go
@@ -1,6 +1,9 @@
 package compute
 
-import "fmt"
+import (
+	"fmt"
+	"sort"
+)
 
 // AutoScale is a struct the describes auto scaling for clusters
 type AutoScale struct {
@@ -405,6 +408,38 @@ type InstancePoolList struct {
 // NodeTypeList contains a list of node types
 type NodeTypeList struct {
 	NodeTypes []NodeType `json:"node_types,omitempty"`
+}
+
+// Sort NodeTypes within this struct
+func (l *NodeTypeList) Sort() {
+	sort.Slice(l.NodeTypes, func(i, j int) bool {
+		if l.NodeTypes[i].IsDeprecated != l.NodeTypes[j].IsDeprecated {
+			return !l.NodeTypes[i].IsDeprecated
+		}
+		if l.NodeTypes[i].NodeInstanceType != nil &&
+			l.NodeTypes[j].NodeInstanceType != nil {
+			if l.NodeTypes[i].NodeInstanceType.LocalDisks !=
+				l.NodeTypes[j].NodeInstanceType.LocalDisks {
+				return l.NodeTypes[i].NodeInstanceType.LocalDisks <
+					l.NodeTypes[j].NodeInstanceType.LocalDisks
+			}
+			if l.NodeTypes[i].NodeInstanceType.LocalDiskSizeGB !=
+				l.NodeTypes[j].NodeInstanceType.LocalDiskSizeGB {
+				return l.NodeTypes[i].NodeInstanceType.LocalDiskSizeGB <
+					l.NodeTypes[j].NodeInstanceType.LocalDiskSizeGB
+			}
+		}
+		if l.NodeTypes[i].MemoryMB != l.NodeTypes[j].MemoryMB {
+			return l.NodeTypes[i].MemoryMB < l.NodeTypes[j].MemoryMB
+		}
+		if l.NodeTypes[i].NumCores != l.NodeTypes[j].NumCores {
+			return l.NodeTypes[i].NumCores < l.NodeTypes[j].NumCores
+		}
+		if l.NodeTypes[i].NumGPUs != l.NodeTypes[j].NumGPUs {
+			return l.NodeTypes[i].NumGPUs < l.NodeTypes[j].NumGPUs
+		}
+		return l.NodeTypes[i].InstanceTypeID < l.NodeTypes[j].InstanceTypeID
+	})
 }
 
 // NotebookTask contains the information for notebook jobs

--- a/docs/data-sources/node_type.md
+++ b/docs/data-sources/node_type.md
@@ -1,0 +1,50 @@
+# databricks_node_type Data Source
+
+Gets smallest node type for [databricks_cluster](../resources/cluster.md) that fits search criteria, like amount of RAM or number of cores. [AWS](https://databricks.com/product/aws-pricing/instance-types) or [Azure](https://azure.microsoft.com/en-us/pricing/details/databricks/). Internally data source fetches [node types](https://docs.databricks.com/dev-tools/api/latest/clusters.html#list-node-types) available per cloud, similar to executing `databricks clusters list-node-types`, and filters it to return smallest possible node with criteria.
+
+-> **Note** This is experimental functionality, which aims to simplify things. In case of wrong parameters given (e.g. min_gpus = 876) or no nodes matching, data source will return cloud-default node type, even though it doesn't match search criteria specified by data source arguments: [i3.xlarge](https://aws.amazon.com/ec2/instance-types/i3/) for AWS or [Standard_D3_v2](https://docs.microsoft.com/en-us/azure/cloud-services/cloud-services-sizes-specs#dv2-series) for Azure.
+
+## Example Usage
+
+```hcl
+data "databricks_node_type" "with_gpu" {
+    local_disk  = true
+    min_cores   = 16
+    gb_per_core = 1
+    min_gpus    = 1
+}
+
+resource "databricks_cluster" "research" {
+    cluster_name            = "Research Cluster"
+    spark_version           = "6.6.x-scala2.11"
+    node_type_id            = databricks_node_type.with_gpu.id
+    autotermination_minutes = 20
+    autoscale {
+        min_workers = 1
+        max_workers = 50
+    }
+}
+```
+
+## Argument Reference
+
+Data source allows you to pick groups by the following attributes
+
+* `min_memory_gb` - (Optional) Minimum amount of memory per node in gigabytes. Defaults to *0*.
+* `gb_per_core` - (Optional) Number of gigabytes per core available on instance. Conflicts with `min_memory_gb`. Defaults to *0*.
+* `min_cores` - (Optional) Minimum number of CPU cores available on instance. Defaults to *0*.
+* `min_gpus` - (Optional) Minimum number of GPU's attached to instance. Defaults to *0*.
+* `local_disk` - (Optional) Pick only nodes with local storage. Defaults to *false*.
+* `category` - (Optional) Node category, which can be one of:
+  * `General purpose`
+  * `Memory optimized`
+  * `Storage optimized`
+  * `Compute optimized`
+  * `GPU`
+
+
+## Attribute Reference
+
+Data source exposes the following attributes:
+
+* `id` - node type, that can be used for [databricks_job](../resources/job.md), [databricks_cluster](../resources/cluster.md), or [databricks_instance_pool](../resources/instance_pool.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,10 +18,14 @@ provider "databricks" {
   token = "<your PAT token>"
 }
 
+data "databricks_node_type" "smallest" {
+  local_disk = true
+}
+
 resource "databricks_cluster" "shared_autoscaling" {
   cluster_name            = "Shared Autoscaling"
   spark_version           = "6.6.x-scala2.11"
-  node_type_id            = "i3.xlarge"
+  node_type_id            = databricks_node_type.smallest.id
   autotermination_minutes = 20
 
   autoscale {

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -3,10 +3,14 @@
 This resource allows you to create, update, and delete clusters.
 
 ```hcl
+data "databricks_node_type" "smallest" {
+  local_disk = true
+}
+
 resource "databricks_cluster" "shared_autoscaling" {
   cluster_name            = "Shared Autoscaling"
   spark_version           = "6.6.x-scala2.11"
-  node_type_id            = "i3.xlarge"
+  node_type_id            = databricks_node_type.smallest.id
   autotermination_minutes = 20
   autoscale {
     min_workers = 1
@@ -20,7 +24,7 @@ resource "databricks_cluster" "shared_autoscaling" {
 * `cluster_name` - (Optional) Cluster name. This doesn’t have to be unique. If not specified at creation, the cluster name will be an empty string.
 * `spark_version` - (Required) [Runtime version](https://docs.databricks.com/runtime/index.html) of the cluster. A [list of available Spark versions](https://docs.databricks.com/release-notes/runtime/releases.html) can be retrieved by using the Runtime Versions API call or `databricks clusters spark-versions` CLI command. It is advised to use [Cluster Policies](cluster_policy.md) to restrict list of versions for simplicity, while maintaining enough of control.
 * `driver_node_type_id` - (Optional) The node type of the Spark driver. This field is optional; if unset, the driver node type will be set as the same value as node_type_id defined above.
-* `node_type_id` - (Required - optional if `instance_pool_id` is given) This field encodes, through a single value, the resources available to each of the Spark nodes in this cluster. For example, the Spark nodes can be provisioned and optimized for memory or compute intensive workloads A list of available node types can be retrieved by using the List Node Types API call. If `instance_pool_id` is specified, this field is not needed.
+* `node_type_id` - (Required - optional if `instance_pool_id` is given) Any supported [databricks_node_type](../data-sources/node_type.md) id. If `instance_pool_id` is specified, this field is not needed. 
 * `instance_pool_id` (Optional - required if `node_type_id` is not given) - To reduce cluster start time, you can attach a cluster to a [predefined pool of idle instances](instance_pool.md). When attached to a pool, a cluster allocates its driver and worker nodes from the pool. If the pool does not have sufficient idle resources to accommodate the cluster’s request, the pool expands by allocating new instances from the instance provider. When an attached cluster is terminated, the instances it used are returned to the pool and can be reused by a different cluster.
 * `policy_id` - (Optional) Idendifier of [Custer Policy](cluster_policy.md) to validate cluster and preset certail defaults. Cluster policy has bigger use when allowing users to create clusters, rather than automatically created one. Essentially, you can put all cluster configuration options into it.
 * `autotermination_minutes` - (Optional) Automatically terminates the cluster after it is inactive for this time in minutes. If not set, this cluster will not be automatically terminated. If specified, the threshold must be between 10 and 10000 minutes. You can also set this value to 0 to explicitly 
@@ -37,19 +41,23 @@ disable automatic termination. _It is highly recommended to have this setting pr
 The following example demonstrates how to create an autoscaling cluster with [Delta Cache](https://docs.databricks.com/delta/optimizations/delta-cache.html) enabled:
 
 ```hcl
+data "databricks_node_type" "smallest" {
+  local_disk = true
+}
+
 resource "databricks_cluster" "shared_autoscaling" {
   cluster_name            = "Shared Autoscaling"
   spark_version           = "6.6.x-scala2.11"
-  node_type_id            = "i3.xlarge"
+  node_type_id            = databricks_node_type.smallest.id
   autotermination_minutes = 20
   autoscale {
-      min_workers = 1
-      max_workers = 50
+    min_workers = 1
+    max_workers = 50
   }
   spark_conf {
-      "spark.databricks.io.cache.enabled": true,
-      "spark.databricks.io.cache.maxDiskUsage": "50g",
-      "spark.databricks.io.cache.maxMetaDataCache": "1g"
+    "spark.databricks.io.cache.enabled": true,
+    "spark.databricks.io.cache.maxDiskUsage": "50g",
+    "spark.databricks.io.cache.maxMetaDataCache": "1g"
   }
 }
 ```

--- a/docs/resources/instance_pool.md
+++ b/docs/resources/instance_pool.md
@@ -7,11 +7,14 @@ This resource allows you to manage instance pools on Databricks. An instance poo
 ## Example Usage
 
 ```hcl
-resource "databricks_instance_pool" "my-pool" {
-  instance_pool_name = "reserved-i3.xlarge-pool"
+data "databricks_node_type" "smallest" {
+}
+
+resource "databricks_instance_pool" "smallest_nodes" {
+  instance_pool_name = "Smallest Nodes"
   min_idle_instances = 0
   max_capacity       = 300
-  node_type_id       = "i3.xlarge"
+  node_type_id       = databricks_node_type.smallest.id
   aws_attributes {
     availability = "ON_DEMAND"
     zone_id = "us-east-1a"

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -5,6 +5,10 @@ The databricks_job resource allows you to create, edit, and delete jobs, which r
 ## Example Usage
 
 ```hcl
+data "databricks_node_type" "smallest" {
+    local_disk = true
+}
+
 resource "databricks_job" "this" {
     name = "Featurization"
     timeout_seconds = 3600
@@ -14,7 +18,7 @@ resource "databricks_job" "this" {
     new_cluster  {
         num_workers   = 300
         spark_version = "6.6.x-scala2.11"
-        node_type_id  = "i3.xlarge"
+        node_type_id  = databricks_node_type.smallest.id
     }
     
     notebook_task {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -29,6 +29,7 @@ func DatabricksProvider() *schema.Provider {
 			"databricks_dbfs_file_paths":         storage.DataSourceDBFSFilePaths(),
 			"databricks_default_user_roles":      identity.DataSourceDefaultUserRoles(),
 			"databricks_group":                   identity.DataSourceGroup(),
+			"databricks_node_type":               compute.DataSourceNodeType(),
 			"databricks_notebook":                workspace.DataSourceNotebook(),
 			"databricks_notebook_paths":          workspace.DataSourceNotebookPaths(),
 			"databricks_zones":                   compute.DataSourceClusterZones(),

--- a/storage/aws_s3_mount.go
+++ b/storage/aws_s3_mount.go
@@ -123,10 +123,12 @@ func getOrCreateMountingClusterWithInstanceProfile(clustersAPI compute.ClustersA
 	}
 	clusterName := fmt.Sprintf("terraform-mount-%s", instanceProfileParts[1])
 	return clustersAPI.GetOrCreateRunningCluster(clusterName, compute.Cluster{
-		NumWorkers:             1,
-		ClusterName:            clusterName,
-		SparkVersion:           compute.CommonRuntimeVersion(),
-		NodeTypeID:             clustersAPI.GetSmallestNodeTypeWithStorage(),
+		NumWorkers:   1,
+		ClusterName:  clusterName,
+		SparkVersion: compute.CommonRuntimeVersion(),
+		NodeTypeID: clustersAPI.GetSmallestNodeType(compute.NodeTypeRequest{
+			LocalDisk: true,
+		}),
 		AutoterminationMinutes: 10,
 		AwsAttributes: &compute.AwsAttributes{
 			InstanceProfileArn: instanceProfile,


### PR DESCRIPTION
Implements issue #346 to help customers pick node types easier:

```hcl
data "databricks_node_type" "with_gpu" {
    local_disk  = true
    min_cores   = 16
    gb_per_core = 1
    min_gpus    = 1
}
resource "databricks_cluster" "research" {
    cluster_name            = "Research Cluster"
    spark_version           = "6.6.x-scala2.11"
    node_type_id            = databricks_node_type.with_gpu.id
    autotermination_minutes = 20
    autoscale {
        min_workers = 1
        max_workers = 50
    }
}
```