### PR TITLE
added support for job to have pause_status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Fix incorrect escaping of notebook names ([#566](https://github.com/databrickslabs/terraform-provider-databricks/pull/566))
 * Added support for spot instances on Azure ([#571](https://github.com/databrickslabs/terraform-provider-databricks/pull/571))
 
+**Behavior changes**
+
+* Job schedules now have their schedule configuration block to support pause_status as a optional field. ([#575](https://github.com/databrickslabs/terraform-provider-databricks/pull/575))
+
 ## 0.3.1
 
 * Added `databricks_global_init_script` resource to configure global init scripts ([#487](https://github.com/databrickslabs/terraform-provider-databricks/issues/487)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,7 @@
 
 * Fix incorrect escaping of notebook names ([#566](https://github.com/databrickslabs/terraform-provider-databricks/pull/566))
 * Added support for spot instances on Azure ([#571](https://github.com/databrickslabs/terraform-provider-databricks/pull/571))
-
-**Behavior changes**
-
-* Job schedules now have their schedule configuration block to support pause_status as a optional field. ([#575](https://github.com/databrickslabs/terraform-provider-databricks/pull/575))
+* Job schedules support pause_status as a optional field. ([#575](https://github.com/databrickslabs/terraform-provider-databricks/pull/575))
 
 ## 0.3.1
 

--- a/compute/model.go
+++ b/compute/model.go
@@ -520,7 +520,7 @@ type JobEmailNotifications struct {
 type CronSchedule struct {
 	QuartzCronExpression string `json:"quartz_cron_expression"`
 	TimezoneID           string `json:"timezone_id"`
-	PauseStatus          string `json:"pause_status,omitempty" tf:"computed"`
+	PauseStatus          string `json:"pause_status,omitempty"`
 }
 
 // JobSettings contains the information for configuring a job on databricks

--- a/compute/model.go
+++ b/compute/model.go
@@ -520,7 +520,7 @@ type JobEmailNotifications struct {
 type CronSchedule struct {
 	QuartzCronExpression string `json:"quartz_cron_expression"`
 	TimezoneID           string `json:"timezone_id"`
-	PauseStatus          string `json:"pause_status,omitempty"`
+	PauseStatus          string `json:"pause_status,omitempty" tf:"computed"`
 }
 
 // JobSettings contains the information for configuring a job on databricks

--- a/compute/resource_job.go
+++ b/compute/resource_job.go
@@ -115,6 +115,14 @@ var jobSchema = common.StructToSchema(JobSettings{},
 			p.Required = false
 		}
 
+		if p, err := common.SchemaPath(s, "schedule", "pause_status"); err == nil {
+			p.Optional = true
+			p.Computed = true
+			p.Type = schema.TypeString
+			p.Required = false
+			p.ValidateFunc = validation.StringInSlice([]string{"PAUSED", "UNPAUSED"}, false)
+		}
+
 		if v, err := common.SchemaPath(s, "new_cluster", "spark_conf"); err == nil {
 			v.DiffSuppressFunc = func(k, old, new string, d *schema.ResourceData) bool {
 				isPossiblyLegacyConfig := "new_cluster.0.spark_conf.%" == k && "1" == old && "0" == new

--- a/compute/resource_job.go
+++ b/compute/resource_job.go
@@ -116,10 +116,6 @@ var jobSchema = common.StructToSchema(JobSettings{},
 		}
 
 		if p, err := common.SchemaPath(s, "schedule", "pause_status"); err == nil {
-			p.Optional = true
-			p.Computed = true
-			p.Type = schema.TypeString
-			p.Required = false
 			p.ValidateFunc = validation.StringInSlice([]string{"PAUSED", "UNPAUSED"}, false)
 		}
 

--- a/compute/resource_job_test.go
+++ b/compute/resource_job_test.go
@@ -31,6 +31,11 @@ func TestResourceJobCreate(t *testing.T) {
 							Jar: "dbfs://aa/bb/cc.jar",
 						},
 					},
+					Schedule: &CronSchedule{
+						QuartzCronExpression: "0 15 22 ? * *",
+						TimezoneID:           "America/Los_Angeles",
+						PauseStatus:          "PAUSED",
+					},
 					Name:                   "Featurizer",
 					MaxRetries:             3,
 					MinRetryIntervalMillis: 5000,
@@ -64,6 +69,11 @@ func TestResourceJobCreate(t *testing.T) {
 						MinRetryIntervalMillis: 5000,
 						RetryOnTimeout:         true,
 						MaxConcurrentRuns:      1,
+						Schedule: &CronSchedule{
+							QuartzCronExpression: "0 15 22 ? * *",
+							TimezoneID:           "America/Los_Angeles",
+							PauseStatus:          "PAUSED",
+						},
 					},
 				},
 			},
@@ -76,7 +86,11 @@ func TestResourceJobCreate(t *testing.T) {
 		min_retry_interval_millis = 5000
 		name = "Featurizer"
 		retry_on_timeout = true
-
+		schedule {
+			quartz_cron_expression = "0 15 22 ? * *"
+			timezone_id = "America/Los_Angeles"
+			pause_status = "PAUSED"
+		}
 		spark_jar_task {
 			main_class_name = "com.labs.BarMain"
 		}

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -69,7 +69,7 @@ The following arguments are required:
 
 * `quartz_cron_expression` - (Required) A [Cron expression using Quartz syntax](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html) that describes the schedule for a job. This field is required.
 * `timezone_id` - (Required) A Java timezone ID. The schedule for a job will be resolved with respect to this timezone. See Java TimeZone for details. This field is required.
-* `pause_status` - (Optional) Indicate whether this schedule is paused or not. Either “PAUSED” or “UNPAUSED”.
+* `pause_status` - (Optional) Indicate whether this schedule is paused or not. Either “PAUSED” or “UNPAUSED”. When the pause_status field is omitted and a schedule is provided, the server will default to using "UNPAUSED" as a value for pause_status.
 
 ### spark_jar_task Configuration Block
 

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -69,6 +69,7 @@ The following arguments are required:
 
 * `quartz_cron_expression` - (Required) A [Cron expression using Quartz syntax](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html) that describes the schedule for a job. This field is required.
 * `timezone_id` - (Required) A Java timezone ID. The schedule for a job will be resolved with respect to this timezone. See Java TimeZone for details. This field is required.
+* `pause_status` - (Optional) Indicate whether this schedule is paused or not. Either “PAUSED” or “UNPAUSED”.
 
 ### spark_jar_task Configuration Block
 


### PR DESCRIPTION
Changed pause_status from the schedule config block in jobs to a optional+computed field rather than a computed field (least amount of disruption to existing state). 
(Users can choose to omit it if the do not want terraform to nitpick that it has changed. Changing it to just optional will give the behavior of always tracking state and always must be managed by terraform.)