### PR TITLE
apply debug_truncate_bytes also for response dumps

### DIFF
--- a/common/http.go
+++ b/common/http.go
@@ -390,7 +390,11 @@ func (c *DatabricksClient) redactedDump(body []byte) (res string) {
 		// error in this case is not much relevant
 		return
 	}
-	return onlyNBytes(string(rePacked), 1024)
+	maxBytes := 1024
+	if c.DebugTruncateBytes > maxBytes {
+		maxBytes = c.DebugTruncateBytes
+	}
+	return onlyNBytes(string(rePacked), maxBytes)
 }
 
 func (c *DatabricksClient) userAgent(ctx context.Context) string {

--- a/compute/clusters.go
+++ b/compute/clusters.go
@@ -181,14 +181,15 @@ func (a ClustersAPI) waitForClusterStatus(clusterID string, desired ClusterState
 		}
 		if !clusterInfo.State.CanReach(desired) {
 			docLink := "https://docs.databricks.com/dev-tools/api/latest/clusters.html#clusterclusterstate"
+			details := ""
 			if clusterInfo.TerminationReason != nil {
-				log.Printf("[DEBUG] Cluster %s termination info: code: %s, type: %s, parameters: %v",
-					clusterID, clusterInfo.TerminationReason.Code, clusterInfo.TerminationReason.Type,
+				details = fmt.Sprintf(", Termination info: code: %s, type: %s, parameters: %v",
+					clusterInfo.TerminationReason.Code, clusterInfo.TerminationReason.Type,
 					clusterInfo.TerminationReason.Parameters)
 			}
 			return resource.NonRetryableError(fmt.Errorf(
-				"%s is not able to transition from %s to %s: %s. Please see %s for more details",
-				clusterID, clusterInfo.State, desired, clusterInfo.StateMessage, docLink))
+				"%s is not able to transition from %s to %s: %s%s. Please see %s for more details",
+				clusterID, clusterInfo.State, desired, clusterInfo.StateMessage, details, docLink))
 		}
 		return resource.RetryableError(
 			fmt.Errorf("%s is %s, but has to be %s",

--- a/compute/clusters_test.go
+++ b/compute/clusters_test.go
@@ -236,7 +236,8 @@ func TestWaitForClusterStatus_NotReachable(t *testing.T) {
 	ctx := context.Background()
 	_, err = NewClustersAPI(ctx, client).waitForClusterStatus("abc", ClusterStateRunning)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "abc is not able to transition from UNKNOWN to RUNNING: Something strange is going on.")
+	assert.Contains(t, err.Error(), "abc is not able to transition from UNKNOWN to RUNNING: Something strange is going on")
+	assert.Contains(t, err.Error(), "code: unknown, type: broken")
 }
 
 func TestWaitForClusterStatus_NormalRetry(t *testing.T) {


### PR DESCRIPTION
also, reworked the reporting of termination information