### PR TITLE
build target in Makefile should depend on vendor target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ coverage: test
 
 VERSION = 0.3.0
 
-build:
+build: vendor
 	@echo "✓ Building source code with go build ..."
 	@go build -mod vendor -v -o terraform-provider-databricks
 


### PR DESCRIPTION
right now, when the version of used package changes we need to explicitly run `make vendor` before calling `make build`, otherwise it fails. This PR makes this dependency explicit.