### PR TITLE
Ensure required fields in nested objects are set

### DIFF
--- a/common/reflect_resource.go
+++ b/common/reflect_resource.go
@@ -263,6 +263,7 @@ func collectionToMaps(v interface{}, s *schema.Schema) ([]interface{}, error) {
 			path []string, valueField *reflect.Value) error {
 			fieldName := path[len(path)-1]
 			fieldValue := valueField.Interface()
+			fieldPath := strings.Join(path, ".")
 			switch fieldSchema.Type {
 			case schema.TypeList, schema.TypeSet:
 				nv, err := collectionToMaps(fieldValue, fieldSchema)
@@ -271,7 +272,7 @@ func collectionToMaps(v interface{}, s *schema.Schema) ([]interface{}, error) {
 				}
 				data[fieldName] = nv
 			default:
-				if s, ok := fieldValue.(string); ok && s == "" {
+				if fieldSchema.Optional && isValueNilOrEmpty(valueField, fieldPath) {
 					return nil
 				}
 				data[fieldName] = fieldValue

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -169,6 +169,9 @@ type Address struct {
 	Line      string `json:"line" tf:"group:v"`
 	Lijn      string `json:"lijn" tf:"group:v"`
 	IsPrimary bool   `json:"primary"`
+
+	OptionalString string `json:"optional_string,omitempty"`
+	RequiredString string `json:"required_string"`
 }
 
 type Dummy struct {
@@ -352,6 +355,18 @@ func TestStructToData(t *testing.T) {
 	assert.Equal(t, "something", d.Get("description"))
 	assert.Equal(t, false, d.Get("enabled"))
 	assert.Equal(t, 2, d.Get("addresses.#"))
+
+	// Empty optional string should not be set.
+	{
+		_, ok := d.GetOkExists("addresses.0.optional_string")
+		assert.Falsef(t, ok, "Empty optional string should not be set in ResourceData")
+	}
+
+	// Empty required string should be set.
+	{
+		_, ok := d.GetOkExists("addresses.0.required_string")
+		assert.Truef(t, ok, "Empty required string should be set in ResourceData")
+	}
 
 	var dummyCopy Dummy
 	err = DataToStructPointer(d, s, &dummyCopy)

--- a/common/reflect_resource_test.go
+++ b/common/reflect_resource_test.go
@@ -358,12 +358,14 @@ func TestStructToData(t *testing.T) {
 
 	// Empty optional string should not be set.
 	{
+		// nolint: marked as deprecated, without viable alternative.
 		_, ok := d.GetOkExists("addresses.0.optional_string")
 		assert.Falsef(t, ok, "Empty optional string should not be set in ResourceData")
 	}
 
 	// Empty required string should be set.
 	{
+		// nolint: marked as deprecated, without viable alternative.
 		_, ok := d.GetOkExists("addresses.0.required_string")
 		assert.Truef(t, ok, "Empty required string should be set in ResourceData")
 	}


### PR DESCRIPTION
We have polymorphic parameters in SQLA queries. For `text` and `number` parameters, there isn't a whole lot to configure, except for the default value (which is differently typed, depending on the parameter type). If the default value isn't set (or is set to be empty), the whole type wrapper object isn't set, and no longer shows up in `*schema.ResourceData`. I'm fixing this by making the default value a required field.

However, if the value was empty, it still didn't show up in `*schema.ResourceData`. This was caused by the reflection code ignoring all empty strings in nested types, instead of checking the schema first, as is done for top level fields.

Intuitively, if a field is required, it should always show up in `*schema.ResourceData`.