### PR TITLE
Fix handling of is_no_public_ip_enabled

### DIFF
--- a/mws/mws.go
+++ b/mws/mws.go
@@ -87,7 +87,7 @@ type Workspace struct {
 	PricingTier                         string `json:"pricing_tier,omitempty" tf:"computed"`
 	PrivateAccessSettingsID             string `json:"private_access_settings_id,omitempty"`
 	NetworkID                           string `json:"network_id,omitempty"`
-	IsNoPublicIPEnabled                 bool   `json:"is_no_public_ip_enabled,omitempty"`
+	IsNoPublicIPEnabled                 bool   `json:"is_no_public_ip_enabled"`
 	WorkspaceID                         int64  `json:"workspace_id,omitempty" tf:"computed"`
 	WorkspaceURL                        string `json:"workspace_url,omitempty" tf:"computed"`
 	WorkspaceStatus                     string `json:"workspace_status,omitempty" tf:"computed"`

--- a/mws/resource_workspace.go
+++ b/mws/resource_workspace.go
@@ -187,10 +187,7 @@ func ResourceWorkspace() *schema.Resource {
 		// The value of `is_no_public_ip_enabled` isn't part of the GET payload.
 		// Keep diff when creating (i.e. `old` == ""), suppress diff otherwise.
 		s["is_no_public_ip_enabled"].DiffSuppressFunc = func(k, old, new string, d *schema.ResourceData) bool {
-			if old == "" {
-				return false
-			}
-			return true
+			return old != ""
 		}
 		s["customer_managed_key_id"].Deprecated = "Use managed_services_customer_managed_key_id instead"
 		s["customer_managed_key_id"].ConflictsWith = []string{"managed_services_customer_managed_key_id", "storage_customer_managed_key_id"}

--- a/mws/resource_workspace_test.go
+++ b/mws/resource_workspace_test.go
@@ -78,7 +78,68 @@ func TestResourceWorkspaceCreate(t *testing.T) {
 			"storage_customer_managed_key_id":          "def",
 			"deployment_name":                          "900150983cd24fb0",
 			"workspace_name":                           "labdata",
-			"is_no_public_ip_enabled":                  true,
+			"network_id":                               "fgh",
+			"storage_configuration_id":                 "ghi",
+		},
+		Create: true,
+	}.Apply(t)
+	assert.NoError(t, err, err)
+	assert.Equal(t, "abc/1234", d.Id())
+}
+
+func TestResourceWorkspaceCreateWithIsNoPublicIPEnabledFalse(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/accounts/abc/workspaces",
+				ExpectedRequest: Workspace{
+					AccountID:                           "abc",
+					IsNoPublicIPEnabled:                 false,
+					WorkspaceName:                       "labdata",
+					DeploymentName:                      "900150983cd24fb0",
+					AwsRegion:                           "us-east-1",
+					CredentialsID:                       "bcd",
+					StorageConfigurationID:              "ghi",
+					NetworkID:                           "fgh",
+					ManagedServicesCustomerManagedKeyID: "def",
+					StoragexCustomerManagedKeyID:        "def",
+				},
+				Response: Workspace{
+					WorkspaceID:    1234,
+					AccountID:      "abc",
+					DeploymentName: "900150983cd24fb0",
+				},
+			},
+			{
+				Method:       "GET",
+				ReuseRequest: true,
+				Resource:     "/api/2.0/accounts/abc/workspaces/1234",
+				Response: Workspace{
+					WorkspaceID:                         1234,
+					WorkspaceStatus:                     WorkspaceStatusRunning,
+					WorkspaceName:                       "labdata",
+					DeploymentName:                      "900150983cd24fb0",
+					AwsRegion:                           "us-east-1",
+					CredentialsID:                       "bcd",
+					StorageConfigurationID:              "ghi",
+					NetworkID:                           "fgh",
+					ManagedServicesCustomerManagedKeyID: "def",
+					StoragexCustomerManagedKeyID:        "def",
+					AccountID:                           "abc",
+				},
+			},
+		},
+		Resource: ResourceWorkspace(),
+		State: map[string]interface{}{
+			"account_id":     "abc",
+			"aws_region":     "us-east-1",
+			"credentials_id": "bcd",
+			"managed_services_customer_managed_key_id": "def",
+			"storage_customer_managed_key_id":          "def",
+			"deployment_name":                          "900150983cd24fb0",
+			"workspace_name":                           "labdata",
+			"is_no_public_ip_enabled":                  false,
 			"network_id":                               "fgh",
 			"storage_configuration_id":                 "ghi",
 		},
