### PR TITLE
Don't restart cluster on changes that doesn't affect it (issue #379)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version changelog
 
+## 0.2.9
+
+* Fixed restarting cluster on changes in cluster configuration aren't related to the cluster configuration ([issue #379](https://github.com/databrickslabs/terraform-provider-databricks/issues/379))
+
 ## 0.2.8
 
 * Added [databricks_workspace_conf](https://github.com/databrickslabs/terraform-provider-databricks/pull/398) resource

--- a/compute/resource_cluster.go
+++ b/compute/resource_cluster.go
@@ -13,6 +13,7 @@ import (
 
 var clusterSchema = resourceClusterSchema()
 
+// ResourceCluster - returns Cluster resource description
 func ResourceCluster() *schema.Resource {
 	return &schema.Resource{
 		SchemaVersion: 2,
@@ -282,6 +283,19 @@ func legacyReadLibraryListFromData(d *schema.ResourceData) (cll ClusterLibraryLi
 	return
 }
 
+func hasClusterConfigChanged(d *schema.ResourceData) bool {
+	for k := range clusterSchema {
+		// TODO: create a map if we'll add more non-cluster config parameters in the future
+		if k == "library" || k == "is_pinned" {
+			continue
+		}
+		if d.HasChange(k) {
+			return true
+		}
+	}
+	return false
+}
+
 func resourceClusterUpdate(d *schema.ResourceData, m interface{}) error {
 	client := m.(*common.DatabricksClient)
 	clusters := NewClustersAPI(client)
@@ -291,18 +305,27 @@ func resourceClusterUpdate(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	modifyClusterRequest(&cluster)
-	clusterInfo, err := clusters.Edit(cluster)
-	if err != nil {
-		return err
+	var clusterInfo ClusterInfo
+	if hasClusterConfigChanged(d) {
+		log.Printf("[DEBUG] Cluster state has changed!")
+		modifyClusterRequest(&cluster)
+		clusterInfo, err = clusters.Edit(cluster)
+		if err != nil {
+			return err
+		}
+	} else {
+		clusterInfo, err = clusters.Get(clusterID)
+		if err != nil {
+			return err
+		}
 	}
 	oldPinned, newPinned := d.GetChange("is_pinned")
 	if oldPinned.(bool) != newPinned.(bool) {
 		log.Printf("[DEBUG] Update: is_pinned. Old: %v, New: %v", oldPinned, newPinned)
 		if newPinned.(bool) {
-			err = clusters.Pin(clusterInfo.ClusterID)
+			err = clusters.Pin(clusterID)
 		} else {
-			err = clusters.Unpin(clusterInfo.ClusterID)
+			err = clusters.Unpin(clusterID)
 		}
 		if err != nil {
 			return err

--- a/compute/resource_cluster_test.go
+++ b/compute/resource_cluster_test.go
@@ -827,18 +827,6 @@ func TestResourceClusterUpdateWithPinned(t *testing.T) {
 				},
 			},
 			{
-				Method:   "POST",
-				Resource: "/api/2.0/clusters/edit",
-				ExpectedRequest: Cluster{
-					AutoterminationMinutes: 15,
-					ClusterID:              "abc",
-					NumWorkers:             100,
-					ClusterName:            "Shared Autoscaling",
-					SparkVersion:           "7.1-scala12",
-					NodeTypeID:             "i3.xlarge",
-				},
-			},
-			{
 				Method:          "POST",
 				Resource:        "/api/2.0/clusters/pin",
 				ExpectedRequest: ClusterID{ClusterID: "abc"},
@@ -854,6 +842,13 @@ func TestResourceClusterUpdateWithPinned(t *testing.T) {
 		ID:       "abc",
 		Update:   true,
 		Resource: ResourceCluster(),
+		InstanceState: map[string]string{
+			"autotermination_minutes": "15",
+			"cluster_name":            "Shared Autoscaling",
+			"spark_version":           "7.1-scala12",
+			"node_type_id":            "i3.xlarge",
+			"num_workers":             "100",
+		},
 		State: map[string]interface{}{
 			"autotermination_minutes": 15,
 			"cluster_name":            "Shared Autoscaling",


### PR DESCRIPTION
This PR adds detection of what cluster parameters were changed, and call `/clusters/edit`
only we changed parameters that are related to cluster directly, not things like
`is_pinned` or `library`...

This fixes #379