### PR TITLE
Bump version to 0.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
 * `error_messages` from `databricks_mws_networks` are deprecated and would be removed in 0.3.
 * `ebs_volume_type` and `azure_disk_volume_type` from `databricks_instance_pool` is going to be moved to `disk_type` sub-block in 0.3, which means you'll slightly have to modify configuration while migrating to 0.3. Computed field `default_tags` is going to be removed from resource. This is done to further increase maintainability of provider in the future.
 
+Updated dependency versions:
+
+* github.com/aws/aws-sdk-go 35.36
+* github.com/hashicorp/go-retryablehttp 0.6.8
+* github.com/Azure/go-autorest/autorest 0.11.12
+
 **Behavior changes**
 * `min_idle_instances` for `databricks_instance_pool` is now optional.
 * `skip_validation` for `databricks_instance_profile` is going to be removed in 0.3.

--- a/Makefile
+++ b/Makefile
@@ -45,23 +45,23 @@ vendor:
 	@echo "✓ Filling vendor folder with library code..."
 	@go mod vendor
 
-test-azcli:
+test-azcli: install
 	@echo "✓ Running Terraform Acceptance Tests for Azure..."
 	@/bin/bash scripts/run.sh azcli '^(TestAcc|TestAzureAcc)' --debug --tee
 
-test-azsp:
+test-azsp: install
 	@echo "✓ Running Terraform Acceptance Tests for Azure..."
 	@/bin/bash scripts/run.sh azsp '^(TestAcc|TestAzureAcc)' --debug --tee
 
-test-mws:
+test-mws: install
 	@echo "✓ Running acceptance Tests for Multiple Workspace APIs on AWS..."
 	@/bin/bash scripts/run.sh mws '^TestMwsAcc' --debug --tee
 
-test-awsst:
+test-awsst: install
 	@echo "✓ Running Terraform Acceptance Tests for AWS ST..."
 	@/bin/bash scripts/run.sh awsst '^(TestAcc|TestAwsAcc)' --debug --tee
 
-test-awsmt:
+test-awsmt: install
 	@echo "✓ Running Terraform Acceptance Tests for AWS MT..."
 	@/bin/bash scripts/run.sh awsmt '^(TestAcc|TestAwsAcc)' --debug --tee
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ coverage: test
 	@echo "✓ Opening coverage for unit tests..."
 	@go tool cover -html=coverage.txt
 
-VERSION = $(shell git describe --long --always | sed 's/v//')
+VERSION = 0.2.9
 
 build:
 	@echo "✓ Building source code with go build..."

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ terraform {
   required_providers {
     databricks = {
       source = "databrickslabs/databricks"
-      version = ">= 0.2.7"
+      version = "0.2.9"
     }
   }
 }

--- a/common/version.go
+++ b/common/version.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	version = "0.2.8"
+	version = "0.2.9"
 )
 
 // Version returns version of provider


### PR DESCRIPTION
awsmt
---
 * [x] TestAccWorkspaceConfFullLifecycle (61.02s)
 * [x] TestAwsAccS3IamMount_NoClusterGiven (630.00s)
 * [x] TestAwsAccS3Mount (2.03s)
 * [x] access.TestAccPermissionsClusterPolicy (10.41s)
 * [x] access.TestAccPermissionsClusters (161.19s)
 * [x] access.TestAccPermissionsInstancePool (10.22s)
 * [x] access.TestAccPermissionsJobs (12.31s)
 * [x] access.TestAccPermissionsNotebooks (12.24s)
 * [x] access.TestAccPermissionsTokens (11.16s)
 * [x] access/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (236.18s)
 * [x] access/acceptance.TestAccInitialManagePrincipals (1.92s)
 * [x] access/acceptance.TestAccInitialManagePrincipalsGroup (0.82s)
 * [x] access/acceptance.TestAccSecretAclResource (90.77s)
 * [x] access/acceptance.TestAccSecretAclResourceDefaultPrincipal (83.85s)
 * [x] access/acceptance.TestAccSecretResource (219.63s)
 * [x] access/acceptance.TestAccSecretScopeResource (178.62s)
 * [x] compute.TestAccContext (169.29s)
 * [x] compute.TestAccInstancePools (2.35s)
 * [x] compute.TestAccLibraryCreate (71.64s)
 * [x] compute.TestAccListClustersIntegration (62.40s)
 * [x] compute.TestAwsAccJobsCreate (1.43s)
 * [x] compute.TestAwsAccSmallestNodeType (0.24s)
 * [x] compute/acceptance.TestAccClusterPolicyResourceFullLifecycle (217.83s)
 * [x] compute/acceptance.TestAccClusterResource_CreateClusterWithLibraries (274.96s)
 * [x] compute/acceptance.TestAccJobResource (52.92s)
 * [x] compute/acceptance.TestAwsAccClusterResource_CreateClusterViaInstancePool (468.39s)
 * [x] compute/acceptance.TestAwsAccClusterResource_ValidatePlan (92.09s)
 * [x] compute/acceptance.TestAwsAccJobResource_NoInstancePool (52.58s)
 * [x] identity.TestAccCreateAdminUser (8.36s)
 * [x] identity.TestAccCreateRUserNonAdmin (2.67s)
 * [x] identity.TestAccCreateToken (0.90s)
 * [x] identity.TestAccCreateUser (4.70s)
 * [x] identity.TestAccFilterGroup (1.03s)
 * [x] identity.TestAccGetAdminGroup (1.12s)
 * [x] identity.TestAccGroup (11.38s)
 * [x] identity.TestAccReadUser (1.36s)
 * [x] identity.TestAccRoleDifferences (2.66s)
 * [x] identity.TestAwsAccInstanceProfiles (2.34s)
 * [x] identity.TestAwsAccReadInheritedRolesFromGroup (14.42s)
 * [x] identity/acceptance.TestAccGroupMemberResource (199.53s)
 * [x] identity/acceptance.TestAccGroupResource (228.04s)
 * [x] identity/acceptance.TestAccGroupResource_verify_entitlements (146.30s)
 * [x] identity/acceptance.TestAccScimGroupResource (292.42s)
 * [x] identity/acceptance.TestAccScimUserResource (315.76s)
 * [x] identity/acceptance.TestAccTokenResource (57.08s)
 * [x] identity/acceptance.TestAccUserResource (63.27s)
 * [x] identity/acceptance.TestAwsAccGroupInstanceProfileResource (210.02s)
 * [x] identity/acceptance.TestAwsAccInstanceProfileResource (198.49s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace (6.37s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies (0.57s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies_Delete (0.56s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Clusters (0.52s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/DBFS_Files (1.01s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Groups (0.44s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Instance_Pools (0.36s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Instance_Profiles (0.36s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Jobs (0.36s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Notebooks (0.55s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_ACLs (0.37s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_Scopes (0.12s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secrets (0.13s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Tokens (0.64s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Users (0.37s)
 * [x] internal/sanity.TestAccMutiworkspaceUsedFromNormalMode (1.83s)
 * [x] storage.TestAccCreateFile (6.35s)
 * [x] storage.TestAccDeleteInvalidMountFails (122.14s)
 * [x] storage.TestAccInvalidSecretScopeFails (9.13s)
 * [x] storage.TestAccSourceOnInvalidMountFails (36.81s)
 * [x] storage/acceptance.TestAwsAccS3IamMount_WithCluster (472.53s)
 * [x] workspace/acceptance.TestAccNotebookResourceMultipleFormats (300.85s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (168.50s)