@@ -137,7 +198,6 @@ func TestResourceWorkspaceCreateLegacyConfig(t *testing.T) {
 			"customer_managed_key_id":  "def",
 			"deployment_name":          "900150983cd24fb0",
 			"workspace_name":           "labdata",
-			"is_no_public_ip_enabled":  true,
 			"network_id":               "fgh",
 			"storage_configuration_id": "ghi",
 		},
@@ -199,7 +259,6 @@ func TestResourceWorkspaceRead(t *testing.T) {
 				Response: Workspace{
 					AccountID:                           "abc",
 					WorkspaceStatus:                     WorkspaceStatusRunning,
-					IsNoPublicIPEnabled:                 true,
 					WorkspaceName:                       "labdata",
 					DeploymentName:                      "900150983cd24fb0",
 					AwsRegion:                           "us-east-1",
@@ -243,7 +302,6 @@ func TestResourceWorkspaceRead_Issue382(t *testing.T) {
 				Response: Workspace{
 					AccountID:                           "abc",
 					WorkspaceStatus:                     WorkspaceStatusRunning,
-					IsNoPublicIPEnabled:                 true,
 					WorkspaceName:                       "labdata",
 					DeploymentName:                      "prefix-900150983cd24fb0",
 					AwsRegion:                           "us-east-1",
@@ -264,7 +322,6 @@ func TestResourceWorkspaceRead_Issue382(t *testing.T) {
 			"storage_customer_managed_key_id":          "def",
 			"deployment_name":                          "900150983cd24fb0",
 			"workspace_name":                           "labdata",
-			"is_no_public_ip_enabled":                  "true",
 			"network_id":                               "fgh",
 			"storage_configuration_id":                 "ghi",
 		},
@@ -276,7 +333,6 @@ func TestResourceWorkspaceRead_Issue382(t *testing.T) {
 			"storage_customer_managed_key_id":          "def",
 			"deployment_name":                          "900150983cd24fb0",
 			"workspace_name":                           "labdata",
-			"is_no_public_ip_enabled":                  true,
 			"network_id":                               "fgh",
 			"storage_configuration_id":                 "ghi",
 		},
@@ -354,7 +410,6 @@ func TestResourceWorkspaceUpdate(t *testing.T) {
 				Resource:     "/api/2.0/accounts/abc/workspaces/1234",
 				Response: Workspace{
 					WorkspaceStatus:                     WorkspaceStatusRunning,
-					IsNoPublicIPEnabled:                 true,
 					WorkspaceName:                       "labdata",
 					DeploymentName:                      "900150983cd24fb0",
 					AwsRegion:                           "us-east-1",
@@ -431,7 +486,6 @@ func TestResourceWorkspaceUpdateLegacyConfig(t *testing.T) {
 			"customer_managed_key_id":  "def",
 			"deployment_name":          "900150983cd24fb0",
 			"workspace_name":           "labdata",
-			"is_no_public_ip_enabled":  true,
 			"network_id":               "fgh",
 			"storage_configuration_id": "ghi",
 			"workspace_id":             1234,
@@ -465,7 +519,6 @@ func TestResourceWorkspaceUpdate_Error(t *testing.T) {
 			"storage_customer_managed_key_id":          "def",
 			"deployment_name":                          "900150983cd24fb0",
 			"workspace_name":                           "labdata",
-			"is_no_public_ip_enabled":                  true,
 			"network_id":                               "fgh",
 			"storage_configuration_id":                 "ghi",
 			"workspace_id":                             1234,

--- a/scripts/mws-integration/main.tf
+++ b/scripts/mws-integration/main.tf
@@ -66,6 +66,15 @@ module "aws_common" {
   tags       = local.tags
 }
 
+data "databricks_aws_bucket_policy" "this" {
+  bucket = module.aws_common.root_bucket
+}
+
+resource "aws_s3_bucket_policy" "root_bucket_policy" {
+  bucket     = module.aws_common.root_bucket
+  policy     = data.databricks_aws_bucket_policy.this.json
+}
+
 resource "aws_s3_bucket" "logdelivery" {
   bucket = "${local.prefix}-logdelivery"
   acl    = "private"


### PR DESCRIPTION
I tried to create a workspace with public IPs for all workers and found it didn't work.

Turns out the `omitempty` on the `is_no_public_ip_enabled` field means a value of `false` doesn't make it to the API, where it then defaults to `true`. Therefore, it can't be `omitempty`, but it's not a required field either. To make matters more complicated, it's not returned as part of the GET response. This PR sets a `DiffSuppressFunc` ignores value changes and only sets the field on creation.

Removed the field from all responses in tests because the API doesn't return it.