### PR TITLE
Fix ActiveDirectoryEndpoint in adls gen1-2 mounts

### DIFF
--- a/common/azure_auth.go
+++ b/common/azure_auth.go
@@ -69,7 +69,7 @@ type tokenInfo struct {
 
 var authorizerMutex sync.Mutex
 
-func (aa *AzureAuth) getAzureEnvironment() (azure.Environment, error) {
+func (aa *AzureAuth) GetAzureEnvironment() (azure.Environment, error) {
 	// Used for unit testing purposes
 	if aa.azureManagementEndpoint != "" {
 		return azure.Environment{
@@ -172,7 +172,7 @@ func (aa *AzureAuth) simpleAADRequestVisitor(
 	ctx context.Context,
 	authorizerFactory func(resource string) (autorest.Authorizer, error),
 	visitors ...func(r *http.Request, ma autorest.Authorizer) error) (func(r *http.Request) error, error) {
-	env, err := aa.getAzureEnvironment()
+	env, err := aa.GetAzureEnvironment()
 	if err != nil {
 		return nil, err
 	}
@@ -220,7 +220,7 @@ func (aa *AzureAuth) acquirePAT(
 	if aa.temporaryPat != nil {
 		return aa.temporaryPat, nil
 	}
-	env, err := aa.getAzureEnvironment()
+	env, err := aa.GetAzureEnvironment()
 	if err != nil {
 		return nil, err
 	}
@@ -294,7 +294,7 @@ func (aa *AzureAuth) ensureWorkspaceURL(ctx context.Context,
 		return fmt.Errorf("somehow resource id is not set")
 	}
 	log.Println("[DEBUG] Getting Workspace ID via management token.")
-	env, err := aa.getAzureEnvironment()
+	env, err := aa.GetAzureEnvironment()
 	if err != nil {
 		return maybeExtendAuthzError(err)
 	}
@@ -341,7 +341,7 @@ func (aa *AzureAuth) getClientSecretAuthorizer(resource string) (autorest.Author
 		// todo: probably should be two different ones...
 		return aa.authorizer, nil
 	}
-	env, err := aa.getAzureEnvironment()
+	env, err := aa.GetAzureEnvironment()
 	if err != nil {
 		return nil, err
 	}

--- a/common/azure_auth.go
+++ b/common/azure_auth.go
@@ -292,9 +292,13 @@ func (aa *AzureAuth) ensureWorkspaceURL(ctx context.Context,
 	if resourceID == "" {
 		return fmt.Errorf("somehow resource id is not set")
 	}
+	env, err := aa.getAzureEnvironment()
+	if err != nil {
+		return maybeExtendAuthzError(err)
+	}
 	log.Println("[DEBUG] Getting Workspace ID via management token.")
 	// All azure endpoints typically end with a trailing slash removing it because resourceID starts with slash
-	managementResourceURL := strings.TrimSuffix(aa.AzureEnvironment.ResourceManagerEndpoint, "/") + resourceID
+	managementResourceURL := strings.TrimSuffix(env.ResourceManagerEndpoint, "/") + resourceID
 	var workspace azureDatabricksWorkspace
 	resp, err := aa.databricksClient.genericQuery(ctx, http.MethodGet,
 		managementResourceURL,

--- a/common/azure_auth_test.go
+++ b/common/azure_auth_test.go
@@ -336,7 +336,7 @@ func TestAzureAuth_configureWithClientSecretAAD(t *testing.T) {
 func TestAzureEnvironment_WithAzureManagementEndpoint(t *testing.T) {
 	fakeEndpoint := "http://google.com"
 	aa := AzureAuth{azureManagementEndpoint: fakeEndpoint}
-	env, err := aa.getAzureEnvironment()
+	env, err := aa.GetAzureEnvironment()
 	assert.Nil(t, err)
 	// This value should be populated with azureManagementEndpoint for testing
 	assert.Equal(t, env.ResourceManagerEndpoint, fakeEndpoint)
@@ -345,40 +345,40 @@ func TestAzureEnvironment_WithAzureManagementEndpoint(t *testing.T) {
 
 	// Making the azureManagementEndpoint empty should yield PublicCloud
 	aa.azureManagementEndpoint = ""
-	env, err = aa.getAzureEnvironment()
+	env, err = aa.GetAzureEnvironment()
 	assert.Nil(t, err)
 	assert.Equal(t, azure.PublicCloud, env)
 }
 
 func TestAzureEnvironment(t *testing.T) {
 	aa := AzureAuth{}
-	env, err := aa.getAzureEnvironment()
+	env, err := aa.GetAzureEnvironment()
 
 	assert.Nil(t, err)
 	assert.Equal(t, azure.PublicCloud, env)
 
 	aa.Environment = "public"
-	env, err = aa.getAzureEnvironment()
+	env, err = aa.GetAzureEnvironment()
 	assert.Nil(t, err)
 	assert.Equal(t, azure.PublicCloud, env)
 
 	aa.Environment = "china"
-	env, err = aa.getAzureEnvironment()
+	env, err = aa.GetAzureEnvironment()
 	assert.Nil(t, err)
 	assert.Equal(t, azure.ChinaCloud, env)
 
 	aa.Environment = "german"
-	env, err = aa.getAzureEnvironment()
+	env, err = aa.GetAzureEnvironment()
 	assert.Nil(t, err)
 	assert.Equal(t, azure.GermanCloud, env)
 
 	aa.Environment = "usgovernment"
-	env, err = aa.getAzureEnvironment()
+	env, err = aa.GetAzureEnvironment()
 	assert.Nil(t, err)
 	assert.Equal(t, azure.USGovernmentCloud, env)
 
 	aa.Environment = "xyzdummy"
-	_, err = aa.getAzureEnvironment()
+	_, err = aa.GetAzureEnvironment()
 	assert.NotNil(t, err)
 }
 
@@ -386,7 +386,7 @@ func TestInvalidAzureEnvironment(t *testing.T) {
 	aa := AzureAuth{}
 
 	aa.Environment = "xyzdummy"
-	_, envErr := aa.getAzureEnvironment()
+	_, envErr := aa.GetAzureEnvironment()
 	assert.NotNil(t, envErr)
 
 	mockFunc := func(resource string) (autorest.Authorizer, error) {

--- a/common/azure_auth_test.go
+++ b/common/azure_auth_test.go
@@ -83,6 +83,9 @@ func TestAddSpManagementTokenVisitor_RefreshedError(t *testing.T) {
 
 func TestGetClientSecretAuthorizer(t *testing.T) {
 	aa := AzureAuth{}
+	env, err := aa.getAzureEnvironment()
+	require.NoError(t, err)
+	aa.AzureEnvironment = &env
 	auth, err := aa.getClientSecretAuthorizer(AzureDatabricksResourceID)
 	require.Nil(t, auth)
 	require.EqualError(t, err, "parameter 'clientID' cannot be empty")
@@ -97,7 +100,10 @@ func TestGetClientSecretAuthorizer(t *testing.T) {
 
 func TestEnsureWorkspaceURL_CornerCases(t *testing.T) {
 	aa := AzureAuth{}
-	err := aa.ensureWorkspaceURL(context.Background(), nil)
+	env, err := aa.getAzureEnvironment()
+	require.NoError(t, err)
+	aa.AzureEnvironment = &env
+	err = aa.ensureWorkspaceURL(context.Background(), nil)
 	assert.EqualError(t, err, "DatabricksClient is not configured")
 
 	aa.databricksClient = &DatabricksClient{}
@@ -111,13 +117,14 @@ func TestEnsureWorkspaceURL_CornerCases(t *testing.T) {
 		WorkspaceName:    "c",
 		databricksClient: &DatabricksClient{},
 	}
-	err = aa.ensureWorkspaceURL(context.Background(), nil)
-	assert.EqualError(t, err, "autorest/azure: There is no cloud environment matching the name \"AZUREXYZCLOUD\"")
 }
 
 func TestAcquirePAT_CornerCases(t *testing.T) {
 	aa := AzureAuth{}
-	_, err := aa.acquirePAT(context.Background(), func(resource string) (autorest.Authorizer, error) {
+	env, err := aa.getAzureEnvironment()
+	require.NoError(t, err)
+	aa.AzureEnvironment = &env
+	_, err = aa.acquirePAT(context.Background(), func(resource string) (autorest.Authorizer, error) {
 		return &autorest.BearerAuthorizer{}, fmt.Errorf("test")
 	})
 	assert.EqualError(t, err, "test")
@@ -140,6 +147,9 @@ func TestAcquirePAT_CornerCases(t *testing.T) {
 
 func TestAzureAuth_ensureWorkspaceURL(t *testing.T) {
 	aa := AzureAuth{}
+	env, err := aa.getAzureEnvironment()
+	require.NoError(t, err)
+	aa.AzureEnvironment = &env
 
 	cnt := []int{0}
 	var serverURL string
@@ -175,7 +185,7 @@ func TestAzureAuth_ensureWorkspaceURL(t *testing.T) {
 		Type:        "Bearer",
 	}
 	authorizer := autorest.NewBearerAuthorizer(token)
-	err := aa.ensureWorkspaceURL(context.Background(), authorizer)
+	err = aa.ensureWorkspaceURL(context.Background(), authorizer)
 	assert.NoError(t, err)
 
 	err = aa.ensureWorkspaceURL(context.Background(), authorizer)
@@ -336,7 +346,7 @@ func TestAzureAuth_configureWithClientSecretAAD(t *testing.T) {
 func TestAzureEnvironment_WithAzureManagementEndpoint(t *testing.T) {
 	fakeEndpoint := "http://google.com"
 	aa := AzureAuth{azureManagementEndpoint: fakeEndpoint}
-	env, err := aa.GetAzureEnvironment()
+	env, err := aa.getAzureEnvironment()
 	assert.Nil(t, err)
 	// This value should be populated with azureManagementEndpoint for testing
 	assert.Equal(t, env.ResourceManagerEndpoint, fakeEndpoint)
@@ -345,64 +355,41 @@ func TestAzureEnvironment_WithAzureManagementEndpoint(t *testing.T) {
 
 	// Making the azureManagementEndpoint empty should yield PublicCloud
 	aa.azureManagementEndpoint = ""
-	env, err = aa.GetAzureEnvironment()
+	env, err = aa.getAzureEnvironment()
 	assert.Nil(t, err)
 	assert.Equal(t, azure.PublicCloud, env)
 }
 
 func TestAzureEnvironment(t *testing.T) {
 	aa := AzureAuth{}
-	env, err := aa.GetAzureEnvironment()
+	env, err := aa.getAzureEnvironment()
 
 	assert.Nil(t, err)
 	assert.Equal(t, azure.PublicCloud, env)
 
 	aa.Environment = "public"
-	env, err = aa.GetAzureEnvironment()
+	env, err = aa.getAzureEnvironment()
 	assert.Nil(t, err)
 	assert.Equal(t, azure.PublicCloud, env)
 
 	aa.Environment = "china"
-	env, err = aa.GetAzureEnvironment()
+	env, err = aa.getAzureEnvironment()
 	assert.Nil(t, err)
 	assert.Equal(t, azure.ChinaCloud, env)
 
 	aa.Environment = "german"
-	env, err = aa.GetAzureEnvironment()
+	env, err = aa.getAzureEnvironment()
 	assert.Nil(t, err)
 	assert.Equal(t, azure.GermanCloud, env)
 
 	aa.Environment = "usgovernment"
-	env, err = aa.GetAzureEnvironment()
+	env, err = aa.getAzureEnvironment()
 	assert.Nil(t, err)
 	assert.Equal(t, azure.USGovernmentCloud, env)
 
 	aa.Environment = "xyzdummy"
-	_, err = aa.GetAzureEnvironment()
+	_, err = aa.getAzureEnvironment()
 	assert.NotNil(t, err)
-}
-
-func TestInvalidAzureEnvironment(t *testing.T) {
-	aa := AzureAuth{}
-
-	aa.Environment = "xyzdummy"
-	_, envErr := aa.GetAzureEnvironment()
-	assert.NotNil(t, envErr)
-
-	mockFunc := func(resource string) (autorest.Authorizer, error) {
-		return nil, nil
-	}
-
-	ctx := context.Background()
-	_, err := aa.simpleAADRequestVisitor(ctx, mockFunc)
-
-	assert.Equal(t, envErr, err)
-
-	_, err = aa.acquirePAT(ctx, mockFunc)
-	assert.Equal(t, envErr, err)
-
-	_, err = aa.getClientSecretAuthorizer("")
-	assert.Equal(t, envErr, err)
 }
 
 func TestMaybeExtendError(t *testing.T) {

--- a/common/azure_cli_auth.go
+++ b/common/azure_cli_auth.go
@@ -105,8 +105,13 @@ func (aa *AzureAuth) configureWithAzureCLI() (func(r *http.Request) error, error
 	if aa.IsClientSecretSet() {
 		return nil, nil
 	}
+	azureEnvironment, err := aa.getAzureEnvironment()
+	if err != nil {
+		return nil, err
+	}
+	aa.AzureEnvironment = &azureEnvironment
 	// verify that Azure CLI is authenticated
-	_, err := cli.GetTokenFromCLI(AzureDatabricksResourceID)
+	_, err = cli.GetTokenFromCLI(AzureDatabricksResourceID)
 	if err != nil {
 		if err.Error() == "Invoking Azure CLI failed with the following error: " {
 			return nil, fmt.Errorf("most likely Azure CLI is not installed. " +

--- a/qa/testing.go
+++ b/qa/testing.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/databrickslabs/terraform-provider-databricks/common"
 	"github.com/databrickslabs/terraform-provider-databricks/internal"
 
@@ -422,9 +423,12 @@ func HttpFixtureClient(t *testing.T, fixtures []HTTPFixture) (client *common.Dat
 			t.FailNow()
 		}
 	}))
+	aa := common.AzureAuth{}
+	aa.AzureEnvironment = &azure.PublicCloud
 	client = &common.DatabricksClient{
-		Host:  server.URL,
-		Token: "...",
+		Host:      server.URL,
+		Token:     "...",
+		AzureAuth: aa,
 	}
 	err = client.Configure()
 	return client, server, err

--- a/storage/adls_gen1_mount.go
+++ b/storage/adls_gen1_mount.go
@@ -3,6 +3,8 @@ package storage
 import (
 	"fmt"
 
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/databrickslabs/terraform-provider-databricks/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -24,13 +26,20 @@ func (m AzureADLSGen1Mount) Source() string {
 }
 
 // Config ...
-func (m AzureADLSGen1Mount) Config() map[string]string {
+func (m AzureADLSGen1Mount) Config(client *common.DatabricksClient) map[string]string {
+	azureEnvironment, err := client.AzureAuth.GetAzureEnvironment()
+	var clientEndpoint string
+	if err != nil {
+		clientEndpoint = azure.PublicCloud.ActiveDirectoryEndpoint
+	} else {
+		clientEndpoint = azureEnvironment.ActiveDirectoryEndpoint
+	}
 	return map[string]string{
 		m.PrefixType + ".oauth2.access.token.provider.type": "ClientCredential",
 
 		m.PrefixType + ".oauth2.client.id":   m.ClientID,
 		m.PrefixType + ".oauth2.credential":  fmt.Sprintf("{secrets/%s/%s}", m.SecretScope, m.SecretKey),
-		m.PrefixType + ".oauth2.refresh.url": fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/token", m.TenantID),
+		m.PrefixType + ".oauth2.refresh.url": fmt.Sprintf("%s/%s/oauth2/token", clientEndpoint, m.TenantID),
 	}
 }
 

--- a/storage/adls_gen1_mount.go
+++ b/storage/adls_gen1_mount.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"fmt"
 
-	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/databrickslabs/terraform-provider-databricks/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -27,19 +26,11 @@ func (m AzureADLSGen1Mount) Source() string {
 
 // Config ...
 func (m AzureADLSGen1Mount) Config(client *common.DatabricksClient) map[string]string {
-	azureEnvironment, err := client.AzureAuth.GetAzureEnvironment()
-	var clientEndpoint string
-	if err != nil {
-		clientEndpoint = azure.PublicCloud.ActiveDirectoryEndpoint
-	} else {
-		clientEndpoint = azureEnvironment.ActiveDirectoryEndpoint
-	}
 	return map[string]string{
 		m.PrefixType + ".oauth2.access.token.provider.type": "ClientCredential",
-
-		m.PrefixType + ".oauth2.client.id":   m.ClientID,
-		m.PrefixType + ".oauth2.credential":  fmt.Sprintf("{secrets/%s/%s}", m.SecretScope, m.SecretKey),
-		m.PrefixType + ".oauth2.refresh.url": fmt.Sprintf("%s/%s/oauth2/token", clientEndpoint, m.TenantID),
+		m.PrefixType + ".oauth2.client.id":                  m.ClientID,
+		m.PrefixType + ".oauth2.credential":                 fmt.Sprintf("{secrets/%s/%s}", m.SecretScope, m.SecretKey),
+		m.PrefixType + ".oauth2.refresh.url":                fmt.Sprintf("%s/%s/oauth2/token", client.AzureAuth.AzureEnvironment.ActiveDirectoryEndpoint, m.TenantID),
 	}
 }
 

--- a/storage/adls_gen2_mount.go
+++ b/storage/adls_gen2_mount.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"fmt"
 
-	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/databrickslabs/terraform-provider-databricks/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -28,19 +27,12 @@ func (m AzureADLSGen2Mount) Source() string {
 
 // Config returns mount configurations
 func (m AzureADLSGen2Mount) Config(client *common.DatabricksClient) map[string]string {
-	azureEnvironment, err := client.AzureAuth.GetAzureEnvironment()
-	var clientEndpoint string
-	if err != nil {
-		clientEndpoint = azure.PublicCloud.ActiveDirectoryEndpoint
-	} else {
-		clientEndpoint = azureEnvironment.ActiveDirectoryEndpoint
-	}
 	return map[string]string{
 		"fs.azure.account.auth.type":                          "OAuth",
 		"fs.azure.account.oauth.provider.type":                "org.apache.hadoop.fs.azurebfs.oauth2.ClientCredsTokenProvider",
 		"fs.azure.account.oauth2.client.id":                   m.ClientID,
 		"fs.azure.account.oauth2.client.secret":               fmt.Sprintf("{secrets/%s/%s}", m.SecretScope, m.SecretKey),
-		"fs.azure.account.oauth2.client.endpoint":             fmt.Sprintf("%s/%s/oauth2/token", clientEndpoint, m.TenantID),
+		"fs.azure.account.oauth2.client.endpoint":             fmt.Sprintf("%s/%s/oauth2/token", client.AzureAuth.AzureEnvironment.ActiveDirectoryEndpoint, m.TenantID),
 		"fs.azure.createRemoteFileSystemDuringInitialization": fmt.Sprintf("%t", m.InitializeFileSystem),
 	}
 }

--- a/storage/aws_s3_mount.go
+++ b/storage/aws_s3_mount.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/databrickslabs/terraform-provider-databricks/common"
 	"github.com/databrickslabs/terraform-provider-databricks/compute"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -22,7 +23,7 @@ func (m AWSIamMount) Source() string {
 }
 
 // Config ...
-func (m AWSIamMount) Config() map[string]string {
+func (m AWSIamMount) Config(client *common.DatabricksClient) map[string]string {
 	return make(map[string]string) // return empty map so nil map does not marshal to null
 }
 

--- a/storage/azure_blob_mount.go
+++ b/storage/azure_blob_mount.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"fmt"
 
+	"github.com/databrickslabs/terraform-provider-databricks/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -24,7 +25,7 @@ func (m AzureBlobMount) Source() string {
 }
 
 // Config ...
-func (m AzureBlobMount) Config() map[string]string {
+func (m AzureBlobMount) Config(client *common.DatabricksClient) map[string]string {
 	var confKey string
 	if m.AuthType == "SAS" {
 		confKey = fmt.Sprintf("fs.azure.sas.%s.%s.blob.core.windows.net", m.ContainerName, m.StorageAccountName)

--- a/storage/mounts.go
+++ b/storage/mounts.go
@@ -19,7 +19,7 @@ import (
 // Mount exposes generic url & extra config map options
 type Mount interface {
 	Source() string
-	Config() map[string]string
+	Config(client *common.DatabricksClient) map[string]string
 }
 
 // MountPoint is something actionable
@@ -63,8 +63,8 @@ func (mp MountPoint) Delete() error {
 }
 
 // Mount mounts object store on workspace
-func (mp MountPoint) Mount(mo Mount) (source string, err error) {
-	extraConfigs, err := json.Marshal(mo.Config())
+func (mp MountPoint) Mount(mo Mount, client *common.DatabricksClient) (source string, err error) {
+	extraConfigs, err := json.Marshal(mo.Config(client))
 	if err != nil {
 		return
 	}
@@ -202,8 +202,9 @@ func mountCreate(tpl interface{}, r *schema.Resource) func(context.Context, *sch
 		if err != nil {
 			return diag.FromErr(err)
 		}
+		client := m.(*common.DatabricksClient)
 		log.Printf("[INFO] Mounting %s at /mnt/%s", mountConfig.Source(), d.Id())
-		source, err := mountPoint.Mount(mountConfig)
+		source, err := mountPoint.Mount(mountConfig, client)
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/storage/mounts_test.go
+++ b/storage/mounts_test.go
@@ -177,8 +177,11 @@ func TestMountPoint_Mount(t *testing.T) {
 		dbutils.notebook.exit(mount_source)
 	`, mountName, expectedMountSource, expectedMountConfig)
 	testMountFuncHelper(t, func(mp MountPoint, mount Mount) (s string, e error) {
-		client := common.CommonEnvironmentClient()
-		return mp.Mount(mount, client)
+		client := common.DatabricksClient{
+			Host:  ".",
+			Token: ".",
+		}
+		return mp.Mount(mount, &client)
 	}, mount, mountName, expectedCommand)
 }
 

--- a/storage/mounts_test.go
+++ b/storage/mounts_test.go
@@ -59,7 +59,8 @@ func testWithNewSecretScope(t *testing.T, callback func(string, string),
 }
 
 func testMounting(t *testing.T, mp MountPoint, m Mount) {
-	source, err := mp.Mount(m)
+	client := common.CommonEnvironmentClient()
+	source, err := mp.Mount(m, client)
 	assert.Equal(t, m.Source(), source)
 	assert.NoError(t, err)
 	defer func() {
@@ -79,6 +80,7 @@ func TestAccSourceOnInvalidMountFails(t *testing.T) {
 
 func TestAccInvalidSecretScopeFails(t *testing.T) {
 	_, mp := mountPointThroughReusedCluster(t)
+	client := common.CommonEnvironmentClient()
 	source, err := mp.Mount(AzureADLSGen1Mount{
 		ClientID:        "abc",
 		TenantID:        "bcd",
@@ -87,7 +89,7 @@ func TestAccInvalidSecretScopeFails(t *testing.T) {
 		Directory:       "/",
 		SecretKey:       "key",
 		SecretScope:     "y",
-	})
+	}, client)
 	assert.Equal(t, "", source)
 	qa.AssertErrorStartsWith(t, err, "Secret does not exist with scope: y and key: key")
 }
@@ -145,8 +147,10 @@ func testMountFuncHelper(t *testing.T, mountFunc func(mp MountPoint, mount Mount
 
 type mockMount struct{}
 
-func (t mockMount) Source() string            { return "fake-mount" }
-func (t mockMount) Config() map[string]string { return map[string]string{"fake-key": "fake-value"} }
+func (t mockMount) Source() string { return "fake-mount" }
+func (t mockMount) Config(client *common.DatabricksClient) map[string]string {
+	return map[string]string{"fake-key": "fake-value"}
+}
 
 func TestMountPoint_Mount(t *testing.T) {
 	mount := mockMount{}
@@ -173,7 +177,8 @@ func TestMountPoint_Mount(t *testing.T) {
 		dbutils.notebook.exit(mount_source)
 	`, mountName, expectedMountSource, expectedMountConfig)
 	testMountFuncHelper(t, func(mp MountPoint, mount Mount) (s string, e error) {
-		return mp.Mount(mount)
+		client := common.CommonEnvironmentClient()
+		return mp.Mount(mount, client)
 	}, mount, mountName, expectedCommand)
 }
 


### PR DESCRIPTION
For all azure environments we have been using public cloud endpoint
which fails to deploy in other environments like govcloud and china. Use
environment variables to fetch the correct ActiveDirectoryEndpoint per
Azure Environment.