### PR TITLE
use spark_version data source in tests, etc.

### DIFF
--- a/compute/clusters.go
+++ b/compute/clusters.go
@@ -326,9 +326,12 @@ func (a ClustersAPI) GetOrCreateRunningCluster(name string, custom ...Cluster) (
 	})
 	log.Printf("[INFO] Creating an autoterminating cluster with node type %s", smallestNodeType)
 	r := Cluster{
-		NumWorkers:             1,
-		ClusterName:            name,
-		SparkVersion:           CommonRuntimeVersion(),
+		NumWorkers:  1,
+		ClusterName: name,
+		SparkVersion: a.LatestSparkVersionOrDefault(SparkVersionRequest{
+			Latest:          true,
+			LongTermSupport: true,
+		}),
 		NodeTypeID:             smallestNodeType,
 		AutoterminationMinutes: 10,
 	}
@@ -444,4 +447,13 @@ func (a ClustersAPI) LatestSparkVersion(svr SparkVersionRequest) (string, error)
 		return "", err
 	}
 	return sparkVersions.LatestSparkVersion(svr)
+}
+
+// LatestSparkVersionOrDefault returns Spark version matching the definition, or default in case of error
+func (a ClustersAPI) LatestSparkVersionOrDefault(svr SparkVersionRequest) string {
+	version, err := a.LatestSparkVersion(svr)
+	if err != nil {
+		return "7.3.x-scala2.12"
+	}
+	return version
 }

