### PR TITLE
Ability to create dynamic passthrough clusters based on members of the group

### DIFF
--- a/access/resource_permissions_test.go
+++ b/access/resource_permissions_test.go
@@ -22,11 +22,20 @@ import (
 var (
 	TestingUser      = "ben"
 	TestingAdminUser = "admin"
+	me               = qa.HTTPFixture{
+		ReuseRequest: true,
+		Method:   "GET",
+		Resource: "/api/2.0/preview/scim/v2/Me",
+		Response: identity.ScimUser{
+			UserName: TestingAdminUser,
+		},
+	}
 )
 
 func TestResourcePermissionsRead(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			me,
 			{
 				Method:   http.MethodGet,
 				Resource: "/api/2.0/permissions/clusters/abc",
@@ -55,13 +64,6 @@ func TestResourcePermissionsRead(t *testing.T) {
 					},
 				},
 			},
-			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.0/preview/scim/v2/Me",
-				Response: identity.ScimUser{
-					UserName: TestingAdminUser,
-				},
-			},
 		},
 		Resource: ResourcePermissions(),
 		Read:     true,
@@ -80,6 +82,7 @@ func TestResourcePermissionsRead(t *testing.T) {
 func TestResourcePermissionsRead_SQLA_Asset(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			me,
 			{
 				Method:   http.MethodGet,
 				Resource: "/api/2.0/preview/sql/permissions/dashboards/abc",
@@ -96,13 +99,6 @@ func TestResourcePermissionsRead_SQLA_Asset(t *testing.T) {
 							PermissionLevel: "CAN_MANAGE",
 						},
 					},
-				},
-			},
-			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.0/preview/scim/v2/Me",
-				Response: identity.ScimUser{
-					UserName: TestingAdminUser,
 				},
 			},
 		},
