### PR TITLE
Data source for supported DBR/Spark versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * `databricks_notebook` can have `language` field optional, as long as `source` is set to a file with `.py`, `.scala`, `.sql`, or `.r` extension.
 * `databricks_me` data source was added to represent `user_name`, `home` & `id` of the caller user (or service principal).
 * Added validation for secret scope name in `databricks_secret`, `databricks_secret_scope` and `databricks_secret_acl`. Non-compliant names may cause errors.
+* Added [databricks_spark_version](https://github.com/databrickslabs/terraform-provider-databricks/issues/347) data source.
 
 **Behavior changes**
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ End-to-end workspace creation on [AWS](scripts/awsmt-integration) or [Azure](scr
 | [databricks_secret](docs/resources/secret.md)
 | [databricks_secret_acl](docs/resources/secret_acl.md)
 | [databricks_secret_scope](docs/resources/secret_scope.md)
+| [databricks_spark_version](docs/data-sources/spark_version.md) data
 | [databricks_token](docs/resources/token.md)
 | [databricks_user](docs/resources/user.md)
 | [databricks_user_instance_profile](docs/resources/user_instance_profile.md)
@@ -78,9 +79,13 @@ data "databricks_node_type" "smallest" {
   local_disk = true
 }
 
+data "databricks_spark_version" "latest_lts" {
+  long_term_support = true
+}
+
 resource "databricks_cluster" "shared_autoscaling" {
   cluster_name            = "Shared Autoscaling"
-  spark_version           = "6.6.x-scala2.11"
+  spark_version           = data.databricks_spark_version.latest_lts.id
   node_type_id            = data.databricks_node_type.smallest.id
   autotermination_minutes = 20
 

--- a/compute/data_spark_version.go
+++ b/compute/data_spark_version.go
@@ -1,0 +1,34 @@
+package compute
+
+import (
+	"context"
+
+	"github.com/databrickslabs/databricks-terraform/internal"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// DataSourceSparkVersion returns DBR version matching to the specification
+func DataSourceSparkVersion() *schema.Resource {
+	s := internal.StructToSchema(SparkVersionRequest{}, func(
+		s map[string]*schema.Schema) map[string]*schema.Schema {
+		return s
+	})
+
+	return &schema.Resource{
+		Schema: s,
+		ReadContext: func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+			var this SparkVersionRequest
+			err := internal.DataToStructPointer(d, s, &this)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			version, err := NewClustersAPI(ctx, m).LatestSparkVersion(this)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			d.SetId(version)
+			return nil
+		},
+	}
+}

--- a/compute/data_spark_version_test.go
+++ b/compute/data_spark_version_test.go
@@ -1,0 +1,196 @@
+package compute
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/databrickslabs/databricks-terraform/internal/qa"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func commonFixtures() []qa.HTTPFixture {
+	return []qa.HTTPFixture{
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/clusters/spark-versions",
+			Response: SparkVersionsList{
+				SparkVersions: []SparkVersion{
+					{
+						Version:     "7.1.x-scala2.12",
+						Description: "7.1 (includes Apache Spark 3.0.0, Scala 2.12)",
+					},
+					{
+						Version:     "7.1.x-gpu-ml-scala2.12",
+						Description: "7.1 ML (includes Apache Spark 3.0.0, Scala 2.12)",
+					},
+					{
+						Version:     "apache-spark-2.4.x-scala2.11",
+						Description: "Light 2.4 (includes Apache Spark 2.4, Scala 2.11)",
+					},
+					{
+						Version:     "7.3.x-hls-scala2.12",
+						Description: "7.3 LTS Genomics (includes Apache Spark 3.0.1, Scala 2.12)",
+					},
+					{
+						Version:     "6.4.x-scala2.11",
+						Description: "6.4 (includes Apache Spark 2.4.5, Scala 2.11)",
+					},
+					{
+						Version:     "7.3.x-scala2.12",
+						Description: "7.3 LTS (includes Apache Spark 3.0.1, Scala 2.12)",
+					},
+					{
+						Version:     "7.4.x-scala2.12",
+						Description: "7.4 (includes Apache Spark 3.0.1, Scala 2.12)",
+					},
+					{
+						Version:     "7.5.x-scala2.12",
+						Description: "7.5 Beta (includes Apache Spark 3.0.1, Scala 2.12)",
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestSparkVersionLatest(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures:    commonFixtures(),
+		Read:        true,
+		Resource:    DataSourceSparkVersion(),
+		NonWritable: true,
+		State:       map[string]interface{}{},
+		ID:          ".",
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, "7.4.x-scala2.12", d.Id())
+}
+
+func TestSparkVersionLTS(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures:    commonFixtures(),
+		Read:        true,
+		Resource:    DataSourceSparkVersion(),
+		NonWritable: true,
+		State: map[string]interface{}{
+			"long_term_support": true,
+		},
+		ID: ".",
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, "7.3.x-scala2.12", d.Id())
+}
+
+func TestSparkVersionGpuMl(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures:    commonFixtures(),
+		Read:        true,
+		Resource:    DataSourceSparkVersion(),
+		NonWritable: true,
+		State: map[string]interface{}{
+			"gpu": true,
+			"ml":  true,
+		},
+		ID: ".",
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, "7.1.x-gpu-ml-scala2.12", d.Id())
+}
+
+func TestSparkVersionGenomics(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures:    commonFixtures(),
+		Read:        true,
+		Resource:    DataSourceSparkVersion(),
+		NonWritable: true,
+		State: map[string]interface{}{
+			"genomics": true,
+		},
+		ID: ".",
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, "7.3.x-hls-scala2.12", d.Id())
+}
+
+func TestSparkVersion300(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures:    commonFixtures(),
+		Read:        true,
+		Resource:    DataSourceSparkVersion(),
+		NonWritable: true,
+		State: map[string]interface{}{
+			"spark_version": "3.0.0",
+		},
+		ID: ".",
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, "7.1.x-scala2.12", d.Id())
+}
+
+func TestSparkVersionBeta(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures:    commonFixtures(),
+		Read:        true,
+		Resource:    DataSourceSparkVersion(),
+		NonWritable: true,
+		State: map[string]interface{}{
+			"beta": true,
+		},
+		ID: ".",
+	}.Apply(t)
+	assert.NoError(t, err)
+	assert.Equal(t, "7.5.x-scala2.12", d.Id())
+}
+
+func TestSparkVersionErrorNoResults(t *testing.T) {
+	_, err := qa.ResourceFixture{
+		Fixtures:    commonFixtures(),
+		Read:        true,
+		Resource:    DataSourceSparkVersion(),
+		NonWritable: true,
+		State: map[string]interface{}{
+			"beta":              true,
+			"long_term_support": true,
+		},
+		ID: ".",
+	}.Apply(t)
+	assert.Error(t, err)
+	assert.Equal(t, true, strings.Contains(err.Error(), "query returned no results"))
+}
+
+func TestSparkVersionErrorMultipleResults(t *testing.T) {
+	_, err := qa.ResourceFixture{
+		Fixtures:    commonFixtures(),
+		Read:        true,
+		Resource:    DataSourceSparkVersion(),
+		NonWritable: true,
+		State: map[string]interface{}{
+			"latest": false,
+		},
+		ID: ".",
+	}.Apply(t)
+	assert.Error(t, err)
+	assert.Equal(t, true, strings.Contains(err.Error(), "query returned multiple results"))
+}
+
+func TestSparkVersionErrorBadAnswer(t *testing.T) {
+	_, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/clusters/spark-versions",
+				Response: "{garbage....",
+			},
+		},
+		Read:        true,
+		Resource:    DataSourceSparkVersion(),
+		NonWritable: true,
+		State: map[string]interface{}{
+			"latest": false,
+		},
+		ID: ".",
+	}.Apply(t)
+	assert.Error(t, err)
+	require.Equal(t, true, strings.Contains(err.Error(), "Invalid JSON received"))
+}

