### PR TITLE
More verbose logging of termination reason

### DIFF
--- a/compute/clusters.go
+++ b/compute/clusters.go
@@ -181,6 +181,11 @@ func (a ClustersAPI) waitForClusterStatus(clusterID string, desired ClusterState
 		}
 		if !clusterInfo.State.CanReach(desired) {
 			docLink := "https://docs.databricks.com/dev-tools/api/latest/clusters.html#clusterclusterstate"
+			if clusterInfo.TerminationReason != nil {
+				log.Printf("[DEBUG] Cluster %s termination info: code: %s, type: %s, parameters: %v",
+					clusterID, clusterInfo.TerminationReason.Code, clusterInfo.TerminationReason.Type,
+					clusterInfo.TerminationReason.Parameters)
+			}
 			return resource.NonRetryableError(fmt.Errorf(
 				"%s is not able to transition from %s to %s: %s. Please see %s for more details",
 				clusterID, clusterInfo.State, desired, clusterInfo.StateMessage, docLink))

--- a/compute/clusters_test.go
+++ b/compute/clusters_test.go
@@ -223,6 +223,8 @@ func TestWaitForClusterStatus_NotReachable(t *testing.T) {
 			Response: ClusterInfo{
 				State:        ClusterStateUnknown,
 				StateMessage: "Something strange is going on",
+				TerminationReason: &TerminationReason{Code: "unknown", Type: "broken",
+					Parameters: map[string]string{"abc": "def"}},
 			},
 		},
 	})


### PR DESCRIPTION
This would help with debugging in cases when cluster can't start for some reason, such as provider error.   Existing debugging doesn't help because `ClusterInfo.StateMessage` doesn't include full error message