### PR TITLE
Preparations for GCP support

### DIFF
--- a/common/client.go
+++ b/common/client.go
@@ -234,7 +234,17 @@ func (c *DatabricksClient) configureHTTPCLient() {
 
 // IsAzure returns true if client is configured for Azure Databricks - either by using AAD auth or with host+token combination
 func (c *DatabricksClient) IsAzure() bool {
-	return c.AzureAuth.resourceID() != "" || strings.Contains(c.Host, "azuredatabricks.net")
+	return c.AzureAuth.resourceID() != "" || strings.Contains(c.Host, ".azuredatabricks.net")
+}
+
+// IsAws returns true if client is configured for AWS
+func (c *DatabricksClient) IsAws() bool {
+	return !c.IsAzure() && !c.IsGcp()
+}
+
+// IsGcp returns true if client is configured for GCP
+func (c *DatabricksClient) IsGcp() bool {
+	return strings.Contains(c.Host, ".gcp.databricks.com")
 }
 
 // FormatURL creates URL from the client Host and additional strings

--- a/compute/common_instances.go
+++ b/compute/common_instances.go
@@ -53,7 +53,7 @@ func CommonInstancePoolID() string {
 
 			IdleInstanceAutoTerminationMinutes: 15,
 		}
-		if !client.IsAzure() {
+		if client.IsAws() {
 			instancePool.AwsAttributes = &InstancePoolAwsAttributes{
 				Availability: AwsAvailabilitySpot,
 			}

--- a/compute/resource_instance_pool_test.go
+++ b/compute/resource_instance_pool_test.go
@@ -30,7 +30,7 @@ func TestAccInstancePools(t *testing.T) {
 			sparkVersion,
 		},
 	}
-	if !client.IsAzure() {
+	if client.IsAws() {
 		pool.DiskSpec = &InstancePoolDiskSpec{
 			DiskType: &InstancePoolDiskType{
 				EbsVolumeType: EbsVolumeTypeGeneralPurposeSsd,

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -164,7 +164,7 @@ func (ic *importContext) refreshMounts() error {
 			ClusterID: cluster.ClusterID,
 		}
 	}
-	if !ic.Client.IsAzure() {
+	if ic.Client.IsAws() {
 		profiles, err := identity.NewInstanceProfilesAPI(ic.Context, ic.Client).List()
 		if err != nil {
 			return err


### PR DESCRIPTION
Added `IsGcp` & `IsAws` functions, changed relevant places when we have AWS specific functionality, etc.