--- a/compute/model.go
+++ b/compute/model.go
@@ -638,3 +638,27 @@ type EventsResponse struct {
 	NextPage   *EventsRequest `json:"next_page"`
 	TotalCount int64          `json:"total_count"`
 }
+
+// SparkVersion - contains information about specific version
+type SparkVersion struct {
+	Version     string `json:"key"`
+	Description string `json:"name"`
+}
+
+// SparkVersionsList - returns a list of all currently supported Spark Versions
+// https://docs.databricks.com/dev-tools/api/latest/clusters.html#runtime-versions
+type SparkVersionsList struct {
+	SparkVersions []SparkVersion `json:"versions"`
+}
+
+// SparkVersionRequest - filtering request
+type SparkVersionRequest struct {
+	LongTermSupport bool   `json:"long_term_support,omitempty" tf:"optional,default:false"`
+	Beta            bool   `json:"beta,omitempty" tf:"optional,default:false,conflicts:long_term_support"`
+	Latest          bool   `json:"latest,omitempty" tf:"optional,default:true"`
+	ML              bool   `json:"ml,omitempty" tf:"optional,default:false"`
+	Genomics        bool   `json:"genomics,omitempty" tf:"optional,default:false"`
+	GPU             bool   `json:"gpu,omitempty" tf:"optional,default:false"`
+	Scala           string `json:"scala,omitempty" tf:"optional,default:2.12"`
+	SparkVersion    string `json:"spark_version,omitempty" tf:"optional,default:"`
+}

