### PR TITLE
Prepare release 0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added the `databricks_user` data source ([#648](https://github.com/databrickslabs/terraform-provider-databricks/pull/648))
 * Fixed support for `spot_instance_policy` in SQLA Endpoints ([#665](https://github.com/databrickslabs/terraform-provider-databricks/issues/665))
 * Added documentation for `databricks_pipeline` resource ([#673](https://github.com/databrickslabs/terraform-provider-databricks/pull/673))
+* Fixed mapping for `databricks_service_principal` on AWS ([#656](https://github.com/databrickslabs/terraform-provider-databricks/issues/656))
 * Made preview environment tests to run on a release basis
 
 Updated dependency versions:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ terraform {
   required_providers {
     databricks = {
       source = "databrickslabs/databricks"
-      version = "0.3.4"
+      version = "0.3.5"
     }
   }
 }

--- a/docs/guides/aws-workspace.md
+++ b/docs/guides/aws-workspace.md
@@ -54,7 +54,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.3.4"
+      version = "0.3.5"
     }
   }
 }

--- a/docs/guides/workspace-management.md
+++ b/docs/guides/workspace-management.md
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.3.4"
+      version = "0.3.5"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -324,7 +324,7 @@ terraform {
   required_providers {
     databricks = {
       source = "databrickslabs/databricks"
-      version = "0.3.4"
+      version = "0.3.5"
     }
   }
 }

--- a/docs/resources/service_principal.md
+++ b/docs/resources/service_principal.md
@@ -3,7 +3,7 @@ subcategory: "Security"
 ---
 # databricks_service_principal Resource
 
-Directly creates service principal, that could be added to [databricks_group](group.md) within workspace.
+Directly creates a service principal that could be added to [databricks_group](group.md) within workspace.
 
 ## Example Usage
 
@@ -19,7 +19,7 @@ Creating service principal with administrative permissions - referencing special
 
 ```hcl
 data "databricks_group" "admins" {
-    display_name = "admins"
+  display_name = "admins"
 }
 
 resource "databricks_service_principal" "sp" {
@@ -44,12 +44,14 @@ resource "databricks_service_principal" "sp" {
 
 ## Argument Reference
 
+-> `application_id` is required on Azure Databricks and is not allowed on other clouds. `display_name` is required on all clouds except Azure.
+
 The following arguments are available:
 
-* `application_id` - (Required) This is the application id of the given service principal and will be their form of access and identity.
-* `display_name` - (Optional) This is an alias for the service principal can be the full name of the service principal.
-* `allow_cluster_create` -  (Optional) Allow the service principal to have [cluster](cluster.md) create priviliges. Defaults to false. More fine grained permissions could be assigned with [databricks_permissions](permissions.md#Cluster-usage) and `cluster_id` argument. Everyone without `allow_cluster_create` arugment set, but with [permission to use](permissions.md#Cluster-Policy-usage) Cluster Policy would be able to create clusters, but within boundaries of that specific policy.
-* `allow_instance_pool_create` -  (Optional) Allow the service principal to have [instance pool](instance_pool.md) create priviliges. Defaults to false. More fine grained permissions could be assigned with [databricks_permissions](permissions.md#Instance-Pool-usage) and [instance_pool_id](permissions.md#instance_pool_id) argument.
+* `application_id` - This is the application id of the given service principal and will be their form of access and identity. On other clouds than Azure this value is auto-generated.
+* `display_name` - (Required) This is an alias for the service principal and can be the full name of the service principal.
+* `allow_cluster_create` -  (Optional) Allow the service principal to have [cluster](cluster.md) create privileges. Defaults to false. More fine grained permissions could be assigned with [databricks_permissions](permissions.md#Cluster-usage) and `cluster_id` argument. Everyone without `allow_cluster_create` argument set, but with [permission to use](permissions.md#Cluster-Policy-usage) Cluster Policy would be able to create clusters, but within the boundaries of that specific policy.
+* `allow_instance_pool_create` -  (Optional) Allow the service principal to have [instance pool](instance_pool.md) create privileges. Defaults to false. More fine grained permissions could be assigned with [databricks_permissions](permissions.md#Instance-Pool-usage) and [instance_pool_id](permissions.md#instance_pool_id) argument.
 * `active` - (Optional) Either service principal is active or not. True by default, but can be set to false in case of service principal deactivation with preserving service principal assets.
 
 ## Attribute Reference

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -309,19 +309,19 @@ var resourcesMap map[string]importable = map[string]importable{
 			for k, policy := range definition {
 				value, vok := policy["value"]
 				defaultValue, dok := policy["defaultValue"]
-				if !vok || !dok {
+				if !vok && !dok {
 					continue
 				}
 				if k == "aws_attributes.instance_profile_arn" {
 					ic.Emit(&resource{
 						Resource: "databricks_instance_profile",
-						ID:       fmt.Sprintf("%s%s", value, defaultValue),
+						ID:       eitherString(value, defaultValue),
 					})
 				}
 				if k == "instance_pool_id" {
 					ic.Emit(&resource{
 						Resource: "databricks_instance_pool",
-						ID:       fmt.Sprintf("%s%s", value, defaultValue),
+						ID:       eitherString(value, defaultValue),
 					})
 				}
 			}

--- a/exporter/test-data/get-cluster-policy.json
+++ b/exporter/test-data/get-cluster-policy.json
@@ -1,6 +1,6 @@
 {
   "created_at_timestamp": 1606308550000,
-  "definition": "{\"autoscale.max_workers\":{\"defaultValue\":2,\"maxValue\":5,\"type\":\"range\"},\"autoscale.min_workers\":{\"hidden\":true,\"type\":\"fixed\",\"value\":1},\"autotermination_minutes\":{\"defaultValue\":20,\"maxValue\":30,\"type\":\"range\"},\"cluster_log_conf.path\":{\"hidden\":true,\"type\":\"fixed\",\"value\":\"dbfs:/cluster-logs\"},\"cluster_log_conf.type\":{\"hidden\":true,\"type\":\"fixed\",\"value\":\"DBFS\"},\"custom_tags.team\":{\"type\":\"fixed\",\"value\":\"users\"},\"dbus_per_hour\":{\"maxValue\":10,\"type\":\"range\"},\"driver_node_type_id\":{\"defaultValue\":\"Standard_F4s\",\"type\":\"whitelist\",\"values\":[\"Standard_F4s\",\"Standard_F8s\"]},\"node_type_id\":{\"defaultValue\":\"Standard_F4s\",\"type\":\"whitelist\",\"values\":[\"Standard_F4s\",\"Standard_F8s\"]},\"spark_version\":{\"defaultValue\":\"7.3.x-scala2.12\",\"type\":\"whitelist\",\"values\":[\"7.2.x-scala2.12\",\"7.3.x-scala2.12\"]}}",
+  "definition": "{\"aws_attributes.instance_profile_arn\":{\"hidden\":true,\"type\":\"fixed\",\"value\":\"arn:aws:iam::12345:instance-profile/shard-s3-access\"},\"instance_pool_id\":{\"hidden\":true,\"type\":\"fixed\",\"value\":\"pool1\"},\"autoscale.max_workers\":{\"defaultValue\":2,\"maxValue\":5,\"type\":\"range\"}}",
   "name": "users cluster policy",
   "policy_id": "123"
 }

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -245,3 +245,13 @@ func (ic *importContext) getMountsThroughCluster(
 	err = json.Unmarshal([]byte(lines[0]), &mm)
 	return
 }
+
+func eitherString(a interface{}, b interface{}) string {
+	if a != nil {
+		return a.(string)
+	}
+	if b != nil {
+		return b.(string)
+	}
+	return ""
+}

--- a/identity/acceptance/resource_service_principal_test.go
+++ b/identity/acceptance/resource_service_principal_test.go
@@ -1,49 +1,28 @@
 package acceptance
 
 import (
-	"os"
 	"testing"
 
 	"github.com/databrickslabs/terraform-provider-databricks/internal/acceptance"
-	"github.com/databrickslabs/terraform-provider-databricks/qa"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAzureAccServicePrincipalResource(t *testing.T) {
-	if _, ok := os.LookupEnv("CLOUD_ENV"); !ok {
-		t.Skip("Acceptance tests skipped unless env 'CLOUD_ENV' is set")
-	}
-	config := qa.EnvironmentTemplate(t, `
-		data "databricks_group" "admins" {
-			display_name = "admins"
-		}
-		resource "databricks_service_principal" "sp_first" {
-			application_id = "00000000-1234-5678-0000-000000000001"
-			display_name = "Eerste {var.RANDOM}"
-		}
-		resource "databricks_service_principal" "sp_second" {
-			application_id = "00000000-1234-5678-0000-000000000002"
-			display_name = "Tweede {var.RANDOM}"
-			allow_cluster_create = true
-		}
-		resource "databricks_service_principal" "sp_third" {
-			application_id = "00000000-1234-5678-0000-000000000003"
-			allow_instance_pool_create = true
-		}`)
-	acceptance.AccTest(t, resource.TestCase{
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("databricks_service_principal.sp_first", "allow_cluster_create", "false"),
-					resource.TestCheckResourceAttr("databricks_service_principal.sp_first", "allow_instance_pool_create", "false"),
-					resource.TestCheckResourceAttr("databricks_service_principal.sp_second", "allow_cluster_create", "true"),
-					resource.TestCheckResourceAttr("databricks_service_principal.sp_second", "allow_instance_pool_create", "false"),
-					resource.TestCheckResourceAttr("databricks_service_principal.sp_third", "allow_cluster_create", "false"),
-					resource.TestCheckResourceAttr("databricks_service_principal.sp_third", "allow_instance_pool_create", "true"),
-				),
-				Destroy: false,
-			},
+	acceptance.Test(t, []acceptance.Step{
+		{
+			Template: `resource "databricks_service_principal" "this" {
+				application_id = "00000000-1234-5678-0000-000000000001"
+				display_name = "SPN {var.RANDOM}"
+			}`,
+		},
+	})
+}
+
+func TestAwsAccServicePrincipalResource(t *testing.T) {
+	acceptance.Test(t, []acceptance.Step{
+		{
+			Template: `resource "databricks_service_principal" "this" {
+				display_name = "SPN {var.RANDOM}"
+			}`,
 		},
 	})
 }

--- a/identity/resource_service_principal_test.go
+++ b/identity/resource_service_principal_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAzureAccSP(t *testing.T) {
-	if _, ok := os.LookupEnv("CLOUD_ENV"); !ok {
+	if cloud, ok := os.LookupEnv("CLOUD_ENV"); !ok || cloud != "azure" {
 		t.Skip("Acceptance tests skipped unless env 'CLOUD_ENV' is set")
 	}
 
@@ -51,9 +51,8 @@ func TestResourceServicePrincipalRead(t *testing.T) {
 				Method:   "GET",
 				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals/abc",
 				Response: ScimUser{
-					ID:            "abc",
-					DisplayName:   "Example Service Principal",
-					ApplicationID: "00000000-0000-0000-0000-000000000000",
+					ID:          "abc",
+					DisplayName: "Example Service Principal",
 					Groups: []GroupsListItem{
 						{
 							Display: "admins",
@@ -74,7 +73,6 @@ func TestResourceServicePrincipalRead(t *testing.T) {
 	}.Apply(t)
 	require.NoError(t, err, err)
 	assert.Equal(t, "abc", d.Id(), "Id should not be empty")
-	assert.Equal(t, "00000000-0000-0000-0000-000000000000", d.Get("application_id"))
 	assert.Equal(t, "Example Service Principal", d.Get("display_name"))
 	assert.Equal(t, false, d.Get("allow_cluster_create"))
 }
@@ -132,8 +130,7 @@ func TestResourceServicePrincipalCreate(t *testing.T) {
 							Value: "allow-cluster-create",
 						},
 					},
-					ApplicationID: "00000000-0000-0000-0000-000000000000",
-					Schemas:       []URN{ServicePrincipalSchema},
+					Schemas: []URN{ServicePrincipalSchema},
 				},
 				Response: ScimUser{
 					ID: "abc",
@@ -143,10 +140,9 @@ func TestResourceServicePrincipalCreate(t *testing.T) {
 				Method:   "GET",
 				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals/abc",
 				Response: ScimUser{
-					DisplayName:   "Example Service Principal",
-					Active:        true,
-					ApplicationID: "00000000-0000-0000-0000-000000000000",
-					ID:            "abc",
+					DisplayName: "Example Service Principal",
+					Active:      true,
+					ID:          "abc",
 					Entitlements: []entitlementsListItem{
 						{
 							Value: AllowClusterCreateEntitlement,
@@ -168,14 +164,12 @@ func TestResourceServicePrincipalCreate(t *testing.T) {
 		Resource: ResourceServicePrincipal(),
 		Create:   true,
 		HCL: `
-		application_id    = "00000000-0000-0000-0000-000000000000"
 		display_name = "Example Service Principal"
 		allow_cluster_create = true
 		`,
 	}.Apply(t)
 	require.NoError(t, err, err)
 	assert.Equal(t, "abc", d.Id(), "Id should not be empty")
-	assert.Equal(t, "00000000-0000-0000-0000-000000000000", d.Get("application_id"))
 	assert.Equal(t, "Example Service Principal", d.Get("display_name"))
 	assert.Equal(t, true, d.Get("allow_cluster_create"))
 }
@@ -192,7 +186,6 @@ func TestResourceServicePrincipalCreate_Error(t *testing.T) {
 		Resource: ResourceServicePrincipal(),
 		Create:   true,
 		HCL: `
-		application_id    = "00000000-0000-0000-0000-000000000000"
 		display_name = "Example Service Principal"
 		allow_cluster_create = true
 		`,
@@ -202,10 +195,9 @@ func TestResourceServicePrincipalCreate_Error(t *testing.T) {
 
 func TestResourceServicePrincipalUpdate(t *testing.T) {
 	newServicePrincipal := ScimUser{
-		Schemas:       []URN{ServicePrincipalSchema},
-		DisplayName:   "Changed Name",
-		ApplicationID: "00000000-0000-0000-0000-000000000000",
-		Active:        true,
+		Schemas:     []URN{ServicePrincipalSchema},
+		DisplayName: "Changed Name",
+		Active:      true,
 		Entitlements: []entitlementsListItem{
 			{
 				Value: AllowInstancePoolCreateEntitlement,
@@ -228,10 +220,9 @@ func TestResourceServicePrincipalUpdate(t *testing.T) {
 				Method:   "GET",
 				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals/abc",
 				Response: ScimUser{
-					DisplayName:   "Example Service Principal",
-					Active:        true,
-					ApplicationID: "00000000-0000-0000-0000-000000000000",
-					ID:            "abc",
+					DisplayName: "Example Service Principal",
+					Active:      true,
+					ID:          "abc",
 					Entitlements: []entitlementsListItem{
 						{
 							Value: AllowClusterCreateEntitlement,
@@ -264,7 +255,6 @@ func TestResourceServicePrincipalUpdate(t *testing.T) {
 		Update:   true,
 		ID:       "abc",
 		HCL: `
-		application_id    = "00000000-0000-0000-0000-000000000000"
 		display_name = "Changed Name"
 		allow_cluster_create = false
 		allow_instance_pool_create = true
@@ -272,7 +262,6 @@ func TestResourceServicePrincipalUpdate(t *testing.T) {
 	}.Apply(t)
 	require.NoError(t, err, err)
 	assert.Equal(t, "abc", d.Id(), "Id should not be empty")
-	assert.Equal(t, "00000000-0000-0000-0000-000000000000", d.Get("application_id"))
 	assert.Equal(t, "Changed Name", d.Get("display_name"))
 	assert.Equal(t, false, d.Get("allow_cluster_create"))
 	assert.Equal(t, true, d.Get("allow_instance_pool_create"))
@@ -291,7 +280,6 @@ func TestResourceServicePrincipalUpdate_Error(t *testing.T) {
 		Update:   true,
 		ID:       "abc",
 		HCL: `
-		application_id    = "00000000-0000-0000-0000-000000000000"
 		display_name = "Changed Name"
 		allow_cluster_create = false
 		allow_instance_pool_create = true
@@ -307,10 +295,9 @@ func TestResourceServicePrincipalUpdate_ErrorPut(t *testing.T) {
 				Method:   "GET",
 				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals/abc",
 				Response: ScimUser{
-					DisplayName:   "Example Service Principal",
-					Active:        true,
-					ApplicationID: "00000000-0000-0000-0000-000000000000",
-					ID:            "abc",
+					DisplayName: "Example Service Principal",
+					Active:      true,
+					ID:          "abc",
 					Entitlements: []entitlementsListItem{
 						{
 							Value: AllowClusterCreateEntitlement,
@@ -338,7 +325,6 @@ func TestResourceServicePrincipalUpdate_ErrorPut(t *testing.T) {
 		Update:   true,
 		ID:       "abc",
 		HCL: `
-		application_id    = "00000000-0000-0000-0000-000000000000"
 		display_name = "Changed Name"
 		allow_cluster_create = false
 		allow_instance_pool_create = true

--- a/identity/resource_service_principal_test.go
+++ b/identity/resource_service_principal_test.go
@@ -193,6 +193,17 @@ func TestResourceServicePrincipalCreate_Error(t *testing.T) {
 	require.Error(t, err, err)
 }
 
+func TestResourceServicePrincipalCreate_Error_AzureNoApplicationID(t *testing.T) {
+	qa.ResourceFixture{
+		Resource: ResourceServicePrincipal(),
+		Create:   true,
+		Azure:    true,
+		HCL: `
+		display_name = "abc"
+		`,
+	}.ExpectError(t, "application_id is required for service principals in Azure Databricks")
+}
+
 func TestResourceServicePrincipalUpdate(t *testing.T) {
 	newServicePrincipal := ScimUser{
 		Schemas:     []URN{ServicePrincipalSchema},


### PR DESCRIPTION
## 0.3.5

* Fixed setting of permissions for SQLA endpoints ([#661](https://github.com/databrickslabs/terraform-provider-databricks/issues/661))
* Added support for preloading of Docker images into instance pools ([#663](https://github.com/databrickslabs/terraform-provider-databricks/issues/663))
* Added the `databricks_user` data source ([#648](https://github.com/databrickslabs/terraform-provider-databricks/pull/648))
* Fixed support for `spot_instance_policy` in SQLA Endpoints ([#665](https://github.com/databrickslabs/terraform-provider-databricks/issues/665))
* Added documentation for `databricks_pipeline` resource ([#673](https://github.com/databrickslabs/terraform-provider-databricks/pull/673))
* Fixed mapping for `databricks_service_principal` on AWS ([#656](https://github.com/databrickslabs/terraform-provider-databricks/issues/656))
* Made preview environment tests to run on a release basis

Updated dependency versions:

* Bump github.com/zclconf/go-cty from 1.8.2 to 1.8.3
* Bump github.com/aws/aws-sdk-go from 1.38.30 to 1.38.51

preview
---

 * [x] compute/acceptance.TestPreviewAccPipelineResource_CreatePipeline (8.58s)
 * [x] sqlanalytics.TestPreviewAccSQLEndpoints (271.86s)
 * [x] sqlanalytics/acceptance.TestPreviewAccDashboard (687.95s)
 * [x] sqlanalytics/acceptance.TestPreviewAccQuery (288.57s)
 * [x] sqlanalytics/acceptance.TestPreviewAccSQLEndpoint (285.84s)

awsmt
---
 * [x] TestAccClusterResource_CreateClusterWithLibraries (222.75s)
 * [x] access.TestAccIPACL (2.75s)
 * [x] access.TestAccPermissionsClusterPolicy (16.30s)
 * [x] access.TestAccPermissionsClusters (203.37s)
 * [x] access.TestAccPermissionsInstancePool (17.98s)
 * [x] access.TestAccPermissionsJobs (15.60s)
 * [x] access.TestAccPermissionsNotebooks (16.92s)
 * [x] access.TestAccPermissionsTokens (14.45s)
 * [x] access/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (45.50s)
 * [x] access/acceptance.TestAccInitialManagePrincipals (3.43s)
 * [x] access/acceptance.TestAccInitialManagePrincipalsGroup (1.83s)
 * [x] access/acceptance.TestAccSecretAclResource (15.24s)
 * [x] access/acceptance.TestAccSecretAclResourceDefaultPrincipal (6.21s)
 * [x] access/acceptance.TestAccSecretResource (6.65s)
 * [x] access/acceptance.TestAccSecretScopeResource (8.28s)
 * [x] access/acceptance.TestAccTableACL (457.93s)
 * [x] compute.TestAccContext (119.33s)
 * [x] compute.TestAccInstancePools (2.05s)
 * [x] compute.TestAccLibraryCreate (143.11s)
 * [x] compute.TestAccListClustersIntegration (187.78s)
 * [x] compute.TestAwsAccSmallestNodeType (0.22s)
 * [x] compute/acceptance.TestAccClusterPolicyResourceFullLifecycle (18.35s)
 * [x] compute/acceptance.TestAccClusterResource_CreateSingleNodeCluster (56.24s)
 * [x] compute/acceptance.TestAccJobResource (3.05s)
 * [x] compute/acceptance.TestAwsAccJobResource_NoInstancePool (3.39s)
 * [x] compute/acceptance.TestAwsAccJobsCreate (1.87s)
 * [x] identity.TestAccCreateToken (0.75s)
 * [x] identity.TestAccCreateToken_NoExpiration (0.47s)
 * [x] identity.TestAccCreateUser (9.55s)
 * [x] identity.TestAccFilterGroup (1.79s)
 * [x] identity.TestAccGroup (24.87s)
 * [x] identity.TestAccReadUser (2.18s)
 * [x] identity.TestAwsAccInstanceProfiles (351.63s)
 * [x] identity/acceptance.TestAccGroupMemberResource (23.14s)
 * [x] identity/acceptance.TestAccGroupResource (25.93s)
 * [x] identity/acceptance.TestAccGroupResource_verify_entitlements (14.65s)
 * [x] identity/acceptance.TestAccTokenResource (4.12s)
 * [x] identity/acceptance.TestAccUserResource (17.09s)
 * [x] identity/acceptance.TestAwsAccGroupInstanceProfileResource (926.05s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace (5.24s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies (0.56s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies_Delete (0.49s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Clusters (0.14s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/DBFS_Files (1.00s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Groups (0.66s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Instance_Pools (0.51s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Instance_Profiles (0.40s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Jobs (0.18s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Notebooks (0.16s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_ACLs (0.47s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_Scopes (0.06s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secrets (0.12s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Tokens (0.31s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Users (0.17s)
 * [x] internal/sanity.TestAccMutiworkspaceUsedFromNormalMode (1.29s)
 * [x] storage.TestAccCreateFile (5.06s)
 * [x] storage.TestAccDeleteInvalidMountFails (3.95s)
 * [x] storage.TestAccInvalidSecretScopeFails (3.18s)
 * [x] storage.TestAccSourceOnInvalidMountFails (31.98s)
 * [x] storage.TestAwsAccS3Mount (371.02s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (5.49s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (2.76s)
 * [x] storage/acceptance.TestAwsAccS3IamMount_NoClusterGiven (557.37s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (7.01s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (7.91s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (5.13s)

azcli
---

 * [x] access.TestAccIPACL (12.50s)
 * [x] access.TestAccPermissionsClusterPolicy (14.31s)
 * [x] access.TestAccPermissionsClusters (616.21s)
 * [x] access.TestAccPermissionsInstancePool (18.25s)
 * [x] access.TestAccPermissionsJobs (15.81s)
 * [x] access.TestAccPermissionsNotebooks (15.91s)
 * [x] access.TestAccPermissionsTokens (13.45s)
 * [x] access/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (55.71s)
 * [x] access/acceptance.TestAccInitialManagePrincipals (2.75s)
 * [x] access/acceptance.TestAccInitialManagePrincipalsGroup (1.57s)
 * [x] access/acceptance.TestAccSecretAclResource (17.56s)
 * [x] access/acceptance.TestAccSecretAclResourceDefaultPrincipal (13.63s)
 * [x] access/acceptance.TestAccSecretResource (22.65s)
 * [x] access/acceptance.TestAccSecretScopeResource (20.10s)
 * [x] access/acceptance.TestAccTableACL (576.53s)
 * [x] access/acceptance.TestAzureAccKeyVaultSimple (4.15s)
 * [x] compute.TestAccContext (43.08s)
 * [x] compute.TestAccInstancePools (4.73s)
 * [x] compute.TestAccLibraryCreate (58.13s)
 * [x] compute.TestAccListClustersIntegration (589.34s)
 * [x] compute.TestAzureAccNodeTypes (1.61s)
 * [x] compute/acceptance.TestAccClusterPolicyResourceFullLifecycle (31.39s)
 * [x] compute/acceptance.TestAccJobResource (14.57s)
 * [x] identity.TestAccCreateToken (2.88s)
 * [x] identity.TestAccCreateToken_NoExpiration (4.29s)
 * [x] identity.TestAccCreateUser (7.81s)
 * [x] identity.TestAccFilterGroup (3.44s)
 * [x] identity.TestAccGroup (31.17s)
 * [x] identity.TestAccReadUser (3.82s)
 * [x] identity.TestAzureAccSP (8.92s)
 * [x] identity/acceptance.TestAccGroupMemberResource (29.89s)
 * [x] identity/acceptance.TestAccGroupResource (36.07s)
 * [x] identity/acceptance.TestAccGroupResource_verify_entitlements (21.69s)
 * [x] identity/acceptance.TestAccTokenResource (12.52s)
 * [x] identity/acceptance.TestAccUserResource (24.67s)
 * [x] identity/acceptance.TestAzureAccServicePrincipalResource (25.64s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace (10.63s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies (0.54s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies_Delete (0.78s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Clusters (3.24s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/DBFS_Files (1.29s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Groups (0.58s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Instance_Pools (0.53s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Jobs (0.56s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Notebooks (0.47s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_ACLs (0.53s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_Scopes (0.45s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secrets (0.58s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Tokens (0.67s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Users (0.42s)
 * [x] internal/sanity.TestAccMutiworkspaceUsedFromNormalMode (14.46s)
 * [x] storage.TestAccCreateFile (15.97s)
 * [x] storage.TestAccDeleteInvalidMountFails (11.13s)
 * [x] storage.TestAccInvalidSecretScopeFails (7.03s)
 * [x] storage.TestAccSourceOnInvalidMountFails (36.15s)
 * [x] storage.TestAzureAccBlobMount (144.19s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (19.86s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (8.75s)
 * [x] storage/acceptance.TestAzureAccBlobMount_correctly_mounts (763.48s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (17.36s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (22.44s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (11.45s)

azsp
---
 * [x] TestAzureAccADLSv2Mount (40.13s)
 * [x] TestAzureAccAdlsGen2Mount_correctly_mounts (10.08s)
 * [x] access.TestAccIPACL (3.18s)
 * [x] access.TestAccPermissionsClusterPolicy (9.91s)
 * [x] access.TestAccPermissionsClusters (329.88s)
 * [x] access.TestAccPermissionsInstancePool (11.50s)
 * [x] access.TestAccPermissionsJobs (13.02s)
 * [x] access.TestAccPermissionsNotebooks (13.90s)
 * [x] access.TestAccPermissionsTokens (12.40s)
 * [x] access/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (31.35s)
 * [x] access/acceptance.TestAccInitialManagePrincipals (2.93s)
 * [x] access/acceptance.TestAccInitialManagePrincipalsGroup (1.77s)
 * [x] access/acceptance.TestAccSecretAclResource (12.51s)
 * [x] access/acceptance.TestAccSecretAclResourceDefaultPrincipal (7.36s)
 * [x] access/acceptance.TestAccSecretResource (11.07s)
 * [x] access/acceptance.TestAccSecretScopeResource (10.64s)
 * [x] access/acceptance.TestAccTableACL (555.74s)
 * [x] compute.TestAccContext (15.18s)
 * [x] compute.TestAccInstancePools (3.00s)
 * [x] compute.TestAccLibraryCreate (56.30s)
 * [x] compute.TestAccListClustersIntegration (342.34s)
 * [x] compute.TestAzureAccNodeTypes (0.41s)
 * [x] compute/acceptance.TestAccClusterPolicyResourceFullLifecycle (16.91s)
 * [x] compute/acceptance.TestAccJobResource (6.04s)
 * [x] identity.TestAccCreateToken (2.75s)
 * [x] identity.TestAccCreateToken_NoExpiration (1.74s)
 * [x] identity.TestAccCreateUser (6.90s)
 * [x] identity.TestAccFilterGroup (1.60s)
 * [x] identity.TestAccGroup (17.04s)
 * [x] identity.TestAccReadUser (1.55s)
 * [x] identity.TestAzureAccSP (5.50s)
 * [x] identity/acceptance.TestAccGroupMemberResource (23.11s)
 * [x] identity/acceptance.TestAccGroupResource (16.07s)
 * [x] identity/acceptance.TestAccGroupResource_verify_entitlements (13.52s)
 * [x] identity/acceptance.TestAccTokenResource (6.79s)
 * [x] identity/acceptance.TestAccUserResource (15.91s)
 * [x] identity/acceptance.TestAzureAccServicePrincipalResource (14.38s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace (4.42s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies (0.37s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies_Delete (0.34s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Clusters (0.19s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/DBFS_Files (0.71s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Groups (0.79s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Instance_Pools (0.11s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Jobs (0.12s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Notebooks (0.32s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_ACLs (0.90s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_Scopes (0.04s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secrets (0.11s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Tokens (0.28s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Users (0.15s)
 * [x] internal/sanity.TestAccMutiworkspaceUsedFromNormalMode (4.20s)
 * [x] storage.TestAccCreateFile (4.77s)
 * [x] storage.TestAccDeleteInvalidMountFails (2.95s)
 * [x] storage.TestAccInvalidSecretScopeFails (2.66s)
 * [x] storage.TestAccSourceOnInvalidMountFails (31.46s)
 * [x] storage.TestAzureAccADLSv1Mount (473.02s)
 * [x] storage.TestAzureAccBlobMount (137.48s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (10.10s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (4.66s)
 * [x] storage/acceptance.TestAzureAccAdlsGen1Mount_correctly_mounts (506.70s)
 * [x] storage/acceptance.TestAzureAccBlobMount_correctly_mounts (410.84s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (6.98s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (10.50s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (5.19s)

mws
---

 * [x] mws.TestMwsAccCreds (2.51s)
 * [x] mws.TestMwsAccCustomerManagedKeys (3.35s)
 * [x] mws.TestMwsAccLogDelivery (7.07s)
 * [x] mws.TestMwsAccMissingResources (3.63s)
 * [x] mws.TestMwsAccMissingResources/Credential (1.16s)
 * [x] mws.TestMwsAccMissingResources/Customer_Managed_Key (0.60s)
 * [x] mws.TestMwsAccMissingResources/Network (0.61s)
 * [x] mws.TestMwsAccMissingResources/Storage (0.59s)
 * [x] mws.TestMwsAccMissingResources/Workspace (0.67s)
 * [x] mws.TestMwsAccPAS (2.36s)
 * [x] mws.TestMwsAccStorageConfigurations (2.06s)
 * [x] mws.TestMwsAccVPCEndpointIntegration (128.65s)
 * [x] mws.TestMwsAccWorkspace (0.68s)
 * [x] mws/acceptance.TestMwsAccCredentials (5.06s)
 * [x] mws/acceptance.TestMwsAccCustomerManagedKeys (8.23s)
 * [x] mws/acceptance.TestMwsAccLogDelivery (11.28s)
 * [x] mws/acceptance.TestMwsAccNetworks (5.23s)
 * [x] mws/acceptance.TestMwsAccPrivateAccessSettings (5.02s)
 * [x] mws/acceptance.TestMwsAccStorageConfigurations (5.05s)
 * [x] mws/acceptance.TestMwsAccVpcEndpoint (107.67s)
 * [x] mws/acceptance.TestMwsAccWorkspaces (147.53s)
