### PR TITLE
Add 0.3.3 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Version changelog
 
+## 0.3.3
+
+* Added `databricks_sql_permissions` resource ([#545](https://github.com/databrickslabs/terraform-provider-databricks/pull/545/files))
+* Fixed documentation bugs ([#603](https://github.com/databrickslabs/terraform-provider-databricks/issues/603))
+* Improved resource exporter ([#593](https://github.com/databrickslabs/terraform-provider-databricks/issues/593))
+* Added missing properties to `databricks_mws_private_access_settings` ([#590](https://github.com/databrickslabs/terraform-provider-databricks/issues/590))
+* Include SQLA data source ID in `databricks_sql_endpoint` state ([#601](https://github.com/databrickslabs/terraform-provider-databricks/issues/601))
+* Apply `debug_truncate_bytes` also for response dumps ([#589](https://github.com/databrickslabs/terraform-provider-databricks/issues/589))
+* More verbose logging of `databricks_cluster` termination reason ([#588](https://github.com/databrickslabs/terraform-provider-databricks/issues/588))
+* Move non-auth provider config documentation into separate section ([#587](https://github.com/databrickslabs/terraform-provider-databricks/pull/587))
+
+
 ## 0.3.2
 
 * Fixed minor issues to add support for GCP ([#558](https://github.com/databrickslabs/terraform-provider-databricks/pull/558))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.3
 
+* Added resources for SQL Analytics queries and dashboards: `databricks_sql_query`, `databricks_sql_visualization`, `databricks_sql_dashboard`, `databricks_sql_widget` ([#553](https://github.com/databrickslabs/terraform-provider-databricks/pull/553))
 * Added `databricks_sql_permissions` resource ([#545](https://github.com/databrickslabs/terraform-provider-databricks/pull/545/files))
 * Fixed documentation bugs ([#603](https://github.com/databrickslabs/terraform-provider-databricks/issues/603))
 * Improved resource exporter ([#593](https://github.com/databrickslabs/terraform-provider-databricks/issues/593))

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 | [databricks_secret_acl](docs/resources/secret_acl.md)
 | [databricks_secret_scope](docs/resources/secret_scope.md)
 | [databricks_sql_endpoint](docs/resources/sql_endpoint.md)
+| [databricks_sql_permissions](docs/resources/sql_permissions.md)
 | [databricks_spark_version](docs/data-sources/spark_version.md) data
 | [databricks_sql_permissions](docs/resources/sql_permissions.md)
 | [databricks_token](docs/resources/token.md)

--- a/docs/resources/mws_networks.md
+++ b/docs/resources/mws_networks.md
@@ -64,13 +64,14 @@ resource "databricks_mws_networks" "this" {
 
 ## Argument Reference
 
-The following arguments are required:
+The following arguments are available:
 
 * `account_id` - Account Id that could be found in the bottom left corner of [Accounts Console](https://accounts.cloud.databricks.com/)
 * `network_name` - name under which this network is regisstered
 * `vpc_id` - [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) id
 * `subnet_ids` - ids of [aws_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet)
 * `security_group_ids` - ids of [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group)
+* `vpc_endpoints` (Optional) - mapping of [databricks_mws_vpc_endpoint](mws_vpc_endpoint.md) for PrivateLink connections
 
 ## Attribute Reference
 

--- a/docs/resources/mws_private_access_settings.md
+++ b/docs/resources/mws_private_access_settings.md
@@ -1,0 +1,34 @@
+---
+subcategory: "AWS"
+---
+# databricks_mws_private_access_settings Resource
+
+-> **Public Preview** This feature is in [Public Preview](https://docs.databricks.com/release-notes/release-types.html). Contact your Databricks representative to request access. 
+
+-> **Note** This resource has an evolving API, which will change in the upcoming versions of the provider in order to simplify user experience.
+
+## Example Usage
+
+```hcl
+resource "databricks_mws_private_access_settings" "pas" {
+  account_id                   = var.databricks_account_id
+  private_access_settings_name = "Private Access Settings for ${aws_vpc.main.id}"
+  region                       = local.region
+}
+```
+
+## Argument Reference
+
+The following arguments are available:
+
+* `account_id` - Account Id that could be found in the bottom left corner of [Accounts Console](https://accounts.cloud.databricks.com/)
+* `private_access_settings_name` - Name of Private Access Settings in Databricks Account
+* `public_access_enabled` (Boolean, Optional, `false` by default) - If `true`, the [databricks_mws_workspaces](mws_workspaces.md) can be accessed over the [databricks_mws_vpc_endpoint](mws_vpc_endpoint.md) as well as over the public network. In such a case, you could also configure an [databricks_ip_access_list](ip_access_list.md) for the workspace, to restrict the source networks that could be used to access it over the public network. If `false` (default), the workspace can be accessed only over VPC endpoints, and not over the public network.
+* `region` - Region of AWS VPC
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `private_access_settings_id` - Canonical unique identifier of Private Access Settings in Databricks Account
+* `status` - Status of Private Access Settings

--- a/docs/resources/mws_vpc_endpoint.md
+++ b/docs/resources/mws_vpc_endpoint.md
@@ -1,0 +1,60 @@
+---
+subcategory: "AWS"
+---
+# databricks_mws_vpc_endpoint Resource
+
+-> **Public Preview** This feature is in [Public Preview](https://docs.databricks.com/release-notes/release-types.html). Contact your Databricks representative to request access. 
+
+Connects [aws_vpc_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) with [databricks_mws_networks](mws_networks.md) through PrivateLink.
+
+## Example Usage
+
+-> **Note** This resource has an evolving API, which will change in the upcoming versions of the provider in order to simplify user experience.
+
+```hcl
+resource "aws_vpc_endpoint" "relay" {
+  service_name       = local.private_link.relay_endpoint
+  vpc_id             = aws_vpc.main.id
+  vpc_endpoint_type  = "Interface"
+  security_group_ids = [aws_security_group.this.id]
+  subnet_ids         = [aws_subnet.databricks_endpoints.id]
+  tags = {
+    "Name" = "${var.workspace_name}-databricks-relay"
+  }
+}
+
+resource "databricks_mws_vpc_endpoint" "relay" {
+  account_id          = var.databricks_account_id
+  aws_vpc_endpoint_id = aws_vpc_endpoint.relay.id
+  vpc_endpoint_name   = "VPC Relay for ${aws_vpc.main.id}"
+  region              = local.region
+}
+
+resource "databricks_mws_networks" "this" {
+  # ...
+
+  vpc_endpoints {
+    dataplane_relay = [databricks_mws_vpc_endpoint.relay.vpc_endpoint_id]
+
+    # rest_api VPC endpoint is created in a similar way
+    rest_api = [databricks_mws_vpc_endpoint.rest.vpc_endpoint_id]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `account_id` - Account Id that could be found in the bottom left corner of [Accounts Console](https://accounts.cloud.databricks.com/)
+* `aws_vpc_endpoint_id` - ID of configured [aws_vpc_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint)
+* `vpc_endpoint_name` - Name of VPC Endpoint in Databricks Account
+* `aws_endpoint_service_id` - ID of Databricks VPC endpoint service to connect to. Please contact your Databricks representative to request mapping
+* `region` - Region of AWS VPC
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `vpc_endpoint_id` - Canonical unique identifier of VPC Endpoint in Databricks Account
+* `state` - State of VPC Endpoint


### PR DESCRIPTION
azcli
---

 * [x] access.TestAccIPACL (12.21s)
 * [x] access.TestAccPermissionsClusterPolicy (17.22s)
 * [x] access.TestAccPermissionsClusters (639.27s)
 * [x] access.TestAccPermissionsInstancePool (19.28s)
 * [x] access.TestAccPermissionsJobs (15.66s)
 * [x] access.TestAccPermissionsNotebooks (17.67s)
 * [x] access.TestAccPermissionsTokens (14.50s)
 * [x] access/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (56.68s)
 * [x] access/acceptance.TestAccInitialManagePrincipals (3.89s)
 * [x] access/acceptance.TestAccInitialManagePrincipalsGroup (2.83s)
 * [x] access/acceptance.TestAccSecretAclResource (18.85s)
 * [x] access/acceptance.TestAccSecretAclResourceDefaultPrincipal (14.68s)
 * [x] access/acceptance.TestAccSecretResource (19.06s)
 * [x] access/acceptance.TestAccSecretScopeResource (20.90s)
 * [x] access/acceptance.TestAccTableACL (622.02s)
 * [x] access/acceptance.TestAzureAccKeyVaultSimple (4.60s)
 * [x] compute.TestAccContext (52.89s)
 * [x] compute.TestAccInstancePools (5.04s)
 * [x] compute.TestAccLibraryCreate (59.84s)
 * [x] compute.TestAccListClustersIntegration (556.40s)
 * [x] compute.TestAzureAccNodeTypes (1.38s)
 * [x] compute/acceptance.TestAccClusterPolicyResourceFullLifecycle (30.23s)
 * [x] compute/acceptance.TestAccJobResource (11.55s)
 * [x] identity.TestAccCreateToken (3.81s)
 * [x] identity.TestAccCreateToken_NoExpiration (3.80s)
 * [x] identity.TestAccCreateUser (10.91s)
 * [x] identity.TestAccFilterGroup (3.55s)
 * [x] identity.TestAccGroup (30.85s)
 * [x] identity.TestAccReadUser (4.16s)
 * [x] identity.TestAzureAccSP (9.46s)
 * [x] identity/acceptance.TestAccGroupMemberResource (33.22s)
 * [x] identity/acceptance.TestAccGroupResource (36.51s)
 * [x] identity/acceptance.TestAccGroupResource_verify_entitlements (21.80s)
 * [x] identity/acceptance.TestAccTokenResource (13.76s)
 * [x] identity/acceptance.TestAccUserResource (25.25s)
 * [x] identity/acceptance.TestAzureAccServicePrincipalResource (25.89s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace (7.71s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies (0.75s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies_Delete (0.73s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Clusters (0.59s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/DBFS_Files (0.94s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Groups (0.61s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Instance_Pools (0.41s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Jobs (0.50s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Notebooks (0.50s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_ACLs (0.59s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_Scopes (0.43s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secrets (0.42s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Tokens (0.73s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Users (0.51s)
 * [x] internal/sanity.TestAccMutiworkspaceUsedFromNormalMode (16.02s)
 * [x] storage.TestAccCreateFile (4.93s)
 * [x] storage.TestAccDeleteInvalidMountFails (6.84s)
 * [x] storage.TestAccInvalidSecretScopeFails (9.99s)
 * [x] storage.TestAccSourceOnInvalidMountFails (34.31s)
 * [x] storage.TestAzureAccBlobMount (163.20s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (15.98s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (7.84s)
 * [x] storage/acceptance.TestAzureAccBlobMount_correctly_mounts (694.18s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (16.95s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (21.63s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (10.75s)

awsmt
---
 * [x] TestAccClusterResource_CreateClusterWithLibraries (229.22s)
 * [x] TestAwsAccS3IamMount_NoClusterGiven (1.77s)
 * [x] access.TestAccIPACL (3.05s)
 * [x] access.TestAccPermissionsClusterPolicy (15.05s)
 * [x] access.TestAccPermissionsClusters (194.35s)
 * [x] access.TestAccPermissionsInstancePool (15.70s)
 * [x] access.TestAccPermissionsJobs (16.31s)
 * [x] access.TestAccPermissionsNotebooks (16.97s)
 * [x] access.TestAccPermissionsTokens (15.02s)
 * [x] access/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (42.86s)
 * [x] access/acceptance.TestAccInitialManagePrincipals (3.40s)
 * [x] access/acceptance.TestAccInitialManagePrincipalsGroup (2.07s)
 * [x] access/acceptance.TestAccSecretAclResource (14.89s)
 * [x] access/acceptance.TestAccSecretAclResourceDefaultPrincipal (5.79s)
 * [x] access/acceptance.TestAccSecretResource (5.21s)
 * [x] access/acceptance.TestAccSecretScopeResource (8.16s)
 * [x] access/acceptance.TestAccTableACL (444.30s)
 * [x] compute.TestAccContext (104.43s)
 * [x] compute.TestAccInstancePools (2.30s)
 * [x] compute.TestAccLibraryCreate (143.57s)
 * [x] compute.TestAccListClustersIntegration (191.18s)
 * [x] compute.TestAwsAccSmallestNodeType (0.20s)
 * [x] compute/acceptance.TestAccClusterPolicyResourceFullLifecycle (12.39s)
 * [x] compute/acceptance.TestAccClusterResource_CreateSingleNodeCluster (56.34s)
 * [x] compute/acceptance.TestAccJobResource (3.78s)
 * [x] compute/acceptance.TestAwsAccJobResource_NoInstancePool (2.99s)
 * [x] compute/acceptance.TestAwsAccJobsCreate (2.10s)
 * [x] identity.TestAccCreateToken (0.78s)
 * [x] identity.TestAccCreateToken_NoExpiration (0.44s)
 * [x] identity.TestAccCreateUser (9.25s)
 * [x] identity.TestAccFilterGroup (1.76s)
 * [x] identity.TestAccGroup (25.36s)
 * [x] identity.TestAccReadUser (2.09s)
 * [x] identity.TestAwsAccInstanceProfiles (313.90s)
 * [x] identity/acceptance.TestAccGroupMemberResource (23.73s)
 * [x] identity/acceptance.TestAccGroupResource (19.39s)
 * [x] identity/acceptance.TestAccGroupResource_verify_entitlements (14.20s)
 * [x] identity/acceptance.TestAccTokenResource (3.76s)
 * [x] identity/acceptance.TestAccUserResource (15.95s)
 * [x] identity/acceptance.TestAwsAccGroupInstanceProfileResource (331.44s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace (8.48s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies (0.40s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies_Delete (0.79s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Clusters (0.65s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/DBFS_Files (0.97s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Groups (1.05s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Instance_Pools (0.47s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Instance_Profiles (0.78s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Jobs (0.76s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Notebooks (0.50s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_ACLs (0.16s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_Scopes (0.66s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secrets (0.39s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Tokens (0.75s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Users (0.15s)
 * [x] internal/sanity.TestAccMutiworkspaceUsedFromNormalMode (1.27s)
 * [x] storage.TestAccCreateFile (3.68s)
 * [x] storage.TestAccDeleteInvalidMountFails (4.39s)
 * [x] storage.TestAccInvalidSecretScopeFails (3.94s)
 * [x] storage.TestAccSourceOnInvalidMountFails (31.89s)
 * [x] storage.TestAwsAccS3Mount (332.88s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (7.70s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (2.87s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (6.73s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (8.34s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (5.27s)