--- a/docs/data-sources/node_type.md
+++ b/docs/data-sources/node_type.md
@@ -2,7 +2,7 @@
 
 Gets the smallest node type for [databricks_cluster](../resources/cluster.md) that fits search criteria, like amount of RAM or number of cores. [AWS](https://databricks.com/product/aws-pricing/instance-types) or [Azure](https://azure.microsoft.com/en-us/pricing/details/databricks/). Internally data source fetches [node types](https://docs.databricks.com/dev-tools/api/latest/clusters.html#list-node-types) available per cloud, similar to executing `databricks clusters list-node-types`, and filters it to return the smallest possible node with criteria.
 
--> **Note** This is experimental functionality, which aims to simplify things. In case of wrong parameters given (e.g. min_gpus = 876) or no nodes matching, data source will return cloud-default node type, even though it doesn't match search criteria specified by data source arguments: [i3.xlarge](https://aws.amazon.com/ec2/instance-types/i3/) for AWS or [Standard_D3_v2](https://docs.microsoft.com/en-us/azure/cloud-services/cloud-services-sizes-specs#dv2-series) for Azure.
+-> **Note** This is experimental functionality, which aims to simplify things. In case of wrong parameters given (e.g. `min_gpus = 876`) or no nodes matching, data source will return cloud-default node type, even though it doesn't match search criteria specified by data source arguments: [i3.xlarge](https://aws.amazon.com/ec2/instance-types/i3/) for AWS or [Standard_D3_v2](https://docs.microsoft.com/en-us/azure/cloud-services/cloud-services-sizes-specs#dv2-series) for Azure.
 
 ## Example Usage
 
@@ -14,10 +14,15 @@ data "databricks_node_type" "with_gpu" {
     min_gpus    = 1
 }
 
+data "databricks_spark_version" "gpu_ml" {
+  gpu = true
+  ml = true
+}
+
 resource "databricks_cluster" "research" {
     cluster_name            = "Research Cluster"
-    spark_version           = "6.6.x-scala2.11"
-    node_type_id            = databricks_node_type.with_gpu.id
+    spark_version           = data.databricks_spark_version.gpu_ml.id
+    node_type_id            = data.databricks_node_type.with_gpu.id
     autotermination_minutes = 20
     autoscale {
         min_workers = 1

--- a/docs/data-sources/spark_version.md
+++ b/docs/data-sources/spark_version.md
@@ -1,0 +1,51 @@
+# databricks_spark_version Data Source
+
+Gets Databricks Runtime (DBR) version that could be used for `spark_version` parameter in [databricks_cluster](../resources/cluster.md) and other resources that fits search criteria, like specific Spark or Scala version, ML or Genomics runtime, etc., similar to executing `databricks clusters spark-versions`, and filters it to return the latest version that matches criteria.
+
+-> **Note** This is experimental functionality, which aims to simplify things. In case of wrong parameters given (e.g. together `ml = true` and `genomics = true`, or something like), data source will throw an error.  Similarly, if search returns multiple results, and `latest = false`, data source will throw an error.
+
+## Example Usage
+
+```hcl
+data "databricks_node_type" "with_gpu" {
+    local_disk  = true
+    min_cores   = 16
+    gb_per_core = 1
+    min_gpus    = 1
+}
+
+data "databricks_spark_version" "gpu_ml" {
+  gpu = true
+  ml = true
+}
+
+resource "databricks_cluster" "research" {
+    cluster_name            = "Research Cluster"
+    spark_version           = data.databricks_spark_version.gpu_ml.id
+    node_type_id            = data.databricks_node_type.with_gpu.id
+    autotermination_minutes = 20
+    autoscale {
+        min_workers = 1
+        max_workers = 50
+    }
+}
+```
+
+## Argument Reference
+
+Data source allows you to pick groups by the following attributes:
+
+* `latest` - (boolean, optional) if we should return only the latest version if there is more than one result.  Default to `true`. If set to `false` and multiple versions are matching, throws an error
+* `long_term_support` - (boolean, optional) if we should limit the search only to LTS (long term support) versions. Default to `false`
+* `ml` - (boolean, optional) if we should limit the search only to ML runtimes. Default to `false`
+* `genomics` - (boolean, optional)  if we should limit the search only to Genomics (HLS) runtimes. Default to `false`
+* `gpu` - (boolean, optional)  if we should limit the search only to runtimes that support GPUs. Default to `false`
+* `beta` - (boolean, optional) if we should limit the search only to runtimes that are in Beta stage. Default to `false`
+* `scala` - (boolean, optional) if we should limit the search only to runtimes that are based on specific Scala version. Default to `2.12`
+* `spark_version` - (boolean, optional) if we should limit the search only to runtimes that are based on specific Spark version. Default to empty string.  It could be specified as `3`, or `3.0`, or full version, like, `3.0.1`
+
+## Attribute Reference
+
+Data source exposes the following attributes:
+
+* `id` - Databricks Runtime version, that can be used as `spark_version` field in [databricks_job](../resources/job.md), [databricks_cluster](../resources/cluster.md), or [databricks_instance_pool](../resources/instance_pool.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,9 +51,13 @@ data "databricks_node_type" "smallest" {
   local_disk = true
 }
 
+data "databricks_spark_version" "latest_lts" {
+  long_term_support = true
+}
+
 resource "databricks_cluster" "shared_autoscaling" {
   cluster_name            = "Shared Autoscaling"
-  spark_version           = "6.6.x-scala2.11"
+  spark_version           = data.databricks_spark_version.latest_lts.id
   node_type_id            = data.databricks_node_type.smallest.id
   autotermination_minutes = 20
 

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -7,9 +7,13 @@ data "databricks_node_type" "smallest" {
   local_disk = true
 }
 
+data "databricks_spark_version" "latest_lts" {
+  long_term_support = true
+}
+
 resource "databricks_cluster" "shared_autoscaling" {
   cluster_name            = "Shared Autoscaling"
-  spark_version           = "6.6.x-scala2.11"
+  spark_version           = data.databricks_spark_version.latest_lts.id
   node_type_id            = data.databricks_node_type.smallest.id
   autotermination_minutes = 20
   autoscale {
@@ -22,7 +26,7 @@ resource "databricks_cluster" "shared_autoscaling" {
 ## Argument Reference
 
 * `cluster_name` - (Optional) Cluster name, which doesn’t have to be unique. If not specified at creation, the cluster name will be an empty string.
-* `spark_version` - (Required) [Runtime version](https://docs.databricks.com/runtime/index.html) of the cluster. You can retrieve [list of available Spark versions](https://docs.databricks.com/release-notes/runtime/releases.html) by using the Runtime Versions API call or `databricks clusters spark-versions` CLI command. We advise using [Cluster Policies](cluster_policy.md) to restrict the list of versions for simplicity while maintaining enough control.
+* `spark_version` - (Required) [Runtime version](https://docs.databricks.com/runtime/index.html) of the cluster. Any supported [databricks_spark_version](../data-sources/spark_version.md) id.  We advise using [Cluster Policies](cluster_policy.md) to restrict the list of versions for simplicity while maintaining enough control.
 * `driver_node_type_id` - (Optional) The node type of the Spark driver. This field is optional; if unset, API will set the driver node type to the same value as `node_type_id` defined above.
 * `node_type_id` - (Required - optional if `instance_pool_id` is given) Any supported [databricks_node_type](../data-sources/node_type.md) id. If `instance_pool_id` is specified, this field is not needed.
 * `instance_pool_id` (Optional - required if `node_type_id` is not given) - To reduce cluster start time, you can attach a cluster to a [predefined pool of idle instances](instance_pool.md). When attached to a pool, a cluster allocates its driver and worker nodes from the pool. If the pool does not have sufficient idle resources to accommodate the cluster’s request, it expands by allocating new instances from the instance provider. When an attached cluster changes its state to `TERMINATED`, the instances it used are returned to the pool and reused by a different cluster.
@@ -45,9 +49,13 @@ data "databricks_node_type" "smallest" {
   local_disk = true
 }
 
+data "databricks_spark_version" "latest_lts" {
+  long_term_support = true
+}
+
 resource "databricks_cluster" "shared_autoscaling" {
   cluster_name            = "Shared Autoscaling"
-  spark_version           = "6.6.x-scala2.11"
+  spark_version           = data.databricks_spark_version.latest_lts.id
   node_type_id            = data.databricks_node_type.smallest.id
   autotermination_minutes = 20
   autoscale {

--- a/docs/resources/instance_pool.md
+++ b/docs/resources/instance_pool.md
@@ -43,7 +43,7 @@ The following arguments are required:
 * `custom_tags` - (Optional) (Map) Additional tags for instance pool resources. Databricks tags all pool resources (e.g. AWS & Azure instances and Disk volumes) with these tags in addition to default_tags. *Databricks allows at most 43 custom tags.*
 * `enable_elastic_disk` - (Optional) (Bool) Autoscaling Local Storage: when enabled, the instances in the pool dynamically acquire additional disk space when they are running low on disk space.
 
-* `preloaded_spark_versions` - (Optional) (List) A list with the runtime version the pool installs on each instance. Pool clusters that use a preloaded runtime version start faster as they do have to wait for the image to download. You can retrieve a list of available runtime versions by using the [Runtime Versions API](https://docs.databricks.com/dev-tools/api/latest/clusters.html#clusterclusterservicelistsparkversions) call.
+* `preloaded_spark_versions` - (Optional) (List) A list with the runtime version the pool installs on each instance. Pool clusters that use a preloaded runtime version start faster as they do have to wait for the image to download.  You can retrieve them via [databricks_spark_version](../data-source/spark-version.md) data source or via  [Runtime Versions API](https://docs.databricks.com/dev-tools/api/latest/clusters.html#clusterclusterservicelistsparkversions) call.
 
 ### aws_attributes Configuration Block
 

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -9,6 +9,10 @@ data "databricks_node_type" "smallest" {
     local_disk = true
 }
 
+data "databricks_spark_version" "latest_lts" {
+  long_term_support = true
+}
+
 resource "databricks_job" "this" {
     name = "Featurization"
     timeout_seconds = 3600
@@ -17,7 +21,7 @@ resource "databricks_job" "this" {
     
     new_cluster  {
         num_workers   = 300
-        spark_version = "6.6.x-scala2.11"
+        spark_version = data.databricks_spark_version.latest_lts.id
         node_type_id  = data.databricks_node_type.smallest.id
     }
     

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -32,6 +32,7 @@ func DatabricksProvider() *schema.Provider {
 			"databricks_node_type":               compute.DataSourceNodeType(),
 			"databricks_notebook":                workspace.DataSourceNotebook(),
 			"databricks_notebook_paths":          workspace.DataSourceNotebookPaths(),
+			"databricks_spark_version":           compute.DataSourceSparkVersion(),
 			"databricks_zones":                   compute.DataSourceClusterZones(),
 		},
 		ResourcesMap: map[string]*schema.Resource{


### PR DESCRIPTION
This PR implements `databricks_spark_version` data source that allows to find DBR/Spark version that matches to specified filtering criteria.

This fixes #347