### PR TITLE
Adding tests to the importer & extend importer functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -335,5 +335,6 @@ website/public/**
 .vscode/private.env
 tf.log
 *.env
+*~
 
 scripts/tt

--- a/docs/guides/experimental-importer.md
+++ b/docs/guides/experimental-importer.md
@@ -27,7 +27,7 @@ All arguments are optional and they tune what code is being generated.
 * `-module` - Name of module in Terraform state, that would affect reference resolution and prefixes for generated commands in `import.sh`.
 * `-last-active-days` - Items with older than `-last-active-days` won't be imported. By default the value is set to 3650 (10 years). Has effect on listing [databricks_cluster](../resources/cluster.md) and [databricks_job](../resources/job.md) resources.
 * `-services` - Coma-separated list of services to import. By default all services are imported. 
-* `listing` - Coma-separated list of services to be listed and further passed on for importing. `-services` parameter controls which transitive dependencies will be processed. We recommend limiting with `-listing` more often, than with `-services`.
+* `-listing` - Coma-separated list of services to be listed and further passed on for importing. `-services` parameter controls which transitive dependencies will be processed. We recommend limiting with `-listing` more often, than with `-services`.
 * `-match` - Match resource names during listing operation. This filter applies to all resources that are getting listed, so if you want to import all dependencies of just one cluster, specify `-match=autoscaling -listing=compute`. By default is empty, which matches everything.
 * `-mounts` - List DBFS mount points, which is a relatively slow operation and would not trigger unless explicitly specified.
 

--- a/docs/guides/experimental-importer.md
+++ b/docs/guides/experimental-importer.md
@@ -30,6 +30,7 @@ All arguments are optional and they tune what code is being generated.
 * `-listing` - Coma-separated list of services to be listed and further passed on for importing. `-services` parameter controls which transitive dependencies will be processed. We recommend limiting with `-listing` more often, than with `-services`.
 * `-match` - Match resource names during listing operation. This filter applies to all resources that are getting listed, so if you want to import all dependencies of just one cluster, specify `-match=autoscaling -listing=compute`. By default is empty, which matches everything.
 * `-mounts` - List DBFS mount points, which is a relatively slow operation and would not trigger unless explicitly specified.
+* `-generateProviderDeclaration` - flag that toggles generation of `databricks.tf` file with declaration of the Databricks Terraform provider that is necessary for Terraform versions since Terraform 0.13 (disabled by default).
 
 ## Services
 

--- a/importer/command.go
+++ b/importer/command.go
@@ -65,9 +65,9 @@ func Run(args ...string) error {
 		}
 	}
 	flags.StringVar(&ic.services, "services", services,
-		"Coma-separated list of services to import. By default all services are imported.")
+		"Comma-separated list of services to import. By default all services are imported.")
 	flags.StringVar(&ic.listing, "listing", listing,
-		"Coma-separated list of services to be listed and further passed on for importing. "+
+		"Comma-separated list of services to be listed and further passed on for importing. "+
 			"`-services` parameter controls which transitive dependencies will be processed. "+
 			"We recommend limiting services with `-listing` more often, than `-services`.")
 	flags.StringVar(&ic.match, "match", "", "Match resource names during listing operation. "+

--- a/importer/command.go
+++ b/importer/command.go
@@ -45,6 +45,8 @@ func Run(args ...string) error {
 		"Items with older than activity specified won't be imported.")
 	flags.BoolVar(&ic.debug, "debug", false, "Print extra debug information.")
 	flags.BoolVar(&ic.mounts, "mounts", false, "List DBFS mount points.")
+	flags.BoolVar(&ic.generateDeclaration, "generateProviderDeclaration", false,
+		"Generate Databricks provider declaration (for Terraform >= 0.13).")
 
 	listing := ""
 	services := ""

--- a/importer/context.go
+++ b/importer/context.go
@@ -145,25 +145,27 @@ func (ic *importContext) Run() error {
 	// nolint
 	sh.WriteString("#!/bin/sh\n\n")
 
-	dcfile, err := os.Create(fmt.Sprintf("%s/databricks.tf", ic.Directory))
-	if err != nil {
-		return err
-	}
-	// nolint
-	dcfile.WriteString(
-		`terraform {
-			required_providers {
-			  databricks = {
-				source = "databrickslabs/databricks"
-				version = "` + common.Version() + `"
-			  }
-			}
-		  }
+	if ic.generateDeclaration {
+		dcfile, err := os.Create(fmt.Sprintf("%s/databricks.tf", ic.Directory))
+		if err != nil {
+			return err
+		}
+		// nolint
+		dcfile.WriteString(
+			`terraform {
+				required_providers {
+			  		databricks = {
+						source = "databrickslabs/databricks"
+						version = "` + common.Version() + `"
+				  	}
+				}
+		  	}
 
-		  provider "databricks" {
-		  }
-		  `)
-	dcfile.Close()
+		  	provider "databricks" {
+		  	}
+		  	`)
+		dcfile.Close()
+	}
 
 	sort.Sort(ic.Scope)
 	for _, r := range ic.Scope {

--- a/importer/context.go
+++ b/importer/context.go
@@ -141,6 +141,7 @@ func (ic *importContext) Run() error {
 		return err
 	}
 	defer sh.Close()
+	// nolint
 	sh.WriteString("#!/bin/sh\n\n")
 
 	sort.Sort(ic.Scope)

--- a/importer/context.go
+++ b/importer/context.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/databrickslabs/databricks-terraform/common"
+	"github.com/databrickslabs/databricks-terraform/compute"
 	"github.com/databrickslabs/databricks-terraform/identity"
 	"github.com/databrickslabs/databricks-terraform/provider"
 
@@ -74,6 +75,7 @@ type importContext struct {
 
 func newImportContext(c *common.DatabricksClient) *importContext {
 	p := provider.DatabricksProvider()
+	c.WithCommandExecutor(compute.NewCommandsAPI(c))
 	p.TerraformVersion = "importer"
 	p.SetMeta(c)
 	ctx := context.WithValue(context.Background(), common.Provider, p)

--- a/importer/context.go
+++ b/importer/context.go
@@ -397,6 +397,9 @@ func (ic *importContext) Emit(r *resource) {
 			return
 		}
 	}
+	if r.Data.Id() == "" {
+		r.Data.SetId(r.ID)
+	}
 	r.Name = ic.ResourceName(r)
 	if ir.Import != nil {
 		if err := ir.Import(ic, r); err != nil {

--- a/importer/context.go
+++ b/importer/context.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 
 	"github.com/databrickslabs/databricks-terraform/common"
-	"github.com/databrickslabs/databricks-terraform/compute"
 	"github.com/databrickslabs/databricks-terraform/identity"
 	"github.com/databrickslabs/databricks-terraform/provider"
 
@@ -75,7 +74,6 @@ type importContext struct {
 
 func newImportContext(c *common.DatabricksClient) *importContext {
 	p := provider.DatabricksProvider()
-	c.WithCommandExecutor(compute.NewCommandsAPI(c))
 	p.TerraformVersion = "importer"
 	p.SetMeta(c)
 	ctx := context.WithValue(context.Background(), common.Provider, p)

--- a/importer/context.go
+++ b/importer/context.go
@@ -136,11 +136,12 @@ func (ic *importContext) Run() error {
 	if len(ic.Scope) == 0 {
 		return fmt.Errorf("No resources to import")
 	}
-	sh, err := os.Create(fmt.Sprintf("%s/import.sh", ic.Directory))
+	sh, err := os.OpenFile(fmt.Sprintf("%s/import.sh", ic.Directory), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
 	if err != nil {
 		return err
 	}
 	defer sh.Close()
+	sh.WriteString("#!/bin/sh\n\n")
 
 	sort.Sort(ic.Scope)
 	for _, r := range ic.Scope {

--- a/importer/importables.go
+++ b/importer/importables.go
@@ -538,12 +538,15 @@ var resourcesMap map[string]importable = map[string]importable{
 			return nil
 		},
 		Import: func(ic *importContext, r *resource) error {
-			if l, err := access.NewSecretsAPI(ic.Context, ic.Client).List(r.ID); err == nil {
-				for _, secret := range l {
-					ic.Emit(&resource{
-						Resource: "databricks_secret",
-						ID:       fmt.Sprintf("%s|||%s", r.ID, secret.Key),
-					})
+			backendType, _ := r.Data.GetOk("backend_type")
+			if backendType != "AZURE_KEYVAULT" {
+				if l, err := access.NewSecretsAPI(ic.Context, ic.Client).List(r.ID); err == nil {
+					for _, secret := range l {
+						ic.Emit(&resource{
+							Resource: "databricks_secret",
+							ID:       fmt.Sprintf("%s|||%s", r.ID, secret.Key),
+						})
+					}
 				}
 			}
 			if l, err := access.NewSecretAclsAPI(ic.Context, ic.Client).List(r.ID); err == nil {

--- a/importer/importables.go
+++ b/importer/importables.go
@@ -444,6 +444,8 @@ var resourcesMap map[string]importable = map[string]importable{
 	"databricks_user": {
 		Service: "users",
 		Name: func(d *schema.ResourceData) string {
+			// TODO: if I have 2 users from different domains: test@domain1.com & test@domain2.com - then I'll generate the same name
+			// use another algorithm for name generation, like, just replace non-word characters with '_'
 			s := strings.Split(d.Get("user_name").(string), "@")
 			return s[0]
 		},

--- a/importer/importables.go
+++ b/importer/importables.go
@@ -20,16 +20,6 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func maybeSplitClusterID(clusterID string) string {
-	// TODO: can panic with error "panic: runtime error: index out of range [2] with length 1" on the non-existing clusters,
-	splits := strings.Split(clusterID, "-")
-	if len(splits) > 2 {
-		return splits[2]
-	}
-	log.Printf("[WARN] Can't split cluster ID: %s", clusterID)
-	return splits[0]
-}
-
 var resourcesMap map[string]importable = map[string]importable{
 	"databricks_dbfs_file": {
 		Service: "storage",
@@ -73,11 +63,11 @@ var resourcesMap map[string]importable = map[string]importable{
 		Name: func(d *schema.ResourceData) string {
 			raw, ok := d.GetOk("instance_pool_name")
 			if !ok {
-				return maybeSplitClusterID(d.Id())
+				return strings.Split(d.Id(), "-")[2]
 			}
 			name := raw.(string)
 			if name == "" {
-				return maybeSplitClusterID(d.Id())
+				return strings.Split(d.Id(), "-")[2]
 			}
 			return name
 		},
@@ -118,7 +108,7 @@ var resourcesMap map[string]importable = map[string]importable{
 		Name: func(d *schema.ResourceData) string {
 			name := d.Get("cluster_name").(string)
 			if name == "" {
-				return maybeSplitClusterID(d.Id())
+				return strings.Split(d.Id(), "-")[2]
 			}
 			return name
 		},

--- a/importer/importables.go
+++ b/importer/importables.go
@@ -20,6 +20,16 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+func maybeSplitClusterID(clusterID string) string {
+	// TODO: can panic with error "panic: runtime error: index out of range [2] with length 1" on the non-existing clusters,
+	splits := strings.Split(clusterID, "-")
+	if len(splits) > 2 {
+		return splits[2]
+	}
+	log.Printf("[WARN] Can't split cluster ID: %s", clusterID)
+	return splits[0]
+}
+
 var resourcesMap map[string]importable = map[string]importable{
 	"databricks_dbfs_file": {
 		Service: "storage",
@@ -63,11 +73,11 @@ var resourcesMap map[string]importable = map[string]importable{
 		Name: func(d *schema.ResourceData) string {
 			raw, ok := d.GetOk("instance_pool_name")
 			if !ok {
-				return strings.Split(d.Id(), "-")[2]
+				return maybeSplitClusterID(d.Id())
 			}
 			name := raw.(string)
 			if name == "" {
-				return strings.Split(d.Id(), "-")[2]
+				return maybeSplitClusterID(d.Id())
 			}
 			return name
 		},
@@ -108,7 +118,7 @@ var resourcesMap map[string]importable = map[string]importable{
 		Name: func(d *schema.ResourceData) string {
 			name := d.Get("cluster_name").(string)
 			if name == "" {
-				return strings.Split(d.Id(), "-")[2]
+				return maybeSplitClusterID(d.Id())
 			}
 			return name
 		},

--- a/importer/importer_test.go
+++ b/importer/importer_test.go
@@ -302,14 +302,16 @@ func TestImportingClusters(t *testing.T) {
 			Response: getJSONObject("test-data/get-cluster-permissions-test1-response.json"),
 		},
 		{
-			Method:   "GET",
-			Resource: "/api/2.0/dbfs/get-status?path=dbfs:%2FFileStore%2Fjars%2Fe388b491_7af3_4a41_9d3f_1966272df00f-spark_mssql_connector_assembly_1_2_0-99f79.jar",
-			Response: getJSONObject("test-data/get-dbfs-library-status.json"),
+			Method:       "GET",
+			Resource:     "/api/2.0/dbfs/get-status?path=dbfs:%2FFileStore%2Fjars%2Ftest.jar",
+			ReuseRequest: true,
+			Response:     getJSONObject("test-data/get-dbfs-library-status.json"),
 		},
 		{
-			Method:   "GET",
-			Resource: "/api/2.0/dbfs/read?length=1000000&path=dbfs%3A%2FFileStore%2Fjars%2Fe388b491_7af3_4a41_9d3f_1966272df00f-spark_mssql_connector_assembly_1_2_0-99f79.jar",
-			Response: getJSONObject("test-data/get-dbfs-library-data.json"),
+			Method:       "GET",
+			Resource:     "/api/2.0/dbfs/read?length=1000000&path=dbfs%3A%2FFileStore%2Fjars%2Ftest.jar",
+			ReuseRequest: true,
+			Response:     getJSONObject("test-data/get-dbfs-library-data.json"),
 		},
 		{
 			Method:   "GET",
@@ -348,6 +350,37 @@ func TestImportingClusters(t *testing.T) {
 			Response: getJSONObject("test-data/get-cluster-policy-permissions.json"),
 		},
 		{
+			Method:   "GET",
+			Resource: "/api/2.0/clusters/get?cluster_id=awscluster",
+			Response: getJSONObject("test-data/get-cluster-awscluster-response.json"),
+		},
+		{
+			Method:   "POST",
+			Resource: "/api/2.0/clusters/events",
+			ExpectedRequest: compute.EventsRequest{
+				ClusterID:  "awscluster",
+				Order:      "DESC",
+				EventTypes: []compute.ClusterEventType{"PINNED", "UNPINNED"},
+				Limit:      1,
+			},
+			Response: compute.EventDetails{},
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/libraries/cluster-status?cluster_id=awscluster",
+			Response: getJSONObject("test-data/libraries-cluster-status-test2.json"),
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/preview/permissions/clusters/awscluster",
+			Response: getJSONObject("test-data/get-cluster-permissions-awscluster-response.json"),
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/instance-profiles/list",
+			Response: getJSONObject("test-data/list-instance-profiles.json"),
+		},
+		{
 			Method:       "GET",
 			Resource:     "/api/2.0/preview/scim/v2/Me",
 			ReuseRequest: true,
@@ -367,6 +400,7 @@ func TestImportingClusters(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TODO: add spark_submit_task job
 func TestImportingJobs(t *testing.T) {
 	defer common.CleanupEnvironment()()
 	_, server, err := qa.HttpFixtureClient(t, []qa.HTTPFixture{
@@ -435,6 +469,60 @@ func TestImportingJobs(t *testing.T) {
 			Method:   "GET",
 			Resource: "/api/2.0/preview/permissions/cluster-policies/123",
 			Response: getJSONObject("test-data/get-cluster-policy-permissions.json"),
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/jobs/get?job_id=15",
+			Response: getJSONObject("test-data/get-job-15.json"),
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/preview/permissions/jobs/15",
+			Response: getJSONObject("test-data/get-job-permissions-15.json"),
+		},
+		{
+			Method:       "GET",
+			Resource:     "/api/2.0/dbfs/get-status?path=dbfs:%2FFileStore%2Fjars%2Ftest.jar",
+			ReuseRequest: true,
+			Response:     getJSONObject("test-data/get-dbfs-library-status.json"),
+		},
+		{
+			Method:       "GET",
+			Resource:     "/api/2.0/dbfs/read?length=1000000&path=dbfs%3A%2FFileStore%2Fjars%2Ftest.jar",
+			ReuseRequest: true,
+			Response:     getJSONObject("test-data/get-dbfs-library-data.json"),
+		},
+		{
+			Method:       "GET",
+			Resource:     "/api/2.0/instance-pools/get?instance_pool_id=pool1",
+			ReuseRequest: true,
+			Response:     getJSONObject("test-data/get-instance-pool1.json"),
+		},
+		{
+			Method:       "GET",
+			Resource:     "/api/2.0/preview/permissions/instance-pools/pool1",
+			ReuseRequest: true,
+			Response:     getJSONObject("test-data/get-instance-pool1-permissions.json"),
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/jobs/get?job_id=16",
+			Response: getJSONObject("test-data/get-job-16.json"),
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/preview/permissions/jobs/16",
+			Response: getJSONObject("test-data/get-job-permissions-16.json"),
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/jobs/get?job_id=17",
+			Response: getJSONObject("test-data/get-job-17.json"),
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/preview/permissions/jobs/17",
+			Response: getJSONObject("test-data/get-job-permissions-17.json"),
 		},
 		{
 			Method:       "GET",

--- a/importer/importer_test.go
+++ b/importer/importer_test.go
@@ -110,7 +110,7 @@ func TestImportingUsersGroupsSecretScopes(t *testing.T) {
 			Method:   "GET",
 			Resource: "/api/2.0/preview/scim/v2/Groups/c",
 			Response: identity.ScimGroup{ID: "c", DisplayName: "test",
-				Parents: []identity.GroupMember{
+				Groups: []identity.GroupMember{
 					{Display: "admins", Value: "a", Ref: "Groups/a", Type: "direct"},
 				},
 			},
@@ -131,11 +131,7 @@ func TestImportingUsersGroupsSecretScopes(t *testing.T) {
 			Resource: "/api/2.0/preview/scim/v2/Users?filter=userName%20eq%20%27test@test.com%27",
 			Response: identity.UserList{
 				Resources: []identity.ScimUser{
-					{ID: "123", DisplayName: "test@test.com", UserName: "test@test.com",
-						Groups: []identity.GroupMember{
-							{Display: "admins", Value: "a", Ref: "Groups/a", Type: "direct"},
-						},
-					},
+					{ID: "123", DisplayName: "test@test.com", UserName: "test@test.com"},
 				},
 				StartIndex:   1,
 				TotalResults: 1,

--- a/importer/importer_test.go
+++ b/importer/importer_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/databrickslabs/databricks-terraform/access"
 	"github.com/databrickslabs/databricks-terraform/common"
@@ -53,7 +54,7 @@ func TestAccImportJobs(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestImporting(t *testing.T) {
+func TestImportingUsersGroupsSecretScopes(t *testing.T) {
 	defer common.CleanupEnvironment()()
 	_, server, err := qa.HttpFixtureClient(t, []qa.HTTPFixture{
 		{
@@ -61,9 +62,11 @@ func TestImporting(t *testing.T) {
 			Resource: "/api/2.0/preview/scim/v2/Groups?",
 			Response: identity.GroupList{
 				Resources: []identity.ScimGroup{
+					// TODO: add another user for which there is no filter resut
 					{ID: "a", DisplayName: "admins",
 						Members: []identity.GroupMember{
 							{Display: "test@test.com", Value: "123", Ref: "Users/123"},
+							{Display: "Test group", Value: "f", Ref: "Groups/f"},
 						},
 					},
 					{ID: "b", DisplayName: "users"},
@@ -77,6 +80,37 @@ func TestImporting(t *testing.T) {
 			Response: identity.ScimGroup{ID: "a", DisplayName: "admins",
 				Members: []identity.GroupMember{
 					{Display: "test@test.com", Value: "123", Ref: "Users/123"},
+					{Display: "Test group", Value: "f", Ref: "Groups/f"},
+				},
+			},
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/preview/scim/v2/Groups/a",
+			Response: identity.ScimGroup{ID: "a", DisplayName: "admins",
+				Members: []identity.GroupMember{
+					{Display: "test@test.com", Value: "123", Ref: "Users/123"},
+					{Display: "Test group", Value: "f", Ref: "Groups/f"},
+				},
+			},
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/preview/scim/v2/Groups/a",
+			Response: identity.ScimGroup{ID: "a", DisplayName: "admins",
+				Members: []identity.GroupMember{
+					{Display: "test@test.com", Value: "123", Ref: "Users/123"},
+					{Display: "Test group", Value: "f", Ref: "Groups/f"},
+				},
+			},
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/preview/scim/v2/Groups/a",
+			Response: identity.ScimGroup{ID: "a", DisplayName: "admins",
+				Members: []identity.GroupMember{
+					{Display: "test@test.com", Value: "123", Ref: "Users/123"},
+					{Display: "Test group", Value: "f", Ref: "Groups/f"},
 				},
 			},
 		},
@@ -88,8 +122,18 @@ func TestImporting(t *testing.T) {
 		{
 			Method:   "GET",
 			Resource: "/api/2.0/preview/scim/v2/Groups/c",
-			Response: identity.ScimGroup{ID: "c", DisplayName: "test"},
+			Response: identity.ScimGroup{ID: "c", DisplayName: "test",
+				Parents: []identity.GroupMember{
+					{Display: "admins", Value: "a", Ref: "Groups/a", Type: "direct"},
+				},
+			},
 		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/preview/scim/v2/Groups/f",
+			Response: identity.ScimGroup{ID: "f", DisplayName: "nested"},
+		},
+		// TODO: add groups to the output
 		{
 			Method:   "GET",
 			Resource: "/api/2.0/preview/scim/v2/Users/123",
@@ -100,7 +144,11 @@ func TestImporting(t *testing.T) {
 			Resource: "/api/2.0/preview/scim/v2/Users?filter=userName%20eq%20%27test@test.com%27",
 			Response: identity.UserList{
 				Resources: []identity.ScimUser{
-					{ID: "123", DisplayName: "test@test.com", UserName: "test@test.com"},
+					{ID: "123", DisplayName: "test@test.com", UserName: "test@test.com",
+						Groups: []identity.GroupMember{
+							{Display: "admins", Value: "a", Ref: "Groups/a", Type: "direct"},
+						},
+					},
 				},
 				StartIndex:   1,
 				TotalResults: 1,
@@ -175,11 +223,207 @@ func TestImporting(t *testing.T) {
 	os.Setenv("DATABRICKS_TOKEN", "..")
 
 	tmpDir := fmt.Sprintf("/tmp/tf-%s", qa.RandomName())
-	//defer os.RemoveAll(tmpDir)
+	defer os.RemoveAll(tmpDir)
 
 	err = Run("-directory", tmpDir)
 	assert.NoError(t, err)
 	// TODO: check the content of the generated files
+}
+
+func TestImportingNoResourcesError(t *testing.T) {
+	defer common.CleanupEnvironment()()
+	_, server, err := qa.HttpFixtureClient(t, []qa.HTTPFixture{
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/preview/scim/v2/Groups?",
+			Response: identity.GroupList{Resources: []identity.ScimGroup{}},
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/jobs/list",
+			Response: compute.JobList{},
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/clusters/list",
+			Response: compute.ClusterList{},
+		},
+		{
+			Method:       "GET",
+			Resource:     "/api/2.0/secrets/scopes/list",
+			ReuseRequest: true,
+			Response: access.SecretScopeList{
+				Scopes: []access.SecretScope{},
+			},
+		},
+	})
+	require.NoError(t, err)
+	defer server.Close()
+
+	os.Setenv("DATABRICKS_HOST", server.URL)
+	os.Setenv("DATABRICKS_TOKEN", "..")
+
+	tmpDir := fmt.Sprintf("/tmp/tf-%s", qa.RandomName())
+	defer os.RemoveAll(tmpDir)
+
+	err = Run("-directory", tmpDir)
+	assert.EqualError(t, err, "No resources to import")
+}
+
+func TestImportingClusters(t *testing.T) {
+	defer common.CleanupEnvironment()()
+	_, server, err := qa.HttpFixtureClient(t, []qa.HTTPFixture{
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/preview/scim/v2/Groups?",
+			Response: identity.GroupList{Resources: []identity.ScimGroup{}},
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/jobs/list",
+			Response: compute.JobList{},
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/clusters/list",
+			Response: compute.ClusterList{
+				Clusters: []compute.ClusterInfo{
+					{ClusterID: "test", ClusterName: "test", SparkVersion: "spark-3.0"},
+					{ClusterID: "running", ClusterName: "running", SparkVersion: "spark-3.0"},
+				},
+			},
+		},
+		// test for cluster 'test'
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/clusters/get?cluster_id=test",
+			Response: compute.ClusterInfo{
+				ClusterID: "test", ClusterName: "test", SparkVersion: "spark-3.0",
+				State: "TERMINATED", LastActivityTime: 1000,
+			},
+		},
+		{
+			Method:   "POST",
+			Resource: "/api/2.0/clusters/events",
+			ExpectedRequest: compute.EventsRequest{
+				ClusterID:  "test",
+				Order:      "DESC",
+				EventTypes: []compute.ClusterEventType{"PINNED", "UNPINNED"},
+				Limit:      1,
+			},
+			Response: compute.EventDetails{},
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/libraries/cluster-status?cluster_id=test",
+			Response: compute.ClusterLibraryStatuses{
+				ClusterID: "test",
+			},
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/preview/permissions/clusters/test",
+			Response: access.ObjectACL{},
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/preview/scim/v2/Me",
+			Response: identity.ScimUser{},
+		},
+		// tests for cluster 'running'
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/clusters/get?cluster_id=running",
+			Response: compute.ClusterInfo{
+				ClusterID: "running", ClusterName: "running", SparkVersion: "spark-3.0",
+				State: "RUNNING", LastActivityTime: time.Now().Unix() - 100,
+			},
+		},
+		{
+			Method:   "POST",
+			Resource: "/api/2.0/clusters/events",
+			ExpectedRequest: compute.EventsRequest{
+				ClusterID:  "running",
+				Order:      "DESC",
+				EventTypes: []compute.ClusterEventType{"PINNED", "UNPINNED"},
+				Limit:      1,
+			},
+			Response: compute.EventDetails{},
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/libraries/cluster-status?cluster_id=running",
+			Response: compute.ClusterLibraryStatuses{
+				ClusterID: "running",
+				LibraryStatuses: []compute.LibraryStatus{
+					{Library: &compute.Library{
+						Maven: &compute.Maven{
+							Coordinates: "com.microsoft.azure:azure-eventhubs-spark_2.12:2.3.17",
+							Repo:        "https://mvnrepository.com",
+							Exclusions:  []string{"abc", "def"},
+						},
+					},
+						Status: "RUNNING",
+					},
+					{Library: &compute.Library{
+						Pypi: &compute.PyPi{
+							Package: "plotly==4.8.2",
+							Repo:    "https://mvnrepository.com",
+						},
+					},
+						Status: "RUNNING",
+					},
+					{Library: &compute.Library{
+						Cran: &compute.Cran{
+							Package: "ggplot",
+							Repo:    "https://mvnrepository.com",
+						},
+					},
+						Status: "RUNNING",
+					},
+				},
+			},
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/preview/permissions/clusters/running",
+			Response: access.ObjectACL{
+				ObjectID: "/clusters/running", ObjectType: "cluster",
+				AccessControlList: []access.AccessControl{
+					{UserName: "test@test.com",
+						AllPermissions: []access.Permission{
+							{PermissionLevel: "CAN_MANAGE", Inherited: false},
+						},
+					},
+				},
+			},
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/preview/scim/v2/Me",
+			Response: identity.ScimUser{ID: "a", DisplayName: "test@test.com"},
+		},
+		// the rest of the lists
+		{
+			Method:       "GET",
+			Resource:     "/api/2.0/secrets/scopes/list",
+			ReuseRequest: true,
+			Response: access.SecretScopeList{
+				Scopes: []access.SecretScope{},
+			},
+		},
+	})
+	require.NoError(t, err)
+	defer server.Close()
+
+	os.Setenv("DATABRICKS_HOST", server.URL)
+	os.Setenv("DATABRICKS_TOKEN", "..")
+
+	tmpDir := fmt.Sprintf("/tmp/tf-%s", qa.RandomName())
+	defer os.RemoveAll(tmpDir)
+
+	err = Run("-directory", tmpDir)
+	assert.NoError(t, err)
 }
 
 func TestImportingWithError(t *testing.T) {

--- a/importer/importer_test.go
+++ b/importer/importer_test.go
@@ -604,9 +604,36 @@ func TestImportingSecrets(t *testing.T) {
 	tmpDir := fmt.Sprintf("/tmp/tf-%s", qa.RandomName())
 	defer os.RemoveAll(tmpDir)
 
-	err = Run("-directory", tmpDir, "-listing", "secrets")
+	err = Run("-directory", tmpDir, "-listing", "secrets", "-generateProviderDeclaration", "true")
 	assert.NoError(t, err)
 }
+
+// func TestImportingMounts(t *testing.T) {
+// 	defer common.CleanupEnvironment()()
+// 	_, server, err := qa.HttpFixtureClient(t, []qa.HTTPFixture{
+// 		{
+// 			Method:   "GET",
+// 			Resource: "/api/2.0/clusters/list",
+// 			Response: compute.ClusterList{},
+// 		},
+// 		{
+// 			Method:   "GET",
+// 			Resource: "/api/2.0/clusters/list-node-types",
+// 			Response: compute.NodeTypeList{},
+// 		},
+// 	})
+// 	require.NoError(t, err)
+// 	defer server.Close()
+
+// 	os.Setenv("DATABRICKS_HOST", server.URL)
+// 	os.Setenv("DATABRICKS_TOKEN", "..")
+
+// 	tmpDir := fmt.Sprintf("/tmp/tf-%s", qa.RandomName())
+// 	defer os.RemoveAll(tmpDir)
+
+// 	err = Run("-directory", tmpDir, "-listing", "mounts", "-mounts", "true")
+// 	assert.NoError(t, err)
+// }
 
 func TestResourceName(t *testing.T) {
 	ic := newImportContext(&common.DatabricksClient{})

--- a/importer/test-data/clusters-list-response.json
+++ b/importer/test-data/clusters-list-response.json
@@ -133,6 +133,81 @@
       "start_time": 1606308581693,
       "state": "RUNNING",
       "state_message": ""
+    },
+    {
+      "autoscale": {
+        "max_workers": 14,
+        "min_workers": 1
+      },
+      "autotermination_minutes": 150,
+      "aws_attributes": {
+        "availability": "SPOT_WITH_FALLBACK",
+        "ebs_volume_count": 0,
+        "first_on_demand": 1,
+        "instance_profile_arn": "arn:aws:iam::12345:instance-profile/shard-s3-access",
+        "spot_bid_price_percent": 100,
+        "zone_id": "us-west-2c"
+      },
+      "cluster_cores": 24,
+      "cluster_id": "awscluster",
+      "cluster_memory_mb": 187392,
+      "cluster_name": "AWS cluster",
+      "cluster_source": "UI",
+      "creator_user_name": "test@test.com",
+      "custom_tags": {
+        "KeepAlive": "True"
+      },
+      "default_tags": {
+        "ClusterId": "0804-220509-stead130",
+        "ClusterName": "AWS cluster",
+        "Creator": "test@test.com",
+        "Vendor": "Databricks"
+      },
+      "disk_spec": {
+        "disk_count": 0
+      },
+      "driver": {
+        "host_private_ip": "10.0.240.104",
+        "instance_id": "i-03f4397abdcd56838",
+        "node_aws_attributes": {
+          "is_spot": false
+        },
+        "node_id": "595cec952ea242d1a5f9fce089514460",
+        "private_ip": "10.0.248.172",
+        "public_dns": "",
+        "start_timestamp": 1606245100391
+      },
+      "driver_node_type_id": "i3.4xlarge",
+      "enable_elastic_disk": true,
+      "enable_local_disk_encryption": false,
+      "executors": [
+        {
+          "host_private_ip": "10.0.234.198",
+          "instance_id": "i-029a79eb283dde2a0",
+          "node_aws_attributes": {
+            "is_spot": true
+          },
+          "node_id": "ccdff72ddc0b46b79d3bb209c9e0cfe3",
+          "private_ip": "10.0.241.139",
+          "public_dns": "",
+          "start_timestamp": 1606304674531
+        }
+      ],
+      "init_scripts_safe_mode": false,
+      "jdbc_port": 10000,
+      "last_activity_time": 1606245156342,
+      "last_state_loss_time": 1606245179193,
+      "node_type_id": "i3.2xlarge",
+      "pinned_by_user_name": "100095",
+      "spark_conf": {
+        "spark.databricks.conda.condaMagic.enabled": "true"
+      },
+      "spark_context_id": 6101559920592247000,
+      "spark_version": "7.3.x-cpu-ml-scala2.12",
+      "start_time": 1606245029966,
+      "state": "RUNNING",
+      "state_message": "",
+      "terminated_time": 0
     }
   ]
 }

--- a/importer/test-data/clusters-list-response.json
+++ b/importer/test-data/clusters-list-response.json
@@ -1,0 +1,138 @@
+{
+  "clusters": [
+    {
+      "autotermination_minutes": 120,
+      "azure_attributes": {
+        "availability": "ON_DEMAND_AZURE",
+        "first_on_demand": 1,
+        "spot_bid_max_price": -1
+      },
+      "cluster_cores": 12,
+      "cluster_id": "test1",
+      "cluster_memory_mb": 43008,
+      "cluster_name": "Test1",
+      "cluster_source": "UI",
+      "creator_user_name": "test@test.com",
+      "default_tags": {
+        "ClusterId": "Test1",
+        "ClusterName": "test1",
+        "Creator": "test@test.com",
+        "Vendor": "Databricks"
+      },
+      "disk_spec": {},
+      "driver": {
+        "host_private_ip": "10.139.0.10",
+        "instance_id": "4edec295d2944f82937e359a1dc0bc09",
+        "node_id": "68402f35830045dcbf42469fb2410b8b",
+        "private_ip": "10.139.64.10",
+        "public_dns": "51.144.17.214",
+        "start_timestamp": 1606308923964
+      },
+      "driver_node_type_id": "Standard_DS3_v2",
+      "enable_elastic_disk": true,
+      "enable_local_disk_encryption": false,
+      "executors": [
+        {
+          "host_private_ip": "10.139.0.9",
+          "instance_id": "5e90f23fbe1c4083a87bf6afc4c3d6bd",
+          "node_id": "fae6e38136cd4b0eb1aeb39640591c8c",
+          "private_ip": "10.139.64.9",
+          "public_dns": "51.144.17.184",
+          "start_timestamp": 1606308923993
+        },
+        {
+          "host_private_ip": "10.139.0.8",
+          "instance_id": "2fea62632e084708901872d201657917",
+          "node_id": "df573232e56b44798d8ae32bf1f09936",
+          "private_ip": "10.139.64.8",
+          "public_dns": "40.91.193.220",
+          "start_timestamp": 1606308924020
+        }
+      ],
+      "init_scripts_safe_mode": false,
+      "jdbc_port": 10000,
+      "last_state_loss_time": 1606308972982,
+      "node_type_id": "Standard_DS3_v2",
+      "num_workers": 2,
+      "pinned_by_user_name": "661448457191611",
+      "spark_conf": {
+        "spark.databricks.delta.preview.enabled": "true"
+      },
+      "spark_context_id": 5558306221970383000,
+      "spark_version": "7.3.x-scala2.12",
+      "start_time": 1603891857812,
+      "state": "RUNNING",
+      "state_message": ""
+    },
+    {
+      "autoscale": {
+        "max_workers": 2,
+        "min_workers": 1
+      },
+      "autotermination_minutes": 10,
+      "azure_attributes": {
+        "availability": "ON_DEMAND_AZURE",
+        "first_on_demand": 1,
+        "spot_bid_max_price": -1
+      },
+      "cluster_cores": 8,
+      "cluster_id": "test2",
+      "cluster_log_conf": {
+        "dbfs": {
+          "destination": "dbfs:/cluster-logs"
+        }
+      },
+      "cluster_log_status": {
+        "last_attempted": 1606308876994
+      },
+      "cluster_memory_mb": 16384,
+      "cluster_name": "Test cluster policy",
+      "cluster_source": "API",
+      "creator_user_name": "test@test.com",
+      "custom_tags": {
+        "team": "users"
+      },
+      "default_tags": {
+        "ClusterId": "test2",
+        "ClusterName": "Test cluster policy",
+        "Creator": "test@test.com",
+        "Vendor": "Databricks"
+      },
+      "disk_spec": {},
+      "driver": {
+        "host_private_ip": "10.139.0.6",
+        "instance_id": "ebef246856824a74a6ada70a2fd65463",
+        "node_id": "16058b39fec9458eb03ef5b3e7c0235a",
+        "private_ip": "10.139.64.6",
+        "public_dns": "51.144.247.201",
+        "start_timestamp": 1606308729904
+      },
+      "driver_node_type_id": "Standard_F4s",
+      "enable_elastic_disk": true,
+      "enable_local_disk_encryption": false,
+      "executors": [
+        {
+          "host_private_ip": "10.139.0.7",
+          "instance_id": "94c4ebd3be48471ca66ddc52c7b13457",
+          "node_id": "7c392a792d704da7b1780e0776ad450c",
+          "private_ip": "10.139.64.7",
+          "public_dns": "52.136.249.105",
+          "start_timestamp": 1606308729929
+        }
+      ],
+      "init_scripts_safe_mode": false,
+      "jdbc_port": 10000,
+      "last_state_loss_time": 0,
+      "node_type_id": "Standard_F4s",
+      "policy_id": "305F640038000012",
+      "spark_conf": {
+        "spark.databricks.delta.preview.enabled": "true"
+      },
+      "spark_context_id": 1279101448673406200,
+      "spark_version": "7.3.x-scala2.12",
+      "start_time": 1606308581693,
+      "state": "RUNNING",
+      "state_message": ""
+    }
+  ]
+}

--- a/importer/test-data/get-cluster-awscluster-response.json
+++ b/importer/test-data/get-cluster-awscluster-response.json
@@ -1,0 +1,75 @@
+{
+    "autoscale": {
+        "max_workers": 14,
+        "min_workers": 1
+    },
+    "autotermination_minutes": 150,
+    "aws_attributes": {
+        "availability": "SPOT_WITH_FALLBACK",
+        "ebs_volume_count": 0,
+        "first_on_demand": 1,
+        "instance_profile_arn": "arn:aws:iam::12345:instance-profile/shard-s3-access",
+        "spot_bid_price_percent": 100,
+        "zone_id": "us-west-2c"
+    },
+    "cluster_cores": 24,
+    "cluster_id": "awscluster",
+    "cluster_memory_mb": 187392,
+    "cluster_name": "AWS cluster",
+    "cluster_source": "UI",
+    "creator_user_name": "test@test.com",
+    "custom_tags": {
+        "KeepAlive": "True"
+    },
+    "default_tags": {
+        "ClusterId": "0804-220509-stead130",
+        "ClusterName": "AWS cluster",
+        "Creator": "test@test.com",
+        "Vendor": "Databricks"
+    },
+    "disk_spec": {
+        "disk_count": 0
+    },
+    "driver": {
+        "host_private_ip": "10.0.240.104",
+        "instance_id": "i-03f4397abdcd56838",
+        "node_aws_attributes": {
+            "is_spot": false
+        },
+        "node_id": "595cec952ea242d1a5f9fce089514460",
+        "private_ip": "10.0.248.172",
+        "public_dns": "",
+        "start_timestamp": 1606245100391
+    },
+    "driver_node_type_id": "i3.4xlarge",
+    "enable_elastic_disk": true,
+    "enable_local_disk_encryption": false,
+    "executors": [
+        {
+            "host_private_ip": "10.0.234.198",
+            "instance_id": "i-029a79eb283dde2a0",
+            "node_aws_attributes": {
+                "is_spot": true
+            },
+            "node_id": "ccdff72ddc0b46b79d3bb209c9e0cfe3",
+            "private_ip": "10.0.241.139",
+            "public_dns": "",
+            "start_timestamp": 1606304674531
+        }
+    ],
+    "init_scripts_safe_mode": false,
+    "jdbc_port": 10000,
+    "last_activity_time": 1606245156342,
+    "last_state_loss_time": 1606245179193,
+    "node_type_id": "i3.2xlarge",
+    "pinned_by_user_name": "100095",
+    "spark_conf": {
+        "spark.databricks.conda.condaMagic.enabled": "true"
+    },
+    "spark_context_id": 6101559920592247000,
+    "spark_version": "7.3.x-cpu-ml-scala2.12",
+    "start_time": 1606245029966,
+    "state": "RUNNING",
+    "state_message": "",
+    "terminated_time": 0
+}

--- a/importer/test-data/get-cluster-permissions-awscluster-response.json
+++ b/importer/test-data/get-cluster-permissions-awscluster-response.json
@@ -1,0 +1,27 @@
+{
+  "access_control_list": [
+    {
+      "all_permissions": [
+        {
+          "inherited": false,
+          "permission_level": "CAN_MANAGE"
+        }
+      ],
+      "user_name": "test@test.com"
+    },
+    {
+      "all_permissions": [
+        {
+          "inherited": true,
+          "inherited_from_object": [
+            "/clusters/"
+          ],
+          "permission_level": "CAN_MANAGE"
+        }
+      ],
+      "group_name": "admins"
+    }
+  ],
+  "object_id": "/clusters/awscluster",
+  "object_type": "cluster"
+}

--- a/importer/test-data/get-cluster-permissions-test1-response.json
+++ b/importer/test-data/get-cluster-permissions-test1-response.json
@@ -1,0 +1,27 @@
+{
+  "access_control_list": [
+    {
+      "all_permissions": [
+        {
+          "inherited": false,
+          "permission_level": "CAN_MANAGE"
+        }
+      ],
+      "user_name": "test@test.com"
+    },
+    {
+      "all_permissions": [
+        {
+          "inherited": true,
+          "inherited_from_object": [
+            "/clusters/"
+          ],
+          "permission_level": "CAN_MANAGE"
+        }
+      ],
+      "group_name": "admins"
+    }
+  ],
+  "object_id": "/clusters/test1",
+  "object_type": "cluster"
+}

--- a/importer/test-data/get-cluster-policy-permissions.json
+++ b/importer/test-data/get-cluster-policy-permissions.json
@@ -1,0 +1,27 @@
+{
+  "access_control_list": [
+    {
+      "all_permissions": [
+        {
+          "inherited": true,
+          "inherited_from_object": [
+            "/cluster-policies/cluster-policies"
+          ],
+          "permission_level": "CAN_USE"
+        }
+      ],
+      "group_name": "admins"
+    },
+    {
+      "all_permissions": [
+        {
+          "inherited": false,
+          "permission_level": "CAN_USE"
+        }
+      ],
+      "group_name": "users"
+    }
+  ],
+  "object_id": "/cluster-policies/123",
+  "object_type": "cluster-policy"
+}

--- a/importer/test-data/get-cluster-policy.json
+++ b/importer/test-data/get-cluster-policy.json
@@ -1,0 +1,6 @@
+{
+  "created_at_timestamp": 1606308550000,
+  "definition": "{\"autoscale.max_workers\":{\"defaultValue\":2,\"maxValue\":5,\"type\":\"range\"},\"autoscale.min_workers\":{\"hidden\":true,\"type\":\"fixed\",\"value\":1},\"autotermination_minutes\":{\"defaultValue\":20,\"maxValue\":30,\"type\":\"range\"},\"cluster_log_conf.path\":{\"hidden\":true,\"type\":\"fixed\",\"value\":\"dbfs:/cluster-logs\"},\"cluster_log_conf.type\":{\"hidden\":true,\"type\":\"fixed\",\"value\":\"DBFS\"},\"custom_tags.team\":{\"type\":\"fixed\",\"value\":\"users\"},\"dbus_per_hour\":{\"maxValue\":10,\"type\":\"range\"},\"driver_node_type_id\":{\"defaultValue\":\"Standard_F4s\",\"type\":\"whitelist\",\"values\":[\"Standard_F4s\",\"Standard_F8s\"]},\"node_type_id\":{\"defaultValue\":\"Standard_F4s\",\"type\":\"whitelist\",\"values\":[\"Standard_F4s\",\"Standard_F8s\"]},\"spark_version\":{\"defaultValue\":\"7.3.x-scala2.12\",\"type\":\"whitelist\",\"values\":[\"7.2.x-scala2.12\",\"7.3.x-scala2.12\"]}}",
+  "name": "users cluster policy",
+  "policy_id": "123"
+}

--- a/importer/test-data/get-cluster-test1-response.json
+++ b/importer/test-data/get-cluster-test1-response.json
@@ -1,0 +1,64 @@
+{
+  "autotermination_minutes": 120,
+  "azure_attributes": {
+    "availability": "ON_DEMAND_AZURE",
+    "first_on_demand": 1,
+    "spot_bid_max_price": -1
+  },
+  "cluster_cores": 12,
+  "cluster_id": "test1",
+  "cluster_memory_mb": 43008,
+  "cluster_name": "Test1",
+  "cluster_source": "UI",
+  "creator_user_name": "test@test.com",
+  "default_tags": {
+    "ClusterId": "test1",
+    "ClusterName": "Test1",
+    "Creator": "test@test.com",
+    "Vendor": "Databricks"
+  },
+  "disk_spec": {},
+  "driver": {
+    "host_private_ip": "10.139.0.10",
+    "instance_id": "4edec295d2944f82937e359a1dc0bc09",
+    "node_id": "68402f35830045dcbf42469fb2410b8b",
+    "private_ip": "10.139.64.10",
+    "public_dns": "51.144.17.214",
+    "start_timestamp": 1606308923964
+  },
+  "driver_node_type_id": "Standard_DS3_v2",
+  "enable_elastic_disk": true,
+  "enable_local_disk_encryption": false,
+  "executors": [
+    {
+      "host_private_ip": "10.139.0.9",
+      "instance_id": "5e90f23fbe1c4083a87bf6afc4c3d6bd",
+      "node_id": "fae6e38136cd4b0eb1aeb39640591c8c",
+      "private_ip": "10.139.64.9",
+      "public_dns": "51.144.17.184",
+      "start_timestamp": 1606308923993
+    },
+    {
+      "host_private_ip": "10.139.0.8",
+      "instance_id": "2fea62632e084708901872d201657917",
+      "node_id": "df573232e56b44798d8ae32bf1f09936",
+      "private_ip": "10.139.64.8",
+      "public_dns": "40.91.193.220",
+      "start_timestamp": 1606308924020
+    }
+  ],
+  "init_scripts_safe_mode": false,
+  "jdbc_port": 10000,
+  "last_state_loss_time": 1606308972982,
+  "node_type_id": "Standard_DS3_v2",
+  "num_workers": 2,
+  "pinned_by_user_name": "661448457191611",
+  "spark_conf": {
+    "spark.databricks.delta.preview.enabled": "true"
+  },
+  "spark_context_id": 5558306221970383000,
+  "spark_version": "7.3.x-scala2.12",
+  "start_time": 1603891857812,
+  "state": "RUNNING",
+  "state_message": ""
+}

--- a/importer/test-data/get-cluster-test1-response.json
+++ b/importer/test-data/get-cluster-test1-response.json
@@ -47,6 +47,13 @@
       "start_timestamp": 1606308924020
     }
   ],
+  "init_scripts": [
+    {
+       "dbfs": {
+          "destination": "dbfs:/FileStore/jars/test.jar"
+      }
+    }
+  ],
   "init_scripts_safe_mode": false,
   "jdbc_port": 10000,
   "last_state_loss_time": 1606308972982,

--- a/importer/test-data/get-cluster-test2-response.json
+++ b/importer/test-data/get-cluster-test2-response.json
@@ -1,0 +1,70 @@
+{
+  "autoscale": {
+    "max_workers": 2,
+    "min_workers": 1
+  },
+  "autotermination_minutes": 10,
+  "azure_attributes": {
+    "availability": "ON_DEMAND_AZURE",
+    "first_on_demand": 1,
+    "spot_bid_max_price": -1
+  },
+  "cluster_cores": 8,
+  "cluster_id": "test2",
+  "cluster_log_conf": {
+    "dbfs": {
+      "destination": "dbfs:/cluster-logs"
+    }
+  },
+  "cluster_log_status": {
+    "last_attempted": 1606308876994
+  },
+  "cluster_memory_mb": 16384,
+  "cluster_name": "Test cluster policy",
+  "cluster_source": "API",
+  "creator_user_name": "test@test.com",
+  "custom_tags": {
+    "team": "users"
+  },
+  "default_tags": {
+    "ClusterId": "test2",
+    "ClusterName": "Test cluster policy",
+    "Creator": "test@test.com",
+    "Vendor": "Databricks"
+  },
+  "disk_spec": {},
+  "driver": {
+    "host_private_ip": "10.139.0.6",
+    "instance_id": "ebef246856824a74a6ada70a2fd65463",
+    "node_id": "16058b39fec9458eb03ef5b3e7c0235a",
+    "private_ip": "10.139.64.6",
+    "public_dns": "51.144.247.201",
+    "start_timestamp": 1606308729904
+  },
+  "driver_node_type_id": "Standard_F4s",
+  "enable_elastic_disk": true,
+  "enable_local_disk_encryption": false,
+  "executors": [
+    {
+      "host_private_ip": "10.139.0.7",
+      "instance_id": "94c4ebd3be48471ca66ddc52c7b13457",
+      "node_id": "7c392a792d704da7b1780e0776ad450c",
+      "private_ip": "10.139.64.7",
+      "public_dns": "52.136.249.105",
+      "start_timestamp": 1606308729929
+    }
+  ],
+  "init_scripts_safe_mode": false,
+  "jdbc_port": 10000,
+  "last_state_loss_time": 0,
+  "node_type_id": "Standard_F4s",
+  "policy_id": "123",
+  "spark_conf": {
+    "spark.databricks.delta.preview.enabled": "true"
+  },
+  "spark_context_id": 1279101448673406200,
+  "spark_version": "7.3.x-scala2.12",
+  "start_time": 1606308581693,
+  "state": "RUNNING",
+  "state_message": ""
+}

--- a/importer/test-data/get-dbfs-library-data.json
+++ b/importer/test-data/get-dbfs-library-data.json
@@ -1,0 +1,4 @@
+{
+  "bytes_read": 10,
+  "data": "MTIzNDU2Nzg5MA=="
+}

--- a/importer/test-data/get-dbfs-library-status.json
+++ b/importer/test-data/get-dbfs-library-status.json
@@ -1,5 +1,5 @@
 {
   "file_size": 10,
   "is_dir": false,
-  "path": "/FileStore/jars/e388b491_7af3_4a41_9d3f_1966272df00f-spark_mssql_connector_assembly_1_2_0-99f79.jar"
+  "path": "/FileStore/jars/test.jar"
 }

--- a/importer/test-data/get-dbfs-library-status.json
+++ b/importer/test-data/get-dbfs-library-status.json
@@ -1,0 +1,5 @@
+{
+  "file_size": 10,
+  "is_dir": false,
+  "path": "/FileStore/jars/e388b491_7af3_4a41_9d3f_1966272df00f-spark_mssql_connector_assembly_1_2_0-99f79.jar"
+}

--- a/importer/test-data/get-instance-pool1-permissions.json
+++ b/importer/test-data/get-instance-pool1-permissions.json
@@ -1,0 +1,27 @@
+{
+  "access_control_list": [
+    {
+      "all_permissions": [
+        {
+          "inherited": false,
+          "permission_level": "CAN_MANAGE"
+        }
+      ],
+      "user_name": "test@test.com"
+    },
+    {
+      "all_permissions": [
+        {
+          "inherited": true,
+          "inherited_from_object": [
+            "/instnace-pools/"
+          ],
+          "permission_level": "CAN_MANAGE"
+        }
+      ],
+      "group_name": "admins"
+    }
+  ],
+  "object_id": "/instance-pools/pool1",
+  "object_type": "instance-pool"
+}

--- a/importer/test-data/get-instance-pool1.json
+++ b/importer/test-data/get-instance-pool1.json
@@ -1,0 +1,36 @@
+{
+  "instance_pool_name": "Pool 1",
+  "min_idle_instances": 0,
+  "aws_attributes": {
+    "availability": "SPOT",
+    "zone_id": "us-west-2a",
+    "spot_bid_price_percent": 100
+  },
+  "node_type_id": "c4.2xlarge",
+  "idle_instance_autotermination_minutes": 60,
+  "enable_elastic_disk": false,
+  "disk_spec": {
+    "disk_type": {
+      "ebs_volume_type": "GENERAL_PURPOSE_SSD"
+    },
+    "disk_count": 1,
+    "disk_size": 100
+  },
+  "preloaded_spark_versions": [
+    "5.4.x-scala2.11"
+  ],
+  "instance_pool_id": "pool1",
+  "default_tags": {
+    "Vendor": "Databricks",
+    "DatabricksInstancePoolCreatorId": "100125",
+    "DatabricksInstancePoolId": "101-120000-brick1-pool-ABCD1234"
+  },
+  "state": "ACTIVE",
+  "stats": {
+    "used_count": 10,
+    "idle_count": 5,
+    "pending_used_count": 5,
+    "pending_idle_count": 5
+  },
+  "status": {}
+}

--- a/importer/test-data/get-job-12.json
+++ b/importer/test-data/get-job-12.json
@@ -1,0 +1,15 @@
+{
+  "created_time": 1605193982171,
+  "creator_user_name": "test@test.com",
+  "job_id": 12,
+  "settings": {
+    "email_notifications": {},
+    "existing_cluster_id": "test2",
+    "max_concurrent_runs": 1,
+    "name": "Test",
+    "notebook_task": {
+      "notebook_path": "/Users/test@test.com/Test"
+    },
+    "timeout_seconds": 0
+  }
+}

--- a/importer/test-data/get-job-14.json
+++ b/importer/test-data/get-job-14.json
@@ -1,0 +1,47 @@
+{
+  "created_time": 1606301532298,
+  "creator_user_name": "test@test.com",
+  "job_id": 14,
+  "settings": {
+    "email_notifications": {
+      "on_failure": [
+        "test@test.com"
+      ]
+    },
+    "libraries": [
+      {
+        "maven": {
+          "coordinates": "com.microsoft.azure:azure-eventhubs-spark_2.12:2.3.17"
+        }
+      },
+      {
+        "pypi": {
+          "package": "spacy"
+        }
+      }
+    ],
+    "max_concurrent_runs": 1,
+    "name": "Demo job",
+    "new_cluster": {
+      "azure_attributes": {
+        "availability": "ON_DEMAND_AZURE"
+      },
+      "enable_elastic_disk": true,
+      "node_type_id": "Standard_DS3_v2",
+      "num_workers": 2,
+      "spark_conf": {
+        "spark.databricks.delta.preview.enabled": "true"
+      },
+      "spark_version": "7.3.x-scala2.12"
+    },
+    "notebook_task": {
+      "notebook_path": "/Production/MakeFeatures"
+    },
+    "schedule": {
+      "pause_status": "UNPAUSED",
+      "quartz_cron_expression": "0 15 22 ? * *",
+      "timezone_id": "UTC"
+    },
+    "timeout_seconds": 0
+  }
+}

--- a/importer/test-data/get-job-15.json
+++ b/importer/test-data/get-job-15.json
@@ -1,0 +1,29 @@
+{
+    "created_time": 1561026045903,
+    "creator_user_name": "test@test.com",
+    "job_id": 15,
+    "settings": {
+        "email_notifications": {},
+        "libraries": [
+            {
+                "jar": "dbfs:/FileStore/jars/test.jar"
+            }
+        ],
+        "max_concurrent_runs": 1,
+        "max_retries": 1,
+        "min_retry_interval_millis": 0,
+        "name": "Scala Project",
+        "new_cluster": {
+            "instance_pool_id": "pool1",
+            "num_workers": 2,
+            "spark_version": "6.4.x-scala2.11"
+        },
+        "retry_on_timeout": false,
+        "spark_jar_task": {
+            "jar_uri": "dbfs:/FileStore/jars/test.jar",
+            "main_class_name": "com.databricks.examples.ProjectDriver",
+            "run_as_repl": true
+        },
+        "timeout_seconds": 3600
+    }
+}

--- a/importer/test-data/get-job-16.json
+++ b/importer/test-data/get-job-16.json
@@ -1,0 +1,28 @@
+{
+    "created_time": 1561026045903,
+    "creator_user_name": "test@test.com",
+    "job_id": 16,
+    "settings": {
+        "email_notifications": {},
+        "libraries": [
+            {
+                "jar": "dbfs:/FileStore/jars/test.jar"
+            }
+        ],
+        "max_concurrent_runs": 1,
+        "max_retries": 1,
+        "min_retry_interval_millis": 0,
+        "name": "Python Project",
+        "new_cluster": {
+            "instance_pool_id": "pool1",
+            "num_workers": 2,
+            "spark_version": "6.4.x-scala2.11"
+        },
+        "retry_on_timeout": false,
+        "spark_python_task": {
+            "python_file": "dbfs:/FileStore/jars/test.jar",
+            "parameters": ["param1"]
+        },
+        "timeout_seconds": 3600
+    }
+}

--- a/importer/test-data/get-job-17.json
+++ b/importer/test-data/get-job-17.json
@@ -1,0 +1,35 @@
+{
+    "created_time": 1571676194487,
+    "creator_user_name": "test@test.com",
+    "job_id": 17,
+    "settings": {
+        "email_notifications": {},
+        "max_concurrent_runs": 1,
+        "name": "SparkR Test",
+        "new_cluster": {
+            "autoscale": {
+                "max_workers": 8,
+                "min_workers": 2
+            },
+            "aws_attributes": {
+                "availability": "SPOT_WITH_FALLBACK",
+                "ebs_volume_count": 0,
+                "first_on_demand": 1,
+                "spot_bid_price_percent": 100,
+                "zone_id": "us-west-2c"
+            },
+            "enable_elastic_disk": false,
+            "node_type_id": "i3.xlarge",
+            "spark_env_vars": {
+                "PYSPARK_PYTHON": "/databricks/python3/bin/python3"
+            },
+            "spark_version": "5.5.x-scala2.11"
+        },
+        "spark_submit_task": {
+            "parameters": [
+                "dbfs:/FileStore/jars/test.jar"
+            ]
+        },
+        "timeout_seconds": 0
+    }
+}

--- a/importer/test-data/get-job-permissions-12.json
+++ b/importer/test-data/get-job-permissions-12.json
@@ -1,0 +1,27 @@
+{
+  "access_control_list": [
+    {
+      "all_permissions": [
+        {
+          "inherited": false,
+          "permission_level": "IS_OWNER"
+        }
+      ],
+      "user_name": "test@test.com"
+    },
+    {
+      "all_permissions": [
+        {
+          "inherited": true,
+          "inherited_from_object": [
+            "/jobs/"
+          ],
+          "permission_level": "CAN_MANAGE"
+        }
+      ],
+      "group_name": "admins"
+    }
+  ],
+  "object_id": "/jobs/12",
+  "object_type": "job"
+}

--- a/importer/test-data/get-job-permissions-14.json
+++ b/importer/test-data/get-job-permissions-14.json
@@ -1,0 +1,54 @@
+{
+  "access_control_list": [
+    {
+      "all_permissions": [
+        {
+          "inherited": false,
+          "permission_level": "IS_OWNER"
+        }
+      ],
+      "user_name": "test@test.com"
+    },
+    {
+      "all_permissions": [
+        {
+          "inherited": false,
+          "permission_level": "CAN_MANAGE_RUN"
+        }
+      ],
+      "group_name": "Automation"
+    },
+    {
+      "all_permissions": [
+        {
+          "inherited": false,
+          "permission_level": "CAN_MANAGE"
+        }
+      ],
+      "group_name": "Engineering"
+    },
+    {
+      "all_permissions": [
+        {
+          "inherited": true,
+          "inherited_from_object": [
+            "/jobs/"
+          ],
+          "permission_level": "CAN_MANAGE"
+        }
+      ],
+      "group_name": "admins"
+    },
+    {
+      "all_permissions": [
+        {
+          "inherited": false,
+          "permission_level": "CAN_VIEW"
+        }
+      ],
+      "group_name": "users"
+    }
+  ],
+  "object_id": "/jobs/14",
+  "object_type": "job"
+}

--- a/importer/test-data/get-job-permissions-15.json
+++ b/importer/test-data/get-job-permissions-15.json
@@ -1,0 +1,54 @@
+{
+  "access_control_list": [
+    {
+      "all_permissions": [
+        {
+          "inherited": false,
+          "permission_level": "IS_OWNER"
+        }
+      ],
+      "user_name": "test@test.com"
+    },
+    {
+      "all_permissions": [
+        {
+          "inherited": false,
+          "permission_level": "CAN_MANAGE_RUN"
+        }
+      ],
+      "group_name": "Automation"
+    },
+    {
+      "all_permissions": [
+        {
+          "inherited": false,
+          "permission_level": "CAN_MANAGE"
+        }
+      ],
+      "group_name": "Engineering"
+    },
+    {
+      "all_permissions": [
+        {
+          "inherited": true,
+          "inherited_from_object": [
+            "/jobs/"
+          ],
+          "permission_level": "CAN_MANAGE"
+        }
+      ],
+      "group_name": "admins"
+    },
+    {
+      "all_permissions": [
+        {
+          "inherited": false,
+          "permission_level": "CAN_VIEW"
+        }
+      ],
+      "group_name": "users"
+    }
+  ],
+  "object_id": "/jobs/15",
+  "object_type": "job"
+}

--- a/importer/test-data/get-job-permissions-16.json
+++ b/importer/test-data/get-job-permissions-16.json
@@ -1,0 +1,54 @@
+{
+  "access_control_list": [
+    {
+      "all_permissions": [
+        {
+          "inherited": false,
+          "permission_level": "IS_OWNER"
+        }
+      ],
+      "user_name": "test@test.com"
+    },
+    {
+      "all_permissions": [
+        {
+          "inherited": false,
+          "permission_level": "CAN_MANAGE_RUN"
+        }
+      ],
+      "group_name": "Automation"
+    },
+    {
+      "all_permissions": [
+        {
+          "inherited": false,
+          "permission_level": "CAN_MANAGE"
+        }
+      ],
+      "group_name": "Engineering"
+    },
+    {
+      "all_permissions": [
+        {
+          "inherited": true,
+          "inherited_from_object": [
+            "/jobs/"
+          ],
+          "permission_level": "CAN_MANAGE"
+        }
+      ],
+      "group_name": "admins"
+    },
+    {
+      "all_permissions": [
+        {
+          "inherited": false,
+          "permission_level": "CAN_VIEW"
+        }
+      ],
+      "group_name": "users"
+    }
+  ],
+  "object_id": "/jobs/16",
+  "object_type": "job"
+}

--- a/importer/test-data/get-job-permissions-17.json
+++ b/importer/test-data/get-job-permissions-17.json
@@ -1,0 +1,54 @@
+{
+  "access_control_list": [
+    {
+      "all_permissions": [
+        {
+          "inherited": false,
+          "permission_level": "IS_OWNER"
+        }
+      ],
+      "user_name": "test@test.com"
+    },
+    {
+      "all_permissions": [
+        {
+          "inherited": false,
+          "permission_level": "CAN_MANAGE_RUN"
+        }
+      ],
+      "group_name": "Automation"
+    },
+    {
+      "all_permissions": [
+        {
+          "inherited": false,
+          "permission_level": "CAN_MANAGE"
+        }
+      ],
+      "group_name": "Engineering"
+    },
+    {
+      "all_permissions": [
+        {
+          "inherited": true,
+          "inherited_from_object": [
+            "/jobs/"
+          ],
+          "permission_level": "CAN_MANAGE"
+        }
+      ],
+      "group_name": "admins"
+    },
+    {
+      "all_permissions": [
+        {
+          "inherited": false,
+          "permission_level": "CAN_VIEW"
+        }
+      ],
+      "group_name": "users"
+    }
+  ],
+  "object_id": "/jobs/16",
+  "object_type": "job"
+}

--- a/importer/test-data/get-jobs-list.json
+++ b/importer/test-data/get-jobs-list.json
@@ -1,0 +1,66 @@
+{
+  "jobs": [
+    {
+      "created_time": 1606301532298,
+      "creator_user_name": "test@test.com",
+      "job_id": 14,
+      "settings": {
+        "email_notifications": {
+          "on_failure": [
+            "test@test.com"
+          ]
+        },
+        "libraries": [
+          {
+            "maven": {
+              "coordinates": "com.microsoft.azure:azure-eventhubs-spark_2.12:2.3.17"
+            }
+          },
+          {
+            "pypi": {
+              "package": "spacy"
+            }
+          }
+        ],
+        "max_concurrent_runs": 1,
+        "name": "Demo job",
+        "new_cluster": {
+          "azure_attributes": {
+            "availability": "ON_DEMAND_AZURE"
+          },
+          "enable_elastic_disk": true,
+          "node_type_id": "Standard_DS3_v2",
+          "num_workers": 2,
+          "spark_conf": {
+            "spark.databricks.delta.preview.enabled": "true"
+          },
+          "spark_version": "7.3.x-scala2.12"
+        },
+        "notebook_task": {
+          "notebook_path": "/Production/MakeFeatures"
+        },
+        "schedule": {
+          "pause_status": "UNPAUSED",
+          "quartz_cron_expression": "0 15 22 ? * *",
+          "timezone_id": "UTC"
+        },
+        "timeout_seconds": 0
+      }
+    },
+    {
+      "created_time": 1605193982171,
+      "creator_user_name": "test@test.com",
+      "job_id": 12,
+      "settings": {
+        "email_notifications": {},
+        "existing_cluster_id": "test2",
+        "max_concurrent_runs": 1,
+        "name": "Test",
+        "notebook_task": {
+          "notebook_path": "/Users/test@test.com/Test"
+        },
+        "timeout_seconds": 0
+      }
+    }
+  ]
+}

--- a/importer/test-data/get-jobs-list.json
+++ b/importer/test-data/get-jobs-list.json
@@ -61,6 +61,98 @@
         },
         "timeout_seconds": 0
       }
-    }
+    },
+    {
+      "created_time": 1561026045903,
+      "creator_user_name": "test@test.com",
+      "job_id": 15,
+      "settings": {
+        "email_notifications": {},
+        "libraries": [
+          {
+            "jar": "dbfs:/FileStore/jars/test.jar"
+          }
+        ],
+        "max_concurrent_runs": 1,
+        "max_retries": 1,
+        "min_retry_interval_millis": 0,
+        "name": "Scala Project",
+        "new_cluster": {
+          "instance_pool_id": "pool1",
+          "num_workers": 2,
+          "spark_version": "6.4.x-scala2.11"
+        },
+        "retry_on_timeout": false,
+        "spark_jar_task": {
+          "jar_uri": "dbfs:/FileStore/jars/test.jar",
+          "main_class_name": "com.databricks.examples.ProjectDriver",
+          "run_as_repl": true
+        },
+        "timeout_seconds": 3600
+      }
+    },
+    {
+      "created_time": 1561026045903,
+      "creator_user_name": "test@test.com",
+      "job_id": 15,
+      "settings": {
+        "email_notifications": {},
+        "libraries": [
+            {
+                "jar": "dbfs:/FileStore/jars/test.jar"
+            }
+        ],
+        "max_concurrent_runs": 1,
+        "max_retries": 1,
+        "min_retry_interval_millis": 0,
+        "name": "Python Project",
+        "new_cluster": {
+            "instance_pool_id": "pool1",
+            "num_workers": 2,
+            "spark_version": "6.4.x-scala2.11"
+        },
+        "retry_on_timeout": false,
+        "spark_python_task": {
+            "python_file": "dbfs:/FileStore/jars/test.jar",
+            "parameters": ["param1"]
+        },
+        "timeout_seconds": 3600
+      }
+    },
+    {
+      "created_time": 1571676194487,
+      "creator_user_name": "test@test.com",
+      "job_id": 17,
+      "settings": {
+        "email_notifications": {},
+        "max_concurrent_runs": 1,
+        "name": "SparkR Test",
+        "new_cluster": {
+            "autoscale": {
+                "max_workers": 8,
+                "min_workers": 2
+            },
+            "aws_attributes": {
+                "availability": "SPOT_WITH_FALLBACK",
+                "ebs_volume_count": 0,
+                "first_on_demand": 1,
+                "spot_bid_price_percent": 100,
+                "zone_id": "us-west-2c"
+            },
+            "enable_elastic_disk": false,
+            "node_type_id": "i3.xlarge",
+            "spark_env_vars": {
+                "PYSPARK_PYTHON": "/databricks/python3/bin/python3"
+            },
+            "spark_version": "5.5.x-scala2.11"
+        },
+        "spark_submit_task": {
+            "parameters": [
+                "dbfs:/FileStore/jars/test.jar"
+            ]
+        },
+        "timeout_seconds": 0
+      }
+    }  
   ]
 }

--- a/importer/test-data/libraries-cluster-status-test1.json
+++ b/importer/test-data/libraries-cluster-status-test1.json
@@ -34,7 +34,21 @@
     {
       "is_library_for_all_clusters": false,
       "library": {
-        "jar": "dbfs:/FileStore/jars/e388b491_7af3_4a41_9d3f_1966272df00f-spark_mssql_connector_assembly_1_2_0-99f79.jar"
+        "jar": "dbfs:/FileStore/jars/test.jar"
+      },
+      "status": "INSTALLED"
+    },
+    {
+      "is_library_for_all_clusters": false,
+      "library": {
+        "egg": "dbfs:/FileStore/jars/test.jar"
+      },
+      "status": "INSTALLED"
+    },
+    {
+      "is_library_for_all_clusters": false,
+      "library": {
+        "whl": "dbfs:/FileStore/jars/test.jar"
       },
       "status": "INSTALLED"
     }

--- a/importer/test-data/libraries-cluster-status-test1.json
+++ b/importer/test-data/libraries-cluster-status-test1.json
@@ -1,0 +1,42 @@
+{
+  "cluster_id": "test1",
+  "library_statuses": [
+    {
+      "is_library_for_all_clusters": false,
+      "library": {
+        "maven": {
+          "coordinates": "com.microsoft.azure:azure-eventhubs-spark_2.12:2.3.17",
+          "repo": "https://some-repo"
+        }
+      },
+      "status": "INSTALLED"
+    },
+    {
+      "is_library_for_all_clusters": false,
+      "library": {
+        "pypi": {
+            "package": "plotly==4.8.2",
+            "repo": "https://some-repo"
+        }
+      },
+      "status": "INSTALLED"
+    },
+    {
+      "is_library_for_all_clusters": false,
+      "library": {
+        "cran": {
+            "package": "ggplot",
+            "repo": "https://some-repo"
+        }
+      },
+      "status": "INSTALLED"
+    },
+    {
+      "is_library_for_all_clusters": false,
+      "library": {
+        "jar": "dbfs:/FileStore/jars/e388b491_7af3_4a41_9d3f_1966272df00f-spark_mssql_connector_assembly_1_2_0-99f79.jar"
+      },
+      "status": "INSTALLED"
+    }
+  ]
+}

--- a/importer/test-data/libraries-cluster-status-test2.json
+++ b/importer/test-data/libraries-cluster-status-test2.json
@@ -1,0 +1,5 @@
+{
+  "cluster_id": "test2",
+  "library_statuses": [
+  ]
+}

--- a/importer/test-data/list-instance-profiles.json
+++ b/importer/test-data/list-instance-profiles.json
@@ -1,0 +1,8 @@
+{
+  "instance_profiles": [
+    {
+      "instance_profile_arn": "arn:aws:iam::12345:instance-profile/shard-s3-access",
+      "is_meta_instance_profile": false
+    }
+  ]
+}

--- a/importer/test-data/secret-scopes-get-principal-response.json
+++ b/importer/test-data/secret-scopes-get-principal-response.json
@@ -1,0 +1,4 @@
+{
+  "permission": "MANAGE",
+  "principal": "test@test.com"
+}

--- a/importer/test-data/secret-scopes-list-scope-acls-response.json
+++ b/importer/test-data/secret-scopes-list-scope-acls-response.json
@@ -1,0 +1,8 @@
+{
+  "items": [
+    {
+      "permission": "MANAGE",
+      "principal": "test@test.com"
+    }
+  ]
+}

--- a/importer/test-data/secret-scopes-list-scope-response.json
+++ b/importer/test-data/secret-scopes-list-scope-response.json
@@ -1,0 +1,8 @@
+{
+  "secrets": [
+    {
+      "key": "some-secret",
+      "last_updated_timestamp": 1602168336000
+    }
+  ]
+}

--- a/importer/test-data/secret-scopes-response.json
+++ b/importer/test-data/secret-scopes-response.json
@@ -1,0 +1,13 @@
+{
+  "scopes": [
+    {
+      "backend_type": "AZURE_KEYVAULT",
+      "is_databricks_managed": false,
+      "keyvault_metadata": {
+        "dns_name": "https://some.vault.azure.net/",
+        "resource_id": "/subscriptions/1242wfwfw-f8a9-4fb5-8a9d-ac1b2c8e756e/resourceGroups/some-rg/providers/Microsoft.KeyVault/vaults/some-kv"
+      },
+      "name": "some-kv-scope"
+    }
+  ]
+}

--- a/importer/util.go
+++ b/importer/util.go
@@ -149,8 +149,7 @@ func (ic *importContext) refreshMounts() error {
 	}
 	// TODO: edit instance profile of a cluster in a loop
 	j, err := commandAPI.Execute(cluster.ClusterID, "python", `
-	import json
-	json.dumps({mp.replace('/mnt/', ''):source for mp, source, _ in dbutils.fs.mounts()})`)
+	import json; print(json.dumps({mp.replace('/mnt/', ''):source for mp, source, _ in dbutils.fs.mounts()}))`)
 	if err != nil {
 		return err
 	}

--- a/importer/util.go
+++ b/importer/util.go
@@ -149,7 +149,7 @@ func (ic *importContext) refreshMounts() error {
 	}
 	// TODO: edit instance profile of a cluster in a loop
 	j, err := commandAPI.Execute(cluster.ClusterID, "python", `
-	import json; print(json.dumps({mp.replace('/mnt/', ''):source for mp, source, _ in dbutils.fs.mounts()}))`)
+	import json; print(json.dumps({mp.replace('/mnt/', '').strip('/'):source for mp, source, _ in dbutils.fs.mounts() if mp.startswith('/mnt/')}))`)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Besides the addition of the test, this PR contains following changes:
* don't emit secrets for secret scopes baked by KeyVault
* initial implementation of importing of ADLSv1/v2 mounts
* Command-line flag to generate a declaration of Terraform provider