@@ -122,6 +118,7 @@ func TestResourcePermissionsRead_SQLA_Asset(t *testing.T) {
 func TestResourcePermissionsRead_NotFound(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			me,
 			{
 				Method:   http.MethodGet,
 				Resource: "/api/2.0/permissions/clusters/abc",
@@ -143,6 +140,7 @@ func TestResourcePermissionsRead_NotFound(t *testing.T) {
 func TestResourcePermissionsRead_some_error(t *testing.T) {
 	_, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			me,
 			{
 				Method:   http.MethodGet,
 				Resource: "/api/2.0/permissions/clusters/abc",
@@ -211,6 +209,7 @@ func TestResourcePermissionsRead_ErrorOnScimMe(t *testing.T) {
 func TestResourcePermissionsDelete(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			me,
 			{
 				Method:   http.MethodGet,
 				Resource: "/api/2.0/permissions/clusters/abc",
@@ -256,6 +255,7 @@ func TestResourcePermissionsDelete(t *testing.T) {
 func TestResourcePermissionsDelete_error(t *testing.T) {
 	_, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			me,
 			{
 				Method:   http.MethodGet,
 				Resource: "/api/2.0/permissions/clusters/abc",
@@ -304,7 +304,7 @@ func TestResourcePermissionsDelete_error(t *testing.T) {
 
 func TestResourcePermissionsCreate_invalid(t *testing.T) {
 	_, err := qa.ResourceFixture{
-		Fixtures: []qa.HTTPFixture{},
+		Fixtures: []qa.HTTPFixture{me},
 		Resource: ResourcePermissions(),
 		Create:   true,
 	}.Apply(t)
@@ -360,6 +360,7 @@ func TestResourcePermissionsCreate_AdminsThrowError(t *testing.T) {
 func TestResourcePermissionsCreate(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			me,
 			{
 				Method:   http.MethodPut,
 				Resource: "/api/2.0/permissions/clusters/abc",
@@ -400,13 +401,6 @@ func TestResourcePermissionsCreate(t *testing.T) {
 					},
 				},
 			},
-			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.0/preview/scim/v2/Me",
-				Response: identity.ScimUser{
-					UserName: TestingAdminUser,
-				},
-			},
 		},
 		Resource: ResourcePermissions(),
 		State: map[string]interface{}{
@@ -431,6 +425,7 @@ func TestResourcePermissionsCreate(t *testing.T) {
 func TestResourcePermissionsCreate_SQLA_Asset(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			me,
 			{
 				Method:   http.MethodPost,
 				Resource: "/api/2.0/preview/sql/permissions/dashboards/abc",
@@ -465,14 +460,6 @@ func TestResourcePermissionsCreate_SQLA_Asset(t *testing.T) {
 					},
 				},
 			},
-			{
-				Method:       http.MethodGet,
-				ReuseRequest: true,
-				Resource:     "/api/2.0/preview/scim/v2/Me",
-				Response: identity.ScimUser{
-					UserName: TestingAdminUser,
-				},
-			},
 		},
 		Resource: ResourcePermissions(),
 		State: map[string]interface{}{
@@ -497,6 +484,7 @@ func TestResourcePermissionsCreate_SQLA_Asset(t *testing.T) {
 func TestResourcePermissionsCreate_SQLA_Endpoint(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			me,
 			{
 				Method:   http.MethodPatch,
 				Resource: "/api/2.0/permissions/sql/endpoints/abc",
@@ -531,14 +519,6 @@ func TestResourcePermissionsCreate_SQLA_Endpoint(t *testing.T) {
 					},
 				},
 			},
-			{
-				Method:       http.MethodGet,
-				ReuseRequest: true,
-				Resource:     "/api/2.0/preview/scim/v2/Me",
-				Response: identity.ScimUser{
-					UserName: TestingAdminUser,
-				},
-			},
 		},
 		Resource: ResourcePermissions(),
 		State: map[string]interface{}{
@@ -563,6 +543,7 @@ func TestResourcePermissionsCreate_SQLA_Endpoint(t *testing.T) {
 func TestResourcePermissionsCreate_NotebookPath_NotExists(t *testing.T) {
 	_, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			me,
 			{
 				Method:   http.MethodGet,
 				Resource: "/api/2.0/workspace/get-status?path=%2FDevelopment%2FInit",
@@ -592,6 +573,7 @@ func TestResourcePermissionsCreate_NotebookPath_NotExists(t *testing.T) {
 func TestResourcePermissionsCreate_NotebookPath(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			me,
 			{
 				Method:   http.MethodGet,
 				Resource: "/api/2.0/workspace/get-status?path=%2FDevelopment%2FInit",
@@ -640,13 +622,6 @@ func TestResourcePermissionsCreate_NotebookPath(t *testing.T) {
 					},
 				},
 			},
-			{
-				Method:   http.MethodGet,
-				Resource: "/api/2.0/preview/scim/v2/Me",
-				Response: identity.ScimUser{
-					UserName: TestingAdminUser,
-				},
-			},
 		},
 		Resource: ResourcePermissions(),
 		State: map[string]interface{}{
@@ -672,6 +647,7 @@ func TestResourcePermissionsCreate_NotebookPath(t *testing.T) {
 func TestResourcePermissionsCreate_error(t *testing.T) {
 	_, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			me,
 			{
 				Method:   http.MethodPut,
 				Resource: "/api/2.0/permissions/clusters/abc",
@@ -704,6 +680,7 @@ func TestResourcePermissionsCreate_error(t *testing.T) {
 func TestResourcePermissionsUpdate(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			me,
 			{
 				Method:   http.MethodGet,
 				Resource: "/api/2.0/permissions/jobs/9",
@@ -730,14 +707,6 @@ func TestResourcePermissionsUpdate(t *testing.T) {
 							},
 						},
 					},
-				},
-			},
-			{
-				Method:       http.MethodGet,
-				ReuseRequest: true,
-				Resource:     "/api/2.0/preview/scim/v2/Me",
-				Response: identity.ScimUser{
-					UserName: TestingAdminUser,
 				},
 			},
 			{

--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -31,7 +31,8 @@ resource "databricks_group_member" "my_member_a" {
 
 Data source allows you to pick groups by the following attributes
 
-- `user_name` - (Required) User name of the user. The user must exist before this resource can be planned.
+- `user_name` - (Optional) User name of the user. The user must exist before this resource can be planned.
+- `id` - (Optional) ID of the user. 
 
 ## Attribute Reference
 
@@ -39,5 +40,6 @@ Data source exposes the following attributes:
 
 - `id` - The id of the calling user.
 - `user_name` - Name of the [user](../resources/user.md), e.g. `mr.foo@example.com`.
+- `display_name` - Display name of the [user](../resources/user.md), e.g. `Mr Foo`.
 - `home` - Home folder of the [user](../resources/user.md), e.g. `/Users/mr.foo@example.com`.
 - `alphanumeric` - Alphanumeric representation of user local name. e.g. `mr_foo`.

--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -32,13 +32,13 @@ resource "databricks_group_member" "my_member_a" {
 Data source allows you to pick groups by the following attributes
 
 - `user_name` - (Optional) User name of the user. The user must exist before this resource can be planned.
-- `id` - (Optional) ID of the user. 
+- `user_id` - (Optional) ID of the user. 
 
 ## Attribute Reference
 
 Data source exposes the following attributes:
 
-- `id` - The id of the calling user.
+- `id` - The id of the user.
 - `user_name` - Name of the [user](../resources/user.md), e.g. `mr.foo@example.com`.
 - `display_name` - Display name of the [user](../resources/user.md), e.g. `Mr Foo`.
 - `home` - Home folder of the [user](../resources/user.md), e.g. `/Users/mr.foo@example.com`.

--- a/docs/guides/passthrough-cluster-per-user.md
+++ b/docs/guides/passthrough-cluster-per-user.md
@@ -1,0 +1,60 @@
+---
+page_title: "Dynamic Passthrough Clusters for a Group"
+---
+
+# Dynamic Passthrough Clusters
+
+This example addresses a pretty common use-case: data science team, which is managed as a group through SCIM provisioning, needs a collection of individual passthrough clusters, which they should be able to restart. It could simply be achieved by group and user data resources to get the list of user names, that belong to a group. Terraform's `for_each` meta-attribute helps to do this easily.
+
+```hcl
+data "databricks_group" "dev" {
+  display_name = "dev-clusters"
+}
+
+data "databricks_user" "dev" {
+  for_each = data.databricks_group.dev.members
+  id = each.key
+}
+```
+
+Once we have a specific list of user resources, we could proceed creating clusters and permissions with `for_each = data.databricks_user.dev` to ensure it's done for each user:
+
+```hcl
+data "databricks_spark_version" "latest" {}
+data "databricks_node_type" "smallest" {
+  local_disk = true
+}
+
+resource "databricks_cluster" "dev" {
+  for_each = data.databricks_user.dev
+
+  cluster_name            = "${each.value.display_name} dev cluster"
+  single_user_name        = each.value.user_name
+
+  spark_version           = data.databricks_spark_version.latest.id
+  node_type_id            = data.databricks_node_type.smallest.id
+  autotermination_minutes = 10
+
+  spark_conf = {
+    # Single-node
+    "spark.databricks.cluster.profile" : "singleNode"
+    "spark.master" : "local[*]",
+
+    # Passthrough
+    "spark.databricks.passthrough.enabled": "true"
+  }
+
+  custom_tags = {
+    "ResourceClass" = "SingleNode"
+  }
+}
+
+resource "databricks_permissions" "dev_restart" {
+  for_each = data.databricks_user.dev
+  cluster_id = databricks_cluster.dev[each.key].cluster_id
+  access_control {
+    user_name = each.value.user_name
+    permission_level = "CAN_RESTART"
+  }
+}
+```

--- a/docs/guides/passthrough-cluster-per-user.md
+++ b/docs/guides/passthrough-cluster-per-user.md
@@ -4,7 +4,7 @@ page_title: "Dynamic Passthrough Clusters for a Group"
 
 # Dynamic Passthrough Clusters
 
-This example addresses a pretty common use-case: data science team, which is managed as a group through SCIM provisioning, needs a collection of individual passthrough clusters, which they should be able to restart. It could simply be achieved by group and user data resources to get the list of user names, that belong to a group. Terraform's `for_each` meta-attribute helps to do this easily.
+This example addresses a pretty common use-case: data science team, which is managed as a group through SCIM provisioning, needs a collection of individual passthrough [databricks_cluster](../resources/cluster.md), which they should be able to restart. It could simply be achieved by [databricks_group](../data-sources/group.md) and [databricks_user](../data-sources/user.md) data resources to get the list of user names, that belong to a group. Terraform's `for_each` meta-attribute helps to do this easily.
 
 ```hcl
 data "databricks_group" "dev" {
@@ -13,7 +13,7 @@ data "databricks_group" "dev" {
 
 data "databricks_user" "dev" {
   for_each = data.databricks_group.dev.members
-  id = each.key
+  user_id = each.key
 }
 ```
 

--- a/identity/data_user.go
+++ b/identity/data_user.go
@@ -31,12 +31,12 @@ func DataSourceUser() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"user_name": {
 				Type:         schema.TypeString,
-				ExactlyOneOf: []string{"user_name", "id"},
+				ExactlyOneOf: []string{"user_name", "user_id"},
 				Optional:     true,
 			},
-			"id": {
+			"user_id": {
 				Type:         schema.TypeString,
-				ExactlyOneOf: []string{"user_name", "id"},
+				ExactlyOneOf: []string{"user_name", "user_id"},
 				Optional:     true,
 			},
 			"home": {
@@ -54,7 +54,7 @@ func DataSourceUser() *schema.Resource {
 		},
 		ReadContext: func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 			usersAPI := NewUsersAPI(ctx, m)
-			user, err := getUser(usersAPI, d.Get("id").(string), d.Get("user_name").(string))
+			user, err := getUser(usersAPI, d.Get("user_id").(string), d.Get("user_name").(string))
 			if err != nil {
 				return diag.FromErr(err)
 			}

--- a/identity/data_user_test.go
+++ b/identity/data_user_test.go
@@ -1,8 +1,10 @@
 package identity
 
 import (
+	"context"
 	"testing"
 
+	"github.com/databrickslabs/terraform-provider-databricks/common"
 	"github.com/databrickslabs/terraform-provider-databricks/qa"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -37,4 +39,40 @@ func TestDataSourceUser(t *testing.T) {
 	assert.Equal(t, d.Get("user_name"), "mr.test@example.com")
 	assert.Equal(t, d.Get("home"), "/Users/mr.test@example.com")
 	assert.Equal(t, d.Get("alphanumeric"), "mr_test")
+}
+
+func TestDataSourceUserGerUser(t *testing.T) {
+	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/preview/scim/v2/Users/a",
+			Response: ScimUser{
+				ID: "a",
+			},
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/preview/scim/v2/Users?filter=userName%20eq%20%27searching_error%27",
+			Status: 404,
+			Response: common.APIError {
+				Message: "searching_error",
+			},
+		},
+		{
+			Method:   "GET",
+			Resource: "/api/2.0/preview/scim/v2/Users?filter=userName%20eq%20%27empty_search%27",
+			Response: UserList {},
+		},
+	}, func(ctx context.Context, client *common.DatabricksClient) {
+		usersAPI := NewUsersAPI(ctx, client)
+		user, err := getUser(usersAPI, "a", "")
+		assert.NoError(t, err)
+		assert.Equal(t, "a", user.ID)
+
+		_, err = getUser(usersAPI, "", "searching_error")
+		assert.EqualError(t, err, "searching_error")
+
+		_, err = getUser(usersAPI, "", "empty_search")
+		assert.EqualError(t, err, "cannot find user empty_search")
+	})
 }


### PR DESCRIPTION
Fix #702 Add `id` attribute to user data resource

* error out, when permissions are attempted to be added for the current user, as it's not possible to decrease administrative privileges
* added a guide for dynamic single-user passthrough clusters