### PR TITLE
patch the entitlements to support allow_workspace_access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version changelog
 
+## 0.3.4
+
+* Added entitlement for `allow_workspace_access` resources: `databricks_group` and `databricks_user` [#633](https://github.com/databrickslabs/terraform-provider-databricks/pull/633)
+
 ## 0.3.3
 
 * Added resources for SQL Analytics queries and dashboards: `databricks_sql_query`, `databricks_sql_visualization`, `databricks_sql_dashboard`, `databricks_sql_widget` ([#553](https://github.com/databrickslabs/terraform-provider-databricks/pull/553))

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -50,6 +50,7 @@ The following arguments are supported:
 * `allow_cluster_create` -  (Optional) This is a field to allow the group to have [cluster](cluster.md) create privileges. More fine grained permissions could be assigned with [databricks_permissions](permissions.md#Cluster-usage) and [cluster_id](permissions.md#cluster_id) argument. Everyone without `allow_cluster_create` argument set, but with [permission to use](permissions.md#Cluster-Policy-usage) Cluster Policy would be able to create clusters, but within boundaries of that specific policy.
 * `allow_instance_pool_create` -  (Optional) This is a field to allow the group to have [instance pool](instance_pool.md) create privileges. More fine grained permissions could be assigned with [databricks_permissions](permissions.md#Instance-Pool-usage) and [instance_pool_id](permissions.md#instance_pool_id) argument.
 * `allow_sql_analytics_access` - (Optional) This is a field to allow the group to have access to [SQL Analytics](https://databricks.com/product/sql-analytics) feature through [databricks_sql_endpoint](sql_endpoint.md).
+* `allow_workspace_access` - (Optional) This is a field to allow the group to have access to the [Dataricks workspace](https://docs.databricks.com/workspace/index.html).
 
 ## Attribute Reference
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -50,7 +50,8 @@ The following arguments are available:
 * `display_name` - (Optional) This is an alias for the username that can be the full name of the user.
 * `allow_cluster_create` -  (Optional) Allow the user to have [cluster](cluster.md) create privileges. Defaults to false. More fine grained permissions could be assigned with [databricks_permissions](permissions.md#Cluster-usage) and `cluster_id` argument. Everyone without `allow_cluster_create` argument set, but with [permission to use](permissions.md#Cluster-Policy-usage) Cluster Policy would be able to create clusters, but within boundaries of that specific policy.
 * `allow_instance_pool_create` -  (Optional) Allow the user to have [instance pool](instance_pool.md) create privileges. Defaults to false. More fine grained permissions could be assigned with [databricks_permissions](permissions.md#Instance-Pool-usage) and [instance_pool_id](permissions.md#instance_pool_id) argument.
-* `allow_sql_analytics_access` - (Optional) This is a field to allow the group to have access to [SQL Analytics](https://databricks.com/product/sql-analytics) feature through [databricks_sql_endpoint](sql_endpoint.md).
+* `allow_sql_analytics_access` - (Optional) This is a field to allow the user to have access to [SQL Analytics](https://databricks.com/product/sql-analytics) feature through [databricks_sql_endpoint](sql_endpoint.md).
+* `allow_workspace_access` - (Optional) This is a field to allow the user to have access to the [Dataricks workspace](https://docs.databricks.com/workspace/index.html).
 * `active` - (Optional) Either user is active or not. True by default, but can be set to false in case of user deactivation with preserving user assets.
 
 ## Attribute Reference

--- a/identity/resource_group.go
+++ b/identity/resource_group.go
@@ -105,7 +105,7 @@ func ResourceGroup() *schema.Resource {
 					entitlementsRemoveList = append(entitlementsRemoveList, string(AllowInstancePoolCreateEntitlement))
 				}
 			}
-			// If allow_instance_pool_create has changed
+			// If allow_workspace_access has changed
 			if d.HasChange("allow_workspace_access") {
 				allowClusterCreate := d.Get("allow_workspace_access").(bool)
 				// Changed to true

--- a/identity/resource_group_test.go
+++ b/identity/resource_group_test.go
@@ -30,6 +30,9 @@ func TestResourceGroupCreate(t *testing.T) {
 						{
 							AllowInstancePoolCreateEntitlement,
 						},
+						{
+							AllowWorkspaceAccessEntitlement,
+						},
 					},
 				},
 				Response: ScimGroup{
@@ -53,6 +56,9 @@ func TestResourceGroupCreate(t *testing.T) {
 						{
 							AllowInstancePoolCreateEntitlement,
 						},
+						{
+							AllowWorkspaceAccessEntitlement,
+						},
 					},
 				},
 			},
@@ -63,6 +69,7 @@ func TestResourceGroupCreate(t *testing.T) {
 		allow_instance_pool_create = true
 		allow_cluster_create = true
 		allow_sql_analytics_access = true
+		allow_workspace_access = true
 		`,
 		Create: true,
 	}.Apply(t)
@@ -72,6 +79,7 @@ func TestResourceGroupCreate(t *testing.T) {
 	assert.Equal(t, true, d.Get("allow_cluster_create"))
 	assert.Equal(t, true, d.Get("allow_instance_pool_create"))
 	assert.Equal(t, true, d.Get("allow_sql_analytics_access"))
+	assert.Equal(t, true, d.Get("allow_workspace_access"))
 }
 
 func TestResourceGroupCreate_Error(t *testing.T) {
@@ -117,6 +125,10 @@ func TestResourceGroupRead(t *testing.T) {
 						{
 							AllowInstancePoolCreateEntitlement,
 						},
+
+						{
+							AllowWorkspaceAccessEntitlement,
+						},
 					},
 				},
 			},
@@ -130,6 +142,7 @@ func TestResourceGroupRead(t *testing.T) {
 	assert.Equal(t, true, d.Get("allow_cluster_create"))
 	assert.Equal(t, true, d.Get("allow_instance_pool_create"))
 	assert.Equal(t, true, d.Get("allow_sql_analytics_access"))
+	assert.Equal(t, true, d.Get("allow_workspace_access"))
 	assert.Equal(t, "Data Scientists", d.Get("display_name"))
 }
 
@@ -155,6 +168,7 @@ func TestResourceGroupRead_NoEntitlements(t *testing.T) {
 	assert.Equal(t, false, d.Get("allow_cluster_create"))
 	assert.Equal(t, false, d.Get("allow_instance_pool_create"))
 	assert.Equal(t, false, d.Get("allow_sql_analytics_access"))
+	assert.Equal(t, false, d.Get("allow_workspace_access"))
 	assert.Equal(t, "Data Scientists", d.Get("display_name"))
 }
 
@@ -221,6 +235,9 @@ func TestResourceGroupUpdate_AddPerms(t *testing.T) {
 								{
 									Value: "allow-instance-pool-create",
 								},
+								{
+									Value: "workspace-access",
+								},
 							},
 						},
 					},
@@ -243,6 +260,9 @@ func TestResourceGroupUpdate_AddPerms(t *testing.T) {
 						{
 							AllowInstancePoolCreateEntitlement,
 						},
+						{
+							AllowWorkspaceAccessEntitlement,
+						},
 					},
 				},
 			},
@@ -253,12 +273,14 @@ func TestResourceGroupUpdate_AddPerms(t *testing.T) {
 			"allow_instance_pool_create": "false",
 			"allow_cluster_create":       "false",
 			"allow_sql_analytics_access": "false",
+			"allow_workspace_access":     "false",
 		},
 		HCL: `
 		display_name = "Data Ninjas"
 		allow_instance_pool_create = true
 		allow_cluster_create = true
 		allow_sql_analytics_access = true
+		allow_workspace_access = true
 		`,
 		Update: true,
 		ID:     "abc",
@@ -269,6 +291,7 @@ func TestResourceGroupUpdate_AddPerms(t *testing.T) {
 	assert.Equal(t, true, d.Get("allow_cluster_create"))
 	assert.Equal(t, true, d.Get("allow_instance_pool_create"))
 	assert.Equal(t, true, d.Get("allow_sql_analytics_access"))
+	assert.Equal(t, true, d.Get("allow_workspace_access"))
 }
 
 func TestResourceGroupUpdate_RemovePerms(t *testing.T) {
@@ -292,6 +315,10 @@ func TestResourceGroupUpdate_RemovePerms(t *testing.T) {
 							Op:   "remove",
 							Path: "entitlements[value eq \"allow-instance-pool-create\"]",
 						},
+						{
+							Op:   "remove",
+							Path: "entitlements[value eq \"workspace-access\"]",
+						},
 					},
 				},
 			},
@@ -314,12 +341,14 @@ func TestResourceGroupUpdate_RemovePerms(t *testing.T) {
 			"allow_instance_pool_create": "true",
 			"allow_cluster_create":       "true",
 			"allow_sql_analytics_access": "true",
+			"allow_workspace_access":     "true",
 		},
 		HCL: `
 		display_name = "Data Ninjas"
 		allow_instance_pool_create = false
 		allow_cluster_create = false
 		allow_sql_analytics_access = false
+		allow_workspace_access = false
 		`,
 	}.Apply(t)
 	require.NoError(t, err, err)
@@ -328,6 +357,7 @@ func TestResourceGroupUpdate_RemovePerms(t *testing.T) {
 	assert.Equal(t, false, d.Get("allow_cluster_create"))
 	assert.Equal(t, false, d.Get("allow_instance_pool_create"))
 	assert.Equal(t, false, d.Get("allow_sql_analytics_access"))
+	assert.Equal(t, false, d.Get("allow_workspace_access"))
 }
 
 func TestResourceGroupUpdate_Error(t *testing.T) {

--- a/identity/resource_group_test.go
+++ b/identity/resource_group_test.go
@@ -125,7 +125,6 @@ func TestResourceGroupRead(t *testing.T) {
 						{
 							AllowInstancePoolCreateEntitlement,
 						},
-
 						{
 							AllowWorkspaceAccessEntitlement,
 						},

--- a/identity/resource_group_test.go
+++ b/identity/resource_group_test.go
@@ -25,10 +25,10 @@ func TestResourceGroupCreate(t *testing.T) {
 							AllowClusterCreateEntitlement,
 						},
 						{
-							AllowSQLAnalyticsAccessEntitlement,
+							AllowInstancePoolCreateEntitlement,
 						},
 						{
-							AllowInstancePoolCreateEntitlement,
+							AllowSQLAnalyticsAccessEntitlement,
 						},
 						{
 							AllowWorkspaceAccessEntitlement,
@@ -51,10 +51,10 @@ func TestResourceGroupCreate(t *testing.T) {
 							AllowClusterCreateEntitlement,
 						},
 						{
-							AllowSQLAnalyticsAccessEntitlement,
+							AllowInstancePoolCreateEntitlement,
 						},
 						{
-							AllowInstancePoolCreateEntitlement,
+							AllowSQLAnalyticsAccessEntitlement,
 						},
 						{
 							AllowWorkspaceAccessEntitlement,
@@ -229,10 +229,10 @@ func TestResourceGroupUpdate_AddPerms(t *testing.T) {
 									Value: "allow-cluster-create",
 								},
 								{
-									Value: "sql-analytics-access",
+									Value: "allow-instance-pool-create",
 								},
 								{
-									Value: "allow-instance-pool-create",
+									Value: "sql-analytics-access",
 								},
 								{
 									Value: "workspace-access",
@@ -308,11 +308,11 @@ func TestResourceGroupUpdate_RemovePerms(t *testing.T) {
 						},
 						{
 							Op:   "remove",
-							Path: "entitlements[value eq \"sql-analytics-access\"]",
+							Path: "entitlements[value eq \"allow-instance-pool-create\"]",
 						},
 						{
 							Op:   "remove",
-							Path: "entitlements[value eq \"allow-instance-pool-create\"]",
+							Path: "entitlements[value eq \"sql-analytics-access\"]",
 						},
 						{
 							Op:   "remove",

--- a/identity/resource_user_test.go
+++ b/identity/resource_user_test.go
@@ -97,6 +97,9 @@ func TestResourceUserCreate(t *testing.T) {
 						{
 							Value: "allow-cluster-create",
 						},
+						{
+							Value: "workspace-access",
+						},
 					},
 					UserName: "me@example.com",
 					Schemas:  []URN{UserSchema},
@@ -116,6 +119,9 @@ func TestResourceUserCreate(t *testing.T) {
 					Entitlements: []entitlementsListItem{
 						{
 							Value: AllowClusterCreateEntitlement,
+						},
+						{
+							Value: AllowWorkspaceAccessEntitlement,
 						},
 					},
 					Groups: []GroupsListItem{
@@ -137,6 +143,7 @@ func TestResourceUserCreate(t *testing.T) {
 		user_name    = "me@example.com"
 		display_name = "Example user"
 		allow_cluster_create = true
+		allow_workspace_access = true
 		`,
 	}.Apply(t)
 	require.NoError(t, err, err)
@@ -144,6 +151,7 @@ func TestResourceUserCreate(t *testing.T) {
 	assert.Equal(t, "me@example.com", d.Get("user_name"))
 	assert.Equal(t, "Example user", d.Get("display_name"))
 	assert.Equal(t, true, d.Get("allow_cluster_create"))
+	assert.Equal(t, true, d.Get("allow_workspace_access"))
 }
 
 func TestResourceUserCreate_Error(t *testing.T) {
@@ -175,6 +183,9 @@ func TestResourceUserUpdate(t *testing.T) {
 		Entitlements: []entitlementsListItem{
 			{
 				Value: AllowInstancePoolCreateEntitlement,
+			},
+			{
+				Value: AllowWorkspaceAccessEntitlement,
 			},
 		},
 		Groups: []GroupsListItem{
@@ -250,6 +261,7 @@ func TestResourceUserUpdate(t *testing.T) {
 		display_name = "Changed Name"
 		allow_cluster_create = false
 		allow_instance_pool_create = true
+		allow_workspace_access = true
 		`,
 	}.Apply(t)
 	require.NoError(t, err, err)
@@ -258,6 +270,7 @@ func TestResourceUserUpdate(t *testing.T) {
 	assert.Equal(t, "Changed Name", d.Get("display_name"))
 	assert.Equal(t, false, d.Get("allow_cluster_create"))
 	assert.Equal(t, true, d.Get("allow_instance_pool_create"))
+	assert.Equal(t, true, d.Get("allow_workspace_access"))
 }
 
 func TestResourceUserUpdate_Error(t *testing.T) {

--- a/identity/resource_user_test.go
+++ b/identity/resource_user_test.go
@@ -20,6 +20,20 @@ func TestResourceUserRead(t *testing.T) {
 					ID:          "abc",
 					DisplayName: "Example user",
 					UserName:    "me@example.com",
+					Entitlements: []entitlementsListItem{
+						{
+							Value: AllowWorkspaceAccessEntitlement,
+						},
+						{
+							Value: AllowSQLAnalyticsAccessEntitlement,
+						},
+						{
+							Value: AllowInstancePoolCreateEntitlement,
+						},
+						{
+							Value: AllowClusterCreateEntitlement,
+						},
+					},
 					Groups: []GroupsListItem{
 						{
 							Display: "admins",
@@ -42,7 +56,10 @@ func TestResourceUserRead(t *testing.T) {
 	assert.Equal(t, "abc", d.Id(), "Id should not be empty")
 	assert.Equal(t, "me@example.com", d.Get("user_name"))
 	assert.Equal(t, "Example user", d.Get("display_name"))
-	assert.Equal(t, false, d.Get("allow_cluster_create"))
+	assert.Equal(t, true, d.Get("allow_cluster_create"))
+	assert.Equal(t, true, d.Get("allow_workspace_access"))
+	assert.Equal(t, true, d.Get("allow_sql_analytics_access"))
+	assert.Equal(t, true, d.Get("allow_instance_pool_create"))
 }
 
 func TestResourceUserRead_NotFound(t *testing.T) {
@@ -98,6 +115,9 @@ func TestResourceUserCreate(t *testing.T) {
 							Value: "allow-cluster-create",
 						},
 						{
+							Value: "sql-analytics-access",
+						},
+						{
 							Value: "workspace-access",
 						},
 					},
@@ -119,6 +139,9 @@ func TestResourceUserCreate(t *testing.T) {
 					Entitlements: []entitlementsListItem{
 						{
 							Value: AllowClusterCreateEntitlement,
+						},
+						{
+							Value: AllowSQLAnalyticsAccessEntitlement,
 						},
 						{
 							Value: AllowWorkspaceAccessEntitlement,
@@ -144,6 +167,7 @@ func TestResourceUserCreate(t *testing.T) {
 		display_name = "Example user"
 		allow_cluster_create = true
 		allow_workspace_access = true
+		allow_sql_analytics_access = true
 		`,
 	}.Apply(t)
 	require.NoError(t, err, err)
@@ -152,6 +176,7 @@ func TestResourceUserCreate(t *testing.T) {
 	assert.Equal(t, "Example user", d.Get("display_name"))
 	assert.Equal(t, true, d.Get("allow_cluster_create"))
 	assert.Equal(t, true, d.Get("allow_workspace_access"))
+	assert.Equal(t, true, d.Get("allow_sql_analytics_access"))
 }
 
 func TestResourceUserCreate_Error(t *testing.T) {

--- a/identity/scim.go
+++ b/identity/scim.go
@@ -130,6 +130,7 @@ const (
 	AllowClusterCreateEntitlement      Entitlement = "allow-cluster-create"
 	AllowInstancePoolCreateEntitlement Entitlement = "allow-instance-pool-create"
 	AllowSQLAnalyticsAccessEntitlement Entitlement = "sql-analytics-access"
+	AllowWorkspaceAccessEntitlement    Entitlement = "workspace-access"
 )
 
 // GroupsListItem contains information about group item

--- a/identity/users.go
+++ b/identity/users.go
@@ -30,6 +30,7 @@ type UserEntity struct {
 	AllowClusterCreate      bool   `json:"allow_cluster_create,omitempty"`
 	AllowSQLAnalyticsAccess bool   `json:"allow_sql_analytics_access,omitempty"`
 	AllowInstancePoolCreate bool   `json:"allow_instance_pool_create,omitempty"`
+	AllowWorkspaceAccess    bool   `json:"allow_workspace_access,omitempty"`
 }
 
 func (u UserEntity) toRequest() ScimUser {
@@ -47,6 +48,11 @@ func (u UserEntity) toRequest() ScimUser {
 	if u.AllowInstancePoolCreate {
 		entitlements = append(entitlements, entitlementsListItem{
 			Value: Entitlement("allow-instance-pool-create"),
+		})
+	}
+	if u.AllowWorkspaceAccess {
+		entitlements = append(entitlements, entitlementsListItem{
+			Value: Entitlement("workspace-access"),
 		})
 	}
 	return ScimUser{
@@ -94,6 +100,10 @@ func (a UsersAPI) Read(userID string) (ru UserEntity, err error) {
 			ru.AllowClusterCreate = true
 		case AllowInstancePoolCreateEntitlement:
 			ru.AllowInstancePoolCreate = true
+		case AllowSQLAnalyticsAccessEntitlement:
+			ru.AllowSQLAnalyticsAccess = true
+		case AllowWorkspaceAccessEntitlement:
+			ru.AllowWorkspaceAccess = true
 		}
 	}
 	return


### PR DESCRIPTION
this pr allows users to use the `allow_workspace_access` entitlement as a field in the `databricks_user` and `databricks_group` resources.