### PR TITLE
Fix error with creation of keyvault-based scope

### DIFF
--- a/access/resource_secret_scope.go
+++ b/access/resource_secret_scope.go
@@ -57,6 +57,9 @@ func (a SecretScopesAPI) Create(s SecretScope) error {
 		BackendType:            "DATABRICKS",
 	}
 	if s.KeyvaultMetadata != nil {
+		if err := a.client.Authenticate(); err != nil {
+			return err
+		}
 		if !a.client.IsAzure() {
 			return fmt.Errorf("Azure KeyVault is not available")
 		}


### PR DESCRIPTION
This problem was caused by the lazy initialization of the terraform provider - the call to
`IsAzure()` didn't recognize Azure because no HTTP call was made yet, and as result - no
authentication information was loaded.

It was easy reproducible with following:

```hcl
data "azurerm_key_vault" "example" {
  name                = "some-kv"
  resource_group_name = "some-rg"
}
resource "databricks_secret_scope" "example" {
  name = data.azurerm_key_vault.example.name
  keyvault_metadata {
    resource_id = data.azurerm_key_vault.example.id
    dns_name    = data.azurerm_key_vault.example.vault_uri
  }
}
```