### PR TITLE
Ensure consistent slashes in notebook paths for different OSes

### DIFF
--- a/workspace/resource_notebook.go
+++ b/workspace/resource_notebook.go
@@ -236,7 +236,7 @@ func ResourceNotebook() *schema.Resource {
 			}
 			notebooksAPI := NewNotebooksAPI(ctx, c)
 			path := d.Get("path").(string)
-			parent := filepath.Dir(path)
+			parent := filepath.ToSlash(filepath.Dir(path))
 			if parent != "/" {
 				err = notebooksAPI.Mkdirs(parent)
 				if err != nil {


### PR DESCRIPTION
Adds `filepath.ToSlash` on the input to mkdir to ensure that path separator stays consistent over different OSes. On Windows systems it would be translated to `\` before sending the request to databricks, which isn't supported. 

Fixes #496 