### PR TITLE
Fix incorrect escaping of special characters in URL query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version changelog
 
+## 0.3.2
+
+* Fix incorrect escaping of notebook names ([#566](https://github.com/databrickslabs/terraform-provider-databricks/pull/566))
+
 ## 0.3.1
 
 * Added `databricks_global_init_script` resource to configure global init scripts ([#487](https://github.com/databrickslabs/terraform-provider-databricks/issues/487)).

--- a/common/http.go
+++ b/common/http.go
@@ -483,8 +483,9 @@ func makeRequestBody(method string, requestURL *string, data interface{}, marsha
 				if v.IsZero() {
 					continue
 				}
-				s = append(s, fmt.Sprintf("%v=%s", k.Interface(),
-					url.PathEscape(fmt.Sprintf("%v", v.Interface()))))
+				s = append(s, fmt.Sprintf("%s=%s",
+					strings.Replace(url.QueryEscape(fmt.Sprintf("%v", k.Interface())), "+", "%20", -1),
+					strings.Replace(url.QueryEscape(fmt.Sprintf("%v", v.Interface())), "+", "%20", -1)))
 			}
 			*requestURL += "?" + strings.Join(s, "&")
 		case reflect.Struct:

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -268,7 +268,7 @@ func TestImportingUsersGroupsSecretScopes(t *testing.T) {
 			},
 			{
 				Method:   "GET",
-				Resource: "/api/2.0/preview/scim/v2/Users?filter=userName%20eq%20%27test@test.com%27",
+				Resource: "/api/2.0/preview/scim/v2/Users?filter=userName%20eq%20%27test%40test.com%27",
 				Response: identity.UserList{
 					Resources: []identity.ScimUser{
 						{ID: "123", DisplayName: "test@test.com", UserName: "test@test.com"},
@@ -444,7 +444,7 @@ func TestImportingClusters(t *testing.T) {
 			},
 			{
 				Method:       "GET",
-				Resource:     "/api/2.0/dbfs/get-status?path=dbfs:%2FFileStore%2Fjars%2Ftest.jar",
+				Resource:     "/api/2.0/dbfs/get-status?path=dbfs%3A%2FFileStore%2Fjars%2Ftest.jar",
 				ReuseRequest: true,
 				Response:     getJSONObject("test-data/get-dbfs-library-status.json"),
 			},
@@ -588,7 +588,7 @@ func TestImportingJobs_JobList(t *testing.T) {
 			},
 			{
 				Method:       "GET",
-				Resource:     "/api/2.0/dbfs/get-status?path=dbfs:%2FFileStore%2Fjars%2Ftest.jar",
+				Resource:     "/api/2.0/dbfs/get-status?path=dbfs%3A%2FFileStore%2Fjars%2Ftest.jar",
 				ReuseRequest: true,
 				Response:     getJSONObject("test-data/get-dbfs-library-status.json"),
 			},


### PR DESCRIPTION
The root cause is that for URL query parts the path escaping was applied that didn't escape the `&` character, so query was split incorrectly

This fixes #565