### PR TITLE
Allow to specify max items to return in the Cluster Events API call (issue #380)

### DIFF
--- a/compute/model.go
+++ b/compute/model.go
@@ -594,6 +594,7 @@ type EventsRequest struct {
 	EventTypes []ClusterEventType `json:"event_types,omitempty"`
 	Offset     int64              `json:"offset,omitempty"`
 	Limit      int64              `json:"limit,omitempty"`
+	MaxItems   uint               `json:"-"`
 }
 
 // ClusterSize is structure to keep

--- a/compute/resource_cluster.go
+++ b/compute/resource_cluster.go
@@ -190,6 +190,7 @@ func setPinnedStatus(d *schema.ResourceData, clusterAPI ClustersAPI) error {
 		Limit:      1,
 		Order:      SortDescending,
 		EventTypes: []ClusterEventType{EvTypePinned, EvTypeUnpinned},
+		MaxItems:   1,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Right now, Cluster Events API doesn't allow to specify maximal number of items to fetch -
the existing `limit` parameter specifies the number of the items per page, not max count,
so this limit should enforced on the caller's site.

this fixes #380