### PR TITLE
Fixed formatting of URLs for notebooks and jobs

### DIFF
--- a/common/azure_auth.go
+++ b/common/azure_auth.go
@@ -48,11 +48,13 @@ type AzureAuth struct {
 	temporaryPat            *TokenResponse
 }
 
+// TokenRequest contains request
 type TokenRequest struct {
 	LifetimeSeconds int64  `json:"lifetime_seconds,omitempty"`
 	Comment         string `json:"comment,omitempty"`
 }
 
+// TokenResponse contains response
 type TokenResponse struct {
 	TokenValue string     `json:"token_value,omitempty"`
 	TokenInfo  *TokenInfo `json:"token_info,omitempty"`
@@ -288,10 +290,10 @@ func (aa *AzureAuth) ensureWorkspaceURL(ctx context.Context,
 		return err
 	}
 	// All azure endpoints typically end with a trailing slash removing it because resourceID starts with slash
-	managementResourceUrl := strings.TrimSuffix(env.ResourceManagerEndpoint, "/") + resourceID
+	managementResourceURL := strings.TrimSuffix(env.ResourceManagerEndpoint, "/") + resourceID
 	var workspace azureDatabricksWorkspace
 	resp, err := aa.databricksClient.genericQuery(ctx, http.MethodGet,
-		managementResourceUrl,
+		managementResourceURL,
 		map[string]string{
 			"api-version": "2018-04-01",
 		}, func(r *http.Request) error {

--- a/common/client.go
+++ b/common/client.go
@@ -236,3 +236,13 @@ func (c *DatabricksClient) configureHTTPCLient() {
 func (c *DatabricksClient) IsAzure() bool {
 	return c.AzureAuth.resourceID() != "" || strings.Contains(c.Host, "azuredatabricks.net")
 }
+
+// FormatURL creates URL from the client Host and additional strings
+func (c *DatabricksClient) FormatURL(strs ...string) string {
+	host := c.Host
+	if !strings.HasSuffix(host, "/") {
+		host += "/"
+	}
+	data := append([]string{host}, strs...)
+	return strings.Join(data, "")
+}

--- a/common/client_test.go
+++ b/common/client_test.go
@@ -151,3 +151,8 @@ func TestDatabricksClientConfigure_InvalidConfigFilePath(t *testing.T) {
 // 	})
 // 	assert.EqualError(t, err, ".")
 // }
+
+func TestDatabricksClient_FormatURL(t *testing.T) {
+	client := DatabricksClient{Host: "https://some.host"}
+	assert.Equal(t, "https://some.host/#job/123", client.FormatURL("#job/123"))
+}

--- a/compute/resource_cluster.go
+++ b/compute/resource_cluster.go
@@ -93,6 +93,10 @@ func resourceClusterSchema() map[string]*schema.Schema {
 			Default:          0,
 			ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(0)),
 		}
+		s["url"] = &schema.Schema{
+			Type:     schema.TypeString,
+			Computed: true,
+		}
 		return s
 	})
 }
@@ -180,6 +184,7 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, c *common.
 	if err = setPinnedStatus(d, clusterAPI); err != nil {
 		return err
 	}
+	d.Set("url", c.FormatURL("#setting/clusters/", d.Id(), "/configuration"))
 	librariesAPI := NewLibrariesAPI(ctx, c)
 	libsClusterStatus, err := waitForLibrariesInstalled(librariesAPI, clusterInfo)
 	if err != nil {

--- a/compute/resource_job.go
+++ b/compute/resource_job.go
@@ -197,7 +197,7 @@ func ResourceJob() *schema.Resource {
 			if err != nil {
 				return err
 			}
-			d.Set("url", fmt.Sprintf("%s#job/%s", c.Host, d.Id()))
+			d.Set("url", c.FormatURL("#job/", d.Id()))
 			return common.StructToData(*job.Settings, jobSchema, d)
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/identity/resource_group.go
+++ b/identity/resource_group.go
@@ -33,6 +33,7 @@ func ResourceGroup() *schema.Resource {
 		if err = d.Set("allow_instance_pool_create", isGroupInstancePoolCreateEntitled(&group)); err != nil {
 			return diag.FromErr(err)
 		}
+		d.Set("url", m.(*common.DatabricksClient).FormatURL("#setting/accounts/groups/", d.Id()))
 		return nil
 	}
 	return &schema.Resource{
@@ -131,6 +132,10 @@ func ResourceGroup() *schema.Resource {
 			"allow_instance_pool_create": {
 				Type:     schema.TypeBool,
 				Optional: true,
+			},
+			"url": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}

--- a/identity/scim.go
+++ b/identity/scim.go
@@ -132,6 +132,7 @@ const (
 	AllowSQLAnalyticsAccessEntitlement Entitlement = "sql-analytics-access"
 )
 
+// GroupsListItem contains information about group item
 type GroupsListItem struct {
 	// TODO: combine entitlementsListItem & roleListItem into this one
 	Display string `json:"display,omitempty"`

--- a/workspace/resource_notebook.go
+++ b/workspace/resource_notebook.go
@@ -3,7 +3,6 @@ package workspace
 import (
 	"context"
 	"encoding/base64"
-	"fmt"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -265,7 +264,7 @@ func ResourceNotebook() *schema.Resource {
 			if err != nil {
 				return err
 			}
-			d.Set("url", fmt.Sprintf("%s#workspace%s", c.Host, d.Id()))
+			d.Set("url", c.FormatURL("#workspace", d.Id()))
 			return common.StructToData(objectStatus, s, d)
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {


### PR DESCRIPTION
also: 
* added `url` field for clusters & groups.
* small cosmetic fixes to make linter happy