### PR TITLE
Fix the HTTP request rate limiter

### DIFF
--- a/common/client.go
+++ b/common/client.go
@@ -198,7 +198,7 @@ func (c *DatabricksClient) configureHTTPCLient() {
 	if c.RateLimitPerSecond == 0 {
 		c.RateLimitPerSecond = DefaultRateLimitPerSecond
 	}
-	c.rateLimiter = rate.NewLimiter(rate.Every(1*time.Second), c.RateLimitPerSecond)
+	c.rateLimiter = rate.NewLimiter(rate.Limit(c.RateLimitPerSecond), 1)
 	// Set up a retryable HTTP Client to handle cases where the service returns
 	// a transient error on initial creation
 	retryDelayDuration := 10 * time.Second


### PR DESCRIPTION
The rate limiter was initialized with a maximum of 1 request per second with a
burst size of `RateLimitPerSecond`. Because we only use the `limiter.Wait()`
API, we can fix the burst at 1.