--- a/compute/common_instances_test.go
+++ b/compute/common_instances_test.go
@@ -15,6 +15,31 @@ func TestNewTinyClusterInCommonPoolPossiblyReused(t *testing.T) {
 	common.ResetCommonEnvironmentClient()
 	client, server, err := qa.HttpFixtureClient(t, []qa.HTTPFixture{
 		{
+			Method:       "GET",
+			ReuseRequest: true,
+			Resource:     "/api/2.0/clusters/spark-versions",
+			Response: SparkVersionsList{
+				SparkVersions: []SparkVersion{
+					{
+						Version:     "7.1.x-cpu-ml-scala2.12",
+						Description: "7.1 ML (includes Apache Spark 3.0.0, Scala 2.12)",
+					},
+					{
+						Version:     "apache-spark-2.4.x-scala2.11",
+						Description: "Light 2.4 (includes Apache Spark 2.4, Scala 2.11)",
+					},
+					{
+						Version:     "7.3.x-scala2.12",
+						Description: "7.3 LTS (includes Apache Spark 3.0.1, Scala 2.12)",
+					},
+					{
+						Version:     "6.4.x-scala2.11",
+						Description: "6.4 (includes Apache Spark 2.4.5, Scala 2.11)",
+					},
+				},
+			},
+		},
+		{
 			Method:   "GET",
 			Resource: "/api/2.0/instance-pools/list",
 			Response: InstancePoolList{
@@ -30,7 +55,7 @@ func TestNewTinyClusterInCommonPoolPossiblyReused(t *testing.T) {
 				},
 				NodeTypeID:                         "m4.large",
 				IdleInstanceAutoTerminationMinutes: 15,
-				PreloadedSparkVersions:             []string{"6.6.x-scala2.11"},
+				PreloadedSparkVersions:             []string{"7.3.x-scala2.12"},
 				InstancePoolName:                   "Terraform Integration Test by test",
 				MaxCapacity:                        10,
 			},
@@ -93,6 +118,31 @@ func TestNewTinyClusterInCommonPool(t *testing.T) {
 	defer common.CleanupEnvironment()()
 	common.ResetCommonEnvironmentClient()
 	client, server, err := qa.HttpFixtureClient(t, []qa.HTTPFixture{
+		{
+			Method:       "GET",
+			ReuseRequest: true,
+			Resource:     "/api/2.0/clusters/spark-versions",
+			Response: SparkVersionsList{
+				SparkVersions: []SparkVersion{
+					{
+						Version:     "7.1.x-cpu-ml-scala2.12",
+						Description: "7.1 ML (includes Apache Spark 3.0.0, Scala 2.12)",
+					},
+					{
+						Version:     "apache-spark-2.4.x-scala2.11",
+						Description: "Light 2.4 (includes Apache Spark 2.4, Scala 2.11)",
+					},
+					{
+						Version:     "7.3.x-scala2.12",
+						Description: "7.3 LTS (includes Apache Spark 3.0.1, Scala 2.12)",
+					},
+					{
+						Version:     "6.4.x-scala2.11",
+						Description: "6.4 (includes Apache Spark 2.4.5, Scala 2.11)",
+					},
+				},
+			},
+		},
 		{
 			Method:   "GET",
 			Resource: "/api/2.0/instance-pools/list",

--- a/compute/resource_instance_pool_test.go
+++ b/compute/resource_instance_pool_test.go
@@ -17,13 +17,16 @@ func TestAccInstancePools(t *testing.T) {
 	}
 	client := common.NewClientFromEnvironment()
 
+	clustersAPI := NewClustersAPI(context.Background(), client)
+	sparkVersion := clustersAPI.LatestSparkVersionOrDefault(SparkVersionRequest{Latest: true, LongTermSupport: true})
+	nodeType := clustersAPI.GetSmallestNodeType(NodeTypeRequest{})
 	pool := InstancePool{
 		InstancePoolName:                   "Terraform Integration Test",
 		MinIdleInstances:                   0,
-		NodeTypeID:                         qa.GetCloudInstanceType(client),
+		NodeTypeID:                         nodeType,
 		IdleInstanceAutoTerminationMinutes: 20,
 		PreloadedSparkVersions: []string{
-			"7.1.x-scala2.12",
+			sparkVersion,
 		},
 	}
 	if !client.IsAzure() {
@@ -60,10 +63,10 @@ func TestAccInstancePools(t *testing.T) {
 		InstancePoolName:                   "Terraform Integration Test Updated",
 		MinIdleInstances:                   0,
 		MaxCapacity:                        20,
-		NodeTypeID:                         qa.GetCloudInstanceType(client),
+		NodeTypeID:                         nodeType,
 		IdleInstanceAutoTerminationMinutes: 20,
 		PreloadedSparkVersions: []string{
-			"7.1.x-scala2.12",
+			sparkVersion,
 		},
 	}
 	if !client.IsAzure() {

--- a/internal/qa/testing.go
+++ b/internal/qa/testing.go
@@ -440,16 +440,6 @@ func AssertErrorStartsWith(t *testing.T, err error, message string) bool {
 	return assert.True(t, strings.HasPrefix(err.Error(), message), err.Error())
 }
 
-// GetCloudInstanceType gives common minimal instance type, depending on a cloud
-func GetCloudInstanceType(c *common.DatabricksClient) string {
-	if c.IsAzure() {
-		return "Standard_DS3_v2"
-	}
-	// TODO: create a method on ClustersAPI to give
-	// cloud specific delta-cache enabled instance by default.
-	return "m4.large"
-}
-
 // TestCreateTempFile  ...
 func TestCreateTempFile(t *testing.T, data string) string {
 	tmpFile, err := ioutil.TempFile("", "tf-test-create-dbfs-file")

--- a/internal/qa/testing_test.go
+++ b/internal/qa/testing_test.go
@@ -227,13 +227,6 @@ func TestResourceFixture_Apply_Fail(t *testing.T) {
 	assert.EqualError(t, err, "Invalid config supplied. [check] Invalid or unknown key")
 }
 
-func TestGetCloudInstanceType(t *testing.T) {
-	c := &common.DatabricksClient{}
-	assert.Equal(t, "m4.large", GetCloudInstanceType(c))
-	c.Host = "https://adb-0987654321.2.azuredatabricks.net/"
-	assert.Equal(t, "Standard_DS3_v2", GetCloudInstanceType(c))
-}
-
 func TestTestCreateTempFile(t *testing.T) {
 	a := TestCreateTempFile(t, "abc")
 	assert.FileExists(t, a)

--- a/storage/aws_s3_mount.go
+++ b/storage/aws_s3_mount.go
@@ -126,7 +126,7 @@ func getOrCreateMountingClusterWithInstanceProfile(clustersAPI compute.ClustersA
 	return clustersAPI.GetOrCreateRunningCluster(clusterName, compute.Cluster{
 		NumWorkers:   1,
 		ClusterName:  clusterName,
-		SparkVersion: compute.CommonRuntimeVersion(),
+		SparkVersion: clustersAPI.LatestSparkVersionOrDefault(compute.SparkVersionRequest{Latest: true, LongTermSupport: true}),
 		NodeTypeID: clustersAPI.GetSmallestNodeType(compute.NodeTypeRequest{
 			LocalDisk: true,
 		}),


### PR DESCRIPTION
instead of hardcoded Spark version obtained via `CommonRuntimeVersion`, now we can get Spark version via REST API