### PR TITLE
Include data source ID in the endpoint state

### DIFF
--- a/docs/resources/sql_endpoint.md
+++ b/docs/resources/sql_endpoint.md
@@ -46,6 +46,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `jdbc_url` - JDBC connection string.
 * `odbc_params` - ODBC connection params: `odbc_params.host`, `odbc_params.path`, `odbc_params.protocol`, and `odbc_params.port`.
+* `data_source_id` - ID of the data source for this endpoint. This is used to bind an SQLA query to an endpoint.
 
 ## Access Control
 

--- a/sqlanalytics/resource_sql_endpoint_test.go
+++ b/sqlanalytics/resource_sql_endpoint_test.go
@@ -2,6 +2,7 @@ package sqlanalytics
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"testing"
 	"time"
@@ -44,6 +45,26 @@ func TestPreviewAccSQLEndpoints(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// Define fixture for retrieving all data sources.
+// Shared between tests that end up performing a read operation.
+var dataSourceListHTTPFixture = qa.HTTPFixture{
+	Method:       "GET",
+	Resource:     "/api/2.0/preview/sql/data_sources",
+	ReuseRequest: true,
+	Response: json.RawMessage(`
+		[
+			{
+				"id": "2f47f0f9-b4b7-40e2-b130-43103151864c",
+				"endpoint_id": "def"
+			},
+			{
+				"id": "d7c9d05c-7496-4c69-b089-48823edad40c",
+				"endpoint_id": "abc"
+			}
+		]
+	`),
+}
+
 func TestResourceSQLEndpointCreate(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
@@ -71,6 +92,7 @@ func TestResourceSQLEndpointCreate(t *testing.T) {
 					MaxNumClusters: 1,
 				},
 			},
+			dataSourceListHTTPFixture,
 		},
 		Resource: ResourceSQLEndpoint(),
 		Create:   true,
@@ -81,6 +103,7 @@ func TestResourceSQLEndpointCreate(t *testing.T) {
 	}.Apply(t)
 	require.NoError(t, err, err)
 	assert.Equal(t, "abc", d.Id(), "Id should not be empty")
+	assert.Equal(t, "d7c9d05c-7496-4c69-b089-48823edad40c", d.Get("data_source_id"))
 }
 
 func TestResourceSQLEndpointCreate_ErrorDisabled(t *testing.T) {
@@ -124,6 +147,7 @@ func TestResourceSQLEndpointRead(t *testing.T) {
 					State:       "RUNNING",
 				},
 			},
+			dataSourceListHTTPFixture,
 		},
 		Resource: ResourceSQLEndpoint(),
 		ID:       "abc",
@@ -135,6 +159,7 @@ func TestResourceSQLEndpointRead(t *testing.T) {
 	}.Apply(t)
 	require.NoError(t, err, err)
 	assert.Equal(t, "abc", d.Id(), "Id should not be empty")
+	assert.Equal(t, "d7c9d05c-7496-4c69-b089-48823edad40c", d.Get("data_source_id"))
 }
 
 func TestResourceSQLEndpointUpdate(t *testing.T) {
@@ -161,6 +186,7 @@ func TestResourceSQLEndpointUpdate(t *testing.T) {
 					State:       "RUNNING",
 				},
 			},
+			dataSourceListHTTPFixture,
 		},
 		Resource: ResourceSQLEndpoint(),
 		ID:       "abc",
@@ -172,6 +198,7 @@ func TestResourceSQLEndpointUpdate(t *testing.T) {
 	}.Apply(t)
 	require.NoError(t, err, err)
 	assert.Equal(t, "abc", d.Id(), "Id should not be empty")
+	assert.Equal(t, "d7c9d05c-7496-4c69-b089-48823edad40c", d.Get("data_source_id"))
 }
 
 func TestResourceSQLEndpointDelete(t *testing.T) {


### PR DESCRIPTION
The data source ID is needed to bind a SQLA query to an endpoint. It is not included in the API's endpoint payload. There is a 1:1 mapping between endpoints and data sources, so we can include it in the endpoint's state.

I verified the acceptance test with:
```
CLOUD_ENV=aws TF_LOG=debug go test -run ^TestPreviewAccSQLEndpoint$ -v github.com/databrickslabs/terraform-provider-databricks/sqlanalytics/acceptance
```

It already failed before this PR because of defaults that are populated by the API (see #600). If fails in the same way with this PR, which reasonably implies that this PR didn't affect it.