### PR TITLE
Prepare 0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@
 * Mounting clusters are recreated now, even when they are deleted ([#637](https://github.com/databrickslabs/terraform-provider-databricks/issues/637))
 * Fixed handling of empty blocks for clusters/jobs/instance pools ([22cdf2f](https://github.com/databrickslabs/terraform-provider-databricks/commit/22cdf2fc9d50f67b14b49d11e7fbaacce0f52399))
 * Mark instance pool attributes as ForceNew when it's requited ([#629](https://github.com/databrickslabs/terraform-provider-databricks/issues/629))
+* Switched to use https://staticcheck.io/ for static code analysis ([#602](https://github.com/databrickslabs/terraform-provider-databricks/issues/602))
 
 **Behavior changes**
 
-* The `customer_managed_key_id` field in `databricks_mws_workspaces` resource is deprecated and should be replaced with `managed_services_customer_managed_key_id` (and optionally `storage_customer_managed_key_id`).  `databricks_mws_customer_managed_keys` now requires the parameter `use_cases` ([#642](https://github.com/databrickslabs/terraform-provider-databricks/pull/642))
+* The `customer_managed_key_id` field in `databricks_mws_workspaces` resource is deprecated and should be replaced with `managed_services_customer_managed_key_id` (and optionally `storage_customer_managed_key_id`). `databricks_mws_customer_managed_keys` now requires the parameter `use_cases` ([#642](https://github.com/databrickslabs/terraform-provider-databricks/pull/642)). *If you've used the resource before, please add `use_cases = ["MANAGED_SERVICES"]` to keep the behaviour.*
 
 Updated dependency versions:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,22 @@
 
 * Fixed state refresh bugs in `databricks_sql_permissions` ([#620](https://github.com/databrickslabs/terraform-provider-databricks/issues/620), [#619](https://github.com/databrickslabs/terraform-provider-databricks/issues/620))
 * Fixed `workspace_ids_filter` mapping for `databricks_mws_log_delivery` ([#635](https://github.com/databrickslabs/terraform-provider-databricks/issues/635))
+* Multiple documentation improvements ([#597](https://github.com/databrickslabs/terraform-provider-databricks/issues/597), [eb60d10](https://github.com/databrickslabs/terraform-provider-databricks/commit/eb60d103ea63221a1eb0069723ba3a0af45dbe3b), [edcd4b1](https://github.com/databrickslabs/terraform-provider-databricks/commit/edcd4b121254e3ff3130bed9c4ef9d849d342561), [404bdab](https://github.com/databrickslabs/terraform-provider-databricks/commit/404bdab637c0a4a15b6a4b6a77567166315955ca), [#615](https://github.com/databrickslabs/terraform-provider-databricks/pull/615), [f14b825](https://github.com/databrickslabs/terraform-provider-databricks/commit/f14b825e9cb11d75e9ad077b35c7e9c410fd8351), [e615c3a](https://github.com/databrickslabs/terraform-provider-databricks/commit/e615c3a68d1ad45f91453ec448b55ca7b204fb97), [#612](https://github.com/databrickslabs/terraform-provider-databricks/pull/612))
+* Mounting clusters are recreated now, even when they are deleted ([#637](https://github.com/databrickslabs/terraform-provider-databricks/issues/637))
+* Fixed handling of empty blocks for clusters/jobs/instance pools ([22cdf2f](https://github.com/databrickslabs/terraform-provider-databricks/commit/22cdf2fc9d50f67b14b49d11e7fbaacce0f52399))
+* Mark instance pool attributes as ForceNew when it's requited ([#629](https://github.com/databrickslabs/terraform-provider-databricks/issues/629))
 
 **Behavior changes**
 
 * The `customer_managed_key_id` field in `databricks_mws_workspaces` resource is deprecated and should be replaced with `managed_services_customer_managed_key_id` (and optionally `storage_customer_managed_key_id`).  `databricks_mws_customer_managed_keys` now requires the parameter `use_cases` ([#642](https://github.com/databrickslabs/terraform-provider-databricks/pull/642))
+
+Updated dependency versions:
+
+* Bump github.com/aws/aws-sdk-go to v1.38.30
+* Bump github.com/hashicorp/go-retryablehttp to v0.7.0
+* Bump github.com/hashicorp/hcl/v2 to v2.10.0
+* Bump github.com/hashicorp/terraform-plugin-sdk/v2 to v2.6.1
+* Bump github.com/zclconf/go-cty to v1.8.2
 
 ## 0.3.3
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ terraform {
   required_providers {
     databricks = {
       source = "databrickslabs/databricks"
-      version = "0.3.3"
+      version = "0.3.4"
     }
   }
 }

--- a/access/resource_sql_permissions.go
+++ b/access/resource_sql_permissions.go
@@ -307,6 +307,12 @@ func ResourceSqlPermissions() *schema.Resource {
 			s[field].Optional = true
 			s[field].AtLeastOneOf = alof
 		}
+		s["database"].DiffSuppressFunc = func(k, old, new string, d *schema.ResourceData) bool {
+			if old == "default" && new == "" {
+				return true
+			}
+			return false
+		}
 		s["cluster_id"].Computed = true
 		return s
 	})

--- a/docs/guides/aws-workspace.md
+++ b/docs/guides/aws-workspace.md
@@ -54,7 +54,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.3.3"
+      version = "0.3.4"
     }
   }
 }

--- a/docs/guides/workspace-management.md
+++ b/docs/guides/workspace-management.md
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.3.3"
+      version = "0.3.4"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -324,7 +324,7 @@ terraform {
   required_providers {
     databricks = {
       source = "databrickslabs/databricks"
-      version = "0.3.3"
+      version = "0.3.4"
     }
   }
 }

--- a/docs/resources/mws_customer_managed_keys.md
+++ b/docs/resources/mws_customer_managed_keys.md
@@ -14,6 +14,8 @@ Please follow this [complete runnable example](../guides/aws-workspace.md) with 
 
 ## Example Usage
 
+-> **Note** If you've used the resource before, please add `use_cases = ["MANAGED_SERVICES"]` to keep the previous behaviour.
+
 ```hcl
 variable "databricks_account_id" {
   description = "Account Id that could be found in the bottom left corner of https://accounts.cloud.databricks.com/"
@@ -26,7 +28,9 @@ resource "aws_kms_grant" "databricks-grant" {
   name = "databricks-grant"
   key_id  = aws_kms_key.customer_managed_key.key_id
   grantee_principal = "arn:aws:iam::414351767826:root"
-  operations = ["Encrypt", "Decrypt"]
+  operations = ["Encrypt", "Decrypt", "DescribeKey", 
+    "GenerateDataKey", "ReEncryptFrom", "ReEncryptTo", 
+    "GenerateDataKeyWithoutPlaintext"]
 }
 
 resource "aws_kms_alias" "customer_managed_key_alias" {
@@ -51,7 +55,7 @@ The following arguments are required:
 
 * `aws_key_info` - This field is a block and is documented below.
 * `account_id` - Account Id that could be found in the bottom left corner of [Accounts Console](https://accounts.cloud.databricks.com/)
-* `use_cases` - list of use cases for which this key will be used.  Possible values are:
+* `use_cases` - *(since v0.3.4)* List of use cases for which this key will be used. *If you've used the resource before, please add `use_cases = ["MANAGED_SERVICES"]` to keep the previous behaviour.* Possible values are:
   * `MANAGED_SERVICES` - for encryption of the workspace objects (notebooks, secrets) that are stored in the control plane
   * `STORAGE` - for encryption of the  DBFS Storage & Cluster EBS Volumes
 

--- a/mws/resource_customer_managed_key_test.go
+++ b/mws/resource_customer_managed_key_test.go
@@ -244,3 +244,11 @@ func TestResourceCustomerManagedKeyDelete(t *testing.T) {
 	assert.NoError(t, err, err)
 	assert.Equal(t, "abc/cmkid", d.Id())
 }
+
+func TestCmkStateUpgrader(t *testing.T) {
+	state, err := migrateResourceCustomerManagedKeyV0(context.Background(),
+		map[string]interface{}{}, nil)
+	assert.NoError(t, err)
+	_, ok := state["use_cases"]
+	assert.True(t, ok)
+}

--- a/scripts/modules/aws-mws-common/kms.tf
+++ b/scripts/modules/aws-mws-common/kms.tf
@@ -10,7 +10,9 @@ resource "aws_kms_grant" "databricks-grant" {
   key_id            = aws_kms_key.customer_managed_key.key_id
   grantee_principal = "arn:aws:iam::${var.databricks_aws_account_id}:root"
 
-  operations = ["Encrypt", "Decrypt"]
+  operations = ["Encrypt", "Decrypt", "DescribeKey", 
+    "GenerateDataKey", "ReEncryptFrom", "ReEncryptTo", 
+    "GenerateDataKeyWithoutPlaintext"]
 }
 
 


### PR DESCRIPTION
# Version changelog

* Fixed state refresh bugs in `databricks_sql_permissions` ([#620](https://github.com/databrickslabs/terraform-provider-databricks/issues/620), [#619](https://github.com/databrickslabs/terraform-provider-databricks/issues/620))
* Fixed `workspace_ids_filter` mapping for `databricks_mws_log_delivery` ([#635](https://github.com/databrickslabs/terraform-provider-databricks/issues/635))
* Multiple documentation improvements ([#597](https://github.com/databrickslabs/terraform-provider-databricks/issues/597), [eb60d10](https://github.com/databrickslabs/terraform-provider-databricks/commit/eb60d103ea63221a1eb0069723ba3a0af45dbe3b), [edcd4b1](https://github.com/databrickslabs/terraform-provider-databricks/commit/edcd4b121254e3ff3130bed9c4ef9d849d342561), [404bdab](https://github.com/databrickslabs/terraform-provider-databricks/commit/404bdab637c0a4a15b6a4b6a77567166315955ca), [#615](https://github.com/databrickslabs/terraform-provider-databricks/pull/615), [f14b825](https://github.com/databrickslabs/terraform-provider-databricks/commit/f14b825e9cb11d75e9ad077b35c7e9c410fd8351), [e615c3a](https://github.com/databrickslabs/terraform-provider-databricks/commit/e615c3a68d1ad45f91453ec448b55ca7b204fb97), [#612](https://github.com/databrickslabs/terraform-provider-databricks/pull/612))
* Mounting clusters are recreated now, even when they are deleted ([#637](https://github.com/databrickslabs/terraform-provider-databricks/issues/637))
* Fixed handling of empty blocks for clusters/jobs/instance pools ([22cdf2f](https://github.com/databrickslabs/terraform-provider-databricks/commit/22cdf2fc9d50f67b14b49d11e7fbaacce0f52399))
* Mark instance pool attributes as ForceNew when it's requited ([#629](https://github.com/databrickslabs/terraform-provider-databricks/issues/629))

**Behavior changes**

* The `customer_managed_key_id` field in `databricks_mws_workspaces` resource is deprecated and should be replaced with `managed_services_customer_managed_key_id` (and optionally `storage_customer_managed_key_id`).  `databricks_mws_customer_managed_keys` now requires the parameter `use_cases` ([#642](https://github.com/databrickslabs/terraform-provider-databricks/pull/642))

Updated dependency versions:

* Bump github.com/aws/aws-sdk-go to v1.38.30
* Bump github.com/hashicorp/go-retryablehttp to v0.7.0
* Bump github.com/hashicorp/hcl/v2 to v2.10.0
* Bump github.com/hashicorp/terraform-plugin-sdk/v2 to v2.6.1
* Bump github.com/zclconf/go-cty to v1.8.2


azcli
---
 * [x] TestAccTableACL (524.30s)
 * [x] access.TestAccIPACL (9.08s)
 * [x] access.TestAccPermissionsClusterPolicy (17.44s)
 * [x] access.TestAccPermissionsClusters (392.47s)
 * [x] access.TestAccPermissionsInstancePool (15.47s)
 * [x] access.TestAccPermissionsJobs (15.24s)
 * [x] access.TestAccPermissionsNotebooks (15.83s)
 * [x] access.TestAccPermissionsTokens (15.20s)
 * [x] access/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (47.76s)
 * [x] access/acceptance.TestAccInitialManagePrincipals (3.40s)
 * [x] access/acceptance.TestAccInitialManagePrincipalsGroup (1.95s)
 * [x] access/acceptance.TestAccSecretAclResource (17.28s)
 * [x] access/acceptance.TestAccSecretAclResourceDefaultPrincipal (12.30s)
 * [x] access/acceptance.TestAccSecretResource (20.86s)
 * [x] access/acceptance.TestAccSecretScopeResource (19.45s)
 * [x] access/acceptance.TestAzureAccKeyVaultSimple (3.28s)
 * [x] compute.TestAccContext (115.28s)
 * [x] compute.TestAccInstancePools (4.50s)
 * [x] compute.TestAccLibraryCreate (71.76s)
 * [x] compute.TestAccListClustersIntegration (288.04s)
 * [x] compute.TestAzureAccNodeTypes (1.66s)
 * [x] compute/acceptance.TestAccClusterPolicyResourceFullLifecycle (33.92s)
 * [x] compute/acceptance.TestAccJobResource (11.63s)
 * [x] identity.TestAccCreateToken (3.86s)
 * [x] identity.TestAccCreateToken_NoExpiration (3.35s)
 * [x] identity.TestAccCreateUser (8.88s)
 * [x] identity.TestAccFilterGroup (4.12s)
 * [x] identity.TestAccGroup (36.47s)
 * [x] identity.TestAccReadUser (3.29s)
 * [x] identity.TestAzureAccSP (8.93s)
 * [x] identity/acceptance.TestAccGroupMemberResource (28.97s)
 * [x] identity/acceptance.TestAccGroupResource (41.18s)
 * [x] identity/acceptance.TestAccGroupResource_verify_entitlements (19.74s)
 * [x] identity/acceptance.TestAccTokenResource (13.73s)
 * [x] identity/acceptance.TestAccUserResource (23.24s)
 * [x] identity/acceptance.TestAzureAccServicePrincipalResource (23.87s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace (5.20s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies (0.68s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies_Delete (0.47s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Clusters (0.30s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/DBFS_Files (0.72s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Groups (0.61s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Instance_Pools (0.52s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Jobs (0.20s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Notebooks (0.19s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_ACLs (0.20s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_Scopes (0.13s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secrets (0.13s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Tokens (0.42s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Users (0.63s)
 * [x] internal/sanity.TestAccMutiworkspaceUsedFromNormalMode (21.12s)
 * [x] storage.TestAccCreateFile (6.67s)
 * [x] storage.TestAccDeleteInvalidMountFails (5.23s)
 * [x] storage.TestAccInvalidSecretScopeFails (10.35s)
 * [x] storage.TestAccSourceOnInvalidMountFails (30.51s)
 * [x] storage.TestAzureAccBlobMount (158.97s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (16.72s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (7.94s)
 * [x] storage/acceptance.TestAzureAccBlobMount_correctly_mounts (685.81s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (16.14s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (20.34s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (9.61s)

mws
---
 * [x] TestMwsAccWorkspaces (5.75s)
 * [x] mws.TestMwsAccCreds (2.80s)
 * [x] mws.TestMwsAccCustomerManagedKeys (3.47s)
 * [x] mws.TestMwsAccLogDelivery (6.01s)
 * [x] mws.TestMwsAccMissingResources (3.42s)
 * [x] mws.TestMwsAccMissingResources/Credential (0.81s)
 * [x] mws.TestMwsAccMissingResources/Customer_Managed_Key (0.65s)
 * [x] mws.TestMwsAccMissingResources/Network (0.65s)
 * [x] mws.TestMwsAccMissingResources/Storage (0.63s)
 * [x] mws.TestMwsAccMissingResources/Workspace (0.69s)
 * [x] mws.TestMwsAccPAS (2.35s)
 * [x] mws.TestMwsAccStorageConfigurations (2.26s)
 * [x] mws.TestMwsAccVPCEndpointIntegration (105.80s)
 * [x] mws.TestMwsAccWorkspace (0.48s)
 * [x] mws/acceptance.TestMwsAccCredentials (5.06s)
 * [x] mws/acceptance.TestMwsAccCustomerManagedKeys (7.06s)
 * [x] mws/acceptance.TestMwsAccLogDelivery (10.58s)
 * [x] mws/acceptance.TestMwsAccNetworks (5.19s)
 * [x] mws/acceptance.TestMwsAccPrivateAccessSettings (5.09s)
 * [x] mws/acceptance.TestMwsAccStorageConfigurations (5.12s)
 * [x] mws/acceptance.TestMwsAccVpcEndpoint (107.00s)

awsmt
---
 * [x] TestAccClusterResource_CreateClusterWithLibraries (266.31s)
 * [x] TestAccTableACL (470.07s)
 * [x] access.TestAccIPACL (3.10s)
 * [x] access.TestAccPermissionsClusterPolicy (16.00s)
 * [x] access.TestAccPermissionsClusters (218.19s)
 * [x] access.TestAccPermissionsInstancePool (17.13s)
 * [x] access.TestAccPermissionsJobs (15.73s)
 * [x] access.TestAccPermissionsNotebooks (16.89s)
 * [x] access.TestAccPermissionsTokens (14.58s)
 * [x] access/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (33.60s)
 * [x] access/acceptance.TestAccInitialManagePrincipals (1.89s)
 * [x] access/acceptance.TestAccInitialManagePrincipalsGroup (0.77s)
 * [x] access/acceptance.TestAccSecretAclResource (14.87s)
 * [x] access/acceptance.TestAccSecretAclResourceDefaultPrincipal (6.41s)
 * [x] access/acceptance.TestAccSecretResource (4.59s)
 * [x] access/acceptance.TestAccSecretScopeResource (5.93s)
 * [x] compute.TestAccContext (89.14s)
 * [x] compute.TestAccInstancePools (4.54s)
 * [x] compute.TestAccLibraryCreate (146.60s)
 * [x] compute.TestAccListClustersIntegration (216.20s)
 * [x] compute.TestAwsAccSmallestNodeType (0.24s)
 * [x] compute/acceptance.TestAccClusterPolicyResourceFullLifecycle (7.32s)
 * [x] compute/acceptance.TestAccClusterResource_CreateSingleNodeCluster (63.74s)
 * [x] compute/acceptance.TestAccJobResource (3.09s)
 * [x] compute/acceptance.TestAwsAccJobResource_NoInstancePool (3.11s)
 * [x] compute/acceptance.TestAwsAccJobsCreate (1.86s)
 * [x] identity.TestAccCreateToken (1.56s)
 * [x] identity.TestAccCreateToken_NoExpiration (0.70s)
 * [x] identity.TestAccCreateUser (8.63s)
 * [x] identity.TestAccFilterGroup (1.65s)
 * [x] identity.TestAccGroup (27.10s)
 * [x] identity.TestAccReadUser (1.71s)
 * [x] identity.TestAwsAccInstanceProfiles (971.78s)
 * [x] identity/acceptance.TestAccGroupMemberResource (22.10s)
 * [x] identity/acceptance.TestAccGroupResource (14.95s)
 * [x] identity/acceptance.TestAccGroupResource_verify_entitlements (13.85s)
 * [x] identity/acceptance.TestAccTokenResource (3.67s)
 * [x] identity/acceptance.TestAccUserResource (15.65s)
 * [x] identity/acceptance.TestAwsAccGroupInstanceProfileResource (996.53s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace (5.82s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies (0.74s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies_Delete (0.44s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Clusters (0.12s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/DBFS_Files (1.30s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Groups (0.46s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Instance_Pools (0.13s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Instance_Profiles (0.38s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Jobs (0.13s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Notebooks (0.15s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_ACLs (0.13s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_Scopes (0.17s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secrets (0.44s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Tokens (0.75s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Users (0.46s)
 * [x] internal/sanity.TestAccMutiworkspaceUsedFromNormalMode (2.00s)
 * [x] storage.TestAccCreateFile (5.20s)
 * [x] storage.TestAccDeleteInvalidMountFails (4.19s)
 * [x] storage.TestAccInvalidSecretScopeFails (3.14s)
 * [x] storage.TestAccSourceOnInvalidMountFails (31.79s)
 * [x] storage.TestAwsAccS3Mount (380.79s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (6.26s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (2.78s)
 * [x] storage/acceptance.TestAwsAccS3IamMount_NoClusterGiven (985.88s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (5.45s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (7.03s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (4.04s)

