### PR TITLE
chore(docs): fix link to point to correct path

### DIFF
--- a/docs/resources/instance_pool.md
+++ b/docs/resources/instance_pool.md
@@ -46,7 +46,7 @@ The following arguments are required:
 * `custom_tags` - (Optional) (Map) Additional tags for instance pool resources. Databricks tags all pool resources (e.g. AWS & Azure instances and Disk volumes). *Databricks allows at most 43 custom tags.*
 * `enable_elastic_disk` - (Optional) (Bool) Autoscaling Local Storage: when enabled, the instances in the pool dynamically acquire additional disk space when they are running low on disk space.
 
-* `preloaded_spark_versions` - (Optional) (List) A list with the runtime version the pool installs on each instance. Pool clusters that use a preloaded runtime version start faster as they do have to wait for the image to download.  You can retrieve them via [databricks_spark_version](../data-source/spark-version.md) data source or via  [Runtime Versions API](https://docs.databricks.com/dev-tools/api/latest/clusters.html#clusterclusterservicelistsparkversions) call.
+* `preloaded_spark_versions` - (Optional) (List) A list with the runtime version the pool installs on each instance. Pool clusters that use a preloaded runtime version start faster as they do have to wait for the image to download.  You can retrieve them via [databricks_spark_version](../data-sources/spark-version.md) data source or via  [Runtime Versions API](https://docs.databricks.com/dev-tools/api/latest/clusters.html#clusterclusterservicelistsparkversions) call.
 
 ### aws_attributes Configuration Block
 


### PR DESCRIPTION
Minor change, fixes a link in the docs to go to the correct link. Looking through git history, doesn't look like `data-source` ever existed as a directory under `docs`, so probably just a spelling mistake.