### PR TITLE
Add functionality to restart always running jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 ## 0.3.6
 
 * Added support for hybrid pools ([#689](https://github.com/databrickslabs/terraform-provider-databricks/pull/689))
+* Added support for `always_running` jobs, which are restarted on resource updates ([#715](https://github.com/databrickslabs/terraform-provider-databricks/pull/715))
+* Azure CLI auth is now forcing JSON output ([#717](https://github.com/databrickslabs/terraform-provider-databricks/pull/717))
+* `databricks_permissions` are getting validation on `terraform plan` stage ([#706](https://github.com/databrickslabs/terraform-provider-databricks/pull/706))
+* Added `databricks_directory` resource ([#690](https://github.com/databrickslabs/terraform-provider-databricks/pull/690))
+* Added support for hybrid instance pools ([#689](https://github.com/databrickslabs/terraform-provider-databricks/pull/689))
+* Added `run_as_role` field to `databricks_sql_query` ([#684](https://github.com/databrickslabs/terraform-provider-databricks/pull/684))
+* Added `user_id` attribute for `databricks_user` data resource, so that it's possible to dynamically create resources based on members of the group ([#714](https://github.com/databrickslabs/terraform-provider-databricks/pull/714))
+
+Updated dependency versions:
+
+* Bump github.com/aws/aws-sdk-go from 1.38.51 to 1.38.71
+* Bump github.com/Azure/go-autorest/autorest/azure/auth from 0.5.7 to 0.5.8
+* Bump github.com/Azure/go-autorest/autorest from 0.11.18 to 0.11.19
+* Bump github.com/Azure/go-autorest/autorest/adal from 0.9.13 to 0.9.14
+* Bump github.com/zclconf/go-cty from 1.8.3 to 1.8.4 
+* Bump github.com/hashicorp/terraform-plugin-sdk/v2 from 2.6.1 to 2.7.0
 
 ## 0.3.5
 

--- a/common/resource.go
+++ b/common/resource.go
@@ -14,6 +14,7 @@ type Resource struct {
 	Read           func(ctx context.Context, d *schema.ResourceData, c *DatabricksClient) error
 	Update         func(ctx context.Context, d *schema.ResourceData, c *DatabricksClient) error
 	Delete         func(ctx context.Context, d *schema.ResourceData, c *DatabricksClient) error
+	CustomizeDiff  func(ctx context.Context, d *schema.ResourceDiff, c interface{}) error
 	StateUpgraders []schema.StateUpgrader
 	Schema         map[string]*schema.Schema
 	SchemaVersion  int
@@ -60,6 +61,7 @@ func (r Resource) ToResource() *schema.Resource {
 		Schema:         r.Schema,
 		SchemaVersion:  r.SchemaVersion,
 		StateUpgraders: r.StateUpgraders,
+		CustomizeDiff:  r.CustomizeDiff,
 		CreateContext: func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 			c := m.(*DatabricksClient)
 			err := r.Create(ctx, d, c)

--- a/compute/model.go
+++ b/compute/model.go
@@ -551,9 +551,6 @@ type JobSettings struct {
 	MaxConcurrentRuns      int32         `json:"max_concurrent_runs,omitempty"`
 
 	EmailNotifications *JobEmailNotifications `json:"email_notifications,omitempty"`
-
-	// custom property for always-on streaming jobs
-	AlwaysRunning bool `json:"always_running,omitempty"`
 }
 
 // JobList ...

--- a/compute/model.go
+++ b/compute/model.go
@@ -551,6 +551,9 @@ type JobSettings struct {
 	MaxConcurrentRuns      int32         `json:"max_concurrent_runs,omitempty"`
 
 	EmailNotifications *JobEmailNotifications `json:"email_notifications,omitempty"`
+
+	// custom property for always-on streaming jobs
+	AlwaysRunning bool `json:"always_running,omitempty"`
 }
 
 // JobList ...
@@ -573,7 +576,9 @@ func (j Job) ID() string {
 
 // RunParameters ...
 type RunParameters struct {
-	// TODO: if we add job_id, it can be also a request to RunNow
+	// a shortcut field to reuse this type for RunNow
+	JobID int64 `json:"job_id,omitempty"`
+
 	NotebookParams    map[string]string `json:"notebook_params,omitempty"`
 	JarParams         []string          `json:"jar_params,omitempty"`
 	PythonParams      []string          `json:"python_params,omitempty"`

--- a/compute/resource_job.go
+++ b/compute/resource_job.go
@@ -6,7 +6,9 @@ import (
 	"log"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
@@ -15,13 +17,14 @@ import (
 
 // NewJobsAPI creates JobsAPI instance from provider meta
 func NewJobsAPI(ctx context.Context, m interface{}) JobsAPI {
-	return JobsAPI{m.(*common.DatabricksClient), ctx}
+	return JobsAPI{m.(*common.DatabricksClient), ctx, 5 * time.Minute}
 }
 
 // JobsAPI exposes the Jobs API
 type JobsAPI struct {
 	client  *common.DatabricksClient
 	context context.Context
+	timeout time.Duration
 }
 
 // List all jobs
@@ -37,18 +40,91 @@ func (a JobsAPI) RunsList(r JobRunsListRequest) (jrl JobRunsList, err error) {
 }
 
 // RunsCancel ...
-func (a JobsAPI) RunsCancel(id int64) error {
+func (a JobsAPI) RunsCancel(runID int64) error {
 	var response interface{}
-	return a.client.Post(a.context, "/jobs/runs/cancel", map[string]interface{}{
-		"run_id": id,
+	err := a.client.Post(a.context, "/jobs/runs/cancel", map[string]interface{}{
+		"run_id": runID,
 	}, &response)
+	if err != nil {
+		return err
+	}
+	return a.waitForRunState(runID, "TERMINATED")
 }
 
-// RunNow ...
-func (a JobsAPI) RunNow(rp RunParameters) (JobRun, error) {
+func (a JobsAPI) waitForRunState(runID int64, desiredState string) error {
+	return resource.RetryContext(a.context, a.timeout, func() *resource.RetryError {
+		jobRun, err := a.RunsGet(runID)
+		if err != nil {
+			return resource.NonRetryableError(
+				fmt.Errorf("cannot get job %s: %v", desiredState, err))
+		}
+		state := jobRun.State
+		if state.LifeCycleState == desiredState {
+			return nil
+		}
+		if state.LifeCycleState == "INTERNAL_ERROR" {
+			return resource.NonRetryableError(
+				fmt.Errorf("cannot get job %s: %s",
+					desiredState, state.StateMessage))
+		}
+		return resource.RetryableError(
+			fmt.Errorf("run is %s: %s",
+				state.LifeCycleState,
+				state.StateMessage))
+	})
+}
+
+// RunNow triggers the job and returns a run ID
+func (a JobsAPI) RunNow(jobID int64) (int64, error) {
 	var jr JobRun
-	err := a.client.Post(a.context, "/jobs/run-now", rp, &jr)
+	err := a.client.Post(a.context, "/jobs/run-now", RunParameters{
+		JobID: jobID,
+	}, &jr)
+	return jr.RunID, err
+}
+
+// RunsGet to retrieve information about the run
+func (a JobsAPI) RunsGet(runID int64) (JobRun, error) {
+	var jr JobRun
+	err := a.client.Get(a.context, "/jobs/runs/get", map[string]interface{}{
+		"run_id": runID,
+	}, &jr)
 	return jr, err
+}
+
+func (a JobsAPI) Run(jobID int64) error {
+	runID, err := a.RunNow(jobID)
+	if err != nil {
+		return fmt.Errorf("cannot start job run: %v", err)
+	}
+	return a.waitForRunState(runID, "RUNNING")
+}
+
+func (a JobsAPI) Restart(id string) error {
+	jobID, err := strconv.ParseInt(id, 10, 32)
+	if err != nil {
+		return err
+	}
+	runs, err := a.RunsList(JobRunsListRequest{JobID: jobID, ActiveOnly: true})
+	if err != nil {
+		return err
+	}
+	if len(runs.Runs) == 0 {
+		// nothing to cancel
+		return a.Run(jobID)
+	}
+	if len(runs.Runs) > 1 {
+		return fmt.Errorf("`always_running` must be specified only with "+
+			"`max_concurrent_runs = 1`. There are %d active runs", len(runs.Runs))
+	}
+	if len(runs.Runs) == 1 {
+		activeRun := runs.Runs[0]
+		err = a.RunsCancel(activeRun.RunID)
+		if err != nil {
+			return fmt.Errorf("cannot cancel run %d: %v", activeRun.RunID, err)
+		}
+	}
+	return a.Run(jobID)
 }
 
 // Create creates a job on the workspace given the job settings
@@ -115,13 +191,6 @@ func wrapMissingJobError(err error, id string) error {
 
 var jobSchema = common.StructToSchema(JobSettings{},
 	func(s map[string]*schema.Schema) map[string]*schema.Schema {
-		s["existing_cluster_id"].Description = "If existing_cluster_id, the ID " +
-			"of an existing cluster that will be used for all runs of this job. " +
-			"When running jobs on an existing cluster, you may need to manually " +
-			"restart the cluster if it stops responding. We strongly suggest to use " +
-			"`new_cluster` for greater reliability."
-		s["new_cluster"].Description = "Same set of parameters as for " +
-			"[databricks_cluster](cluster.md) resource."
 		if p, err := common.SchemaPath(s, "new_cluster", "num_workers"); err == nil {
 			p.Optional = true
 			p.Default = 0
@@ -129,11 +198,9 @@ var jobSchema = common.StructToSchema(JobSettings{},
 			p.ValidateDiagFunc = validation.ToDiagFunc(validation.IntAtLeast(0))
 			p.Required = false
 		}
-
 		if p, err := common.SchemaPath(s, "schedule", "pause_status"); err == nil {
 			p.ValidateFunc = validation.StringInSlice([]string{"PAUSED", "UNPAUSED"}, false)
 		}
-
 		if v, err := common.SchemaPath(s, "new_cluster", "spark_conf"); err == nil {
 			v.DiffSuppressFunc = func(k, old, new string, d *schema.ResourceData) bool {
 				isPossiblyLegacyConfig := k == "new_cluster.0.spark_conf.%" && old == "1" && new == "0"
@@ -145,7 +212,6 @@ var jobSchema = common.StructToSchema(JobSettings{},
 				return false
 			}
 		}
-
 		if v, err := common.SchemaPath(s, "new_cluster", "aws_attributes"); err == nil {
 			v.DiffSuppressFunc = common.MakeEmptyBlockSuppressFunc("new_cluster.0.aws_attributes.#")
 		}
@@ -155,81 +221,32 @@ var jobSchema = common.StructToSchema(JobSettings{},
 		if v, err := common.SchemaPath(s, "new_cluster", "gcp_attributes"); err == nil {
 			v.DiffSuppressFunc = common.MakeEmptyBlockSuppressFunc("new_cluster.0.gcp_attributes.#")
 		}
-
 		s["email_notifications"].DiffSuppressFunc = common.MakeEmptyBlockSuppressFunc("email_notifications.#")
-
-		s["name"].Description = "An optional name for the job. The default value is Untitled."
-		s["library"].Description = "An optional list of libraries to be installed on " +
-			"the cluster that will execute the job. The default value is an empty list."
-		s["email_notifications"].Description = "An optional set of email addresses " +
-			"notified when runs of this job begin and complete and when this job is " +
-			"deleted. The default behavior is to not send any emails."
-		s["timeout_seconds"].Description = "An optional timeout applied to each run " +
-			"of this job. The default behavior is to have no timeout."
-		s["max_retries"].Description = "An optional maximum number of times to retry " +
-			"an unsuccessful run. A run is considered to be unsuccessful if it " +
-			"completes with a FAILED result_state or INTERNAL_ERROR life_cycle_state. " +
-			"The value -1 means to retry indefinitely and the value 0 means to never " +
-			"retry. The default behavior is to never retry."
-		s["min_retry_interval_millis"].Description = "An optional minimal interval in " +
-			"milliseconds between the start of the failed run and the subsequent retry run. " +
-			"The default behavior is that unsuccessful runs are immediately retried."
-		s["retry_on_timeout"].Description = "An optional policy to specify whether to " +
-			"retry a job when it times out. The default behavior is to not retry on timeout."
-		s["schedule"].Description = "An optional periodic schedule for this job. " +
-			"The default behavior is that the job runs when triggered by clicking " +
-			"Run Now in the Jobs UI or sending an API request to runNow."
 		s["url"] = &schema.Schema{
 			Type:     schema.TypeString,
 			Computed: true,
 		}
-		s["max_concurrent_runs"] = &schema.Schema{
-			Optional:         true,
-			Default:          1,
-			Type:             schema.TypeInt,
-			ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(1)),
-			Description:      "An optional maximum allowed number of concurrent runs of the job.",
+		s["always_running"] = &schema.Schema{
+			Optional: true,
+			Default:  false,
+			Type:     schema.TypeBool,
 		}
 		return s
 	})
-
-func restartJob(jobsAPI JobsAPI, id string) error {
-	jobID, err := strconv.ParseInt(id, 10, 32)
-	if err != nil {
-		return err
-	}
-	runs, err := jobsAPI.RunsList(JobRunsListRequest{JobID: jobID, ActiveOnly: true})
-	if err != nil {
-		return err
-	}
-	if len(runs.Runs) == 0 {
-		// nothing to cancel
-		return nil
-	}
-	if len(runs.Runs) > 1 {
-		// nothing to cancel
-		return fmt.Errorf("`always_running` must be specified only with "+
-			"`max_concurrent_runs = 1`. There are %d active runs", len(runs.Runs))
-	}
-	activeRun := runs.Runs[0]
-	err = jobsAPI.RunsCancel(activeRun.RunID)
-	if err != nil {
-		return fmt.Errorf("cannot cancel run %d: %v", activeRun.RunID, err)
-	}
-	_, err = jobsAPI.RunNow(RunParameters{
-		JobID: jobID,
-	})
-	if err != nil {
-		return fmt.Errorf("cannot start job run: %v", err)
-	}
-	return nil
-}
 
 // ResourceJob ...
 func ResourceJob() *schema.Resource {
 	return common.Resource{
 		Schema:        jobSchema,
 		SchemaVersion: 2,
+		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, c interface{}) error {
+			alwaysRunning := d.Get("always_running").(bool)
+			maxConcurrentRuns := d.Get("max_concurrent_runs").(int)
+			if alwaysRunning && maxConcurrentRuns > 1 {
+				return fmt.Errorf("`always_running` must be specified only with `max_concurrent_runs = 1`")
+			}
+			return nil
+		},
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			var js JobSettings
 			err := common.DataToStructPointer(d, jobSchema, &js)
@@ -241,11 +258,15 @@ func ResourceJob() *schema.Resource {
 					return err
 				}
 			}
-			job, err := NewJobsAPI(ctx, c).Create(js)
+			jobsAPI := NewJobsAPI(ctx, c)
+			job, err := jobsAPI.Create(js)
 			if err != nil {
 				return err
 			}
 			d.SetId(job.ID())
+			if d.Get("always_running").(bool) {
+				return jobsAPI.Run(job.JobID)
+			}
 			return nil
 		},
 		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
@@ -273,9 +294,8 @@ func ResourceJob() *schema.Resource {
 			if err != nil {
 				return err
 			}
-			if js.AlwaysRunning {
-				// TODO: fail if Maximum Concurrent Runs is not 1
-				return restartJob(jobsAPI, d.Id())
+			if d.Get("always_running").(bool) {
+				return jobsAPI.Restart(d.Id())
 			}
 			return nil
 		},

--- a/compute/resource_job_test.go
+++ b/compute/resource_job_test.go
@@ -2,6 +2,7 @@ package compute
 
 import (
 	"context"
+	"os"
 	"strings"
 	"testing"
 
@@ -493,6 +494,17 @@ func TestResourceJobUpdate(t *testing.T) {
 	assert.NoError(t, err, err)
 	assert.Equal(t, "789", d.Id(), "Id should be the same as in reading")
 	assert.Equal(t, "Featurizer New", d.Get("name"))
+}
+
+func TestAccRestartJob(t *testing.T) {
+	if _, ok := os.LookupEnv("VSCODE_PID"); !ok {
+		t.Skip("This test is supposed to be run only from IDE")
+	}
+	// TODO: remove this test after functionality is ready
+	client := common.CommonEnvironmentClient()
+	jobsAPI := NewJobsAPI(context.Background(), client)
+	err := restartJob(jobsAPI, "210")
+	assert.NoError(t, err)
 }
 
 func TestResourceJobUpdate_Error(t *testing.T) {

--- a/compute/resource_job_test.go
+++ b/compute/resource_job_test.go
@@ -116,8 +116,8 @@ func TestResourceJobCreate_AlwaysRunning(t *testing.T) {
 					SparkJarTask: &SparkJarTask{
 						MainClassName: "com.labs.BarMain",
 					},
-					Name:                   "Featurizer",
-					MaxRetries:             3,
+					Name:       "Featurizer",
+					MaxRetries: 3,
 				},
 				Response: Job{
 					JobID: 789,
@@ -133,25 +133,25 @@ func TestResourceJobCreate_AlwaysRunning(t *testing.T) {
 						SparkJarTask: &SparkJarTask{
 							MainClassName: "com.labs.BarMain",
 						},
-						Name:                   "Featurizer",
-						MaxRetries:             3,
+						Name:       "Featurizer",
+						MaxRetries: 3,
 					},
 				},
 			},
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/jobs/run-now",
-				ExpectedRequest: RunParameters {
+				ExpectedRequest: RunParameters{
 					JobID: 789,
 				},
-				Response: JobRun {
+				Response: JobRun{
 					RunID: 890,
 				},
 			},
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/jobs/runs/get?run_id=890",
-				Response: JobRun {
+				Response: JobRun{
 					State: RunState{
 						LifeCycleState: "RUNNING",
 					},
@@ -600,22 +600,22 @@ func TestResourceJobUpdate_Restart(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/jobs/runs/list?active_only=true&job_id=789",
-				Response: JobRunsList {},
+				Response: JobRunsList{},
 			},
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/jobs/run-now",
-				ExpectedRequest: RunParameters {
+				ExpectedRequest: RunParameters{
 					JobID: 789,
 				},
-				Response: JobRun {
+				Response: JobRun{
 					RunID: 890,
 				},
 			},
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/jobs/runs/get?run_id=890",
-				Response: JobRun {
+				Response: JobRun{
 					State: RunState{
 						LifeCycleState: "RUNNING",
 					},
@@ -638,19 +638,19 @@ func TestResourceJobUpdate_Restart(t *testing.T) {
 func TestJobRestarts(t *testing.T) {
 	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
 		{
-			Method:   "POST",
-			Resource: "/api/2.0/jobs/run-now",
+			Method:       "POST",
+			Resource:     "/api/2.0/jobs/run-now",
 			ReuseRequest: true,
-			ExpectedRequest: RunParameters {
+			ExpectedRequest: RunParameters{
 				JobID: 123,
 			},
-			Response: JobRun {
+			Response: JobRun{
 				RunID: 234,
 			},
 		},
 		{
-			Method:   "GET",
-			Resource: "/api/2.0/jobs/runs/get?run_id=234",
+			Method:       "GET",
+			Resource:     "/api/2.0/jobs/runs/get?run_id=234",
 			ReuseRequest: true,
 			Response: JobRun{
 				State: RunState{
@@ -661,7 +661,7 @@ func TestJobRestarts(t *testing.T) {
 		{
 			Method:   "GET",
 			Resource: "/api/2.0/jobs/runs/get?run_id=345",
-			Status: 400,
+			Status:   400,
 			Response: common.APIError{
 				Message: "nope",
 			},
@@ -672,21 +672,21 @@ func TestJobRestarts(t *testing.T) {
 			Response: JobRun{
 				State: RunState{
 					LifeCycleState: "INTERNAL_ERROR",
-					StateMessage: "Quota exceeded",
+					StateMessage:   "Quota exceeded",
 				},
 			},
 		},
 		{
 			Method:   "GET",
 			Resource: "/api/2.0/jobs/runs/list?active_only=true&job_id=123",
-			Response: JobRunsList {
+			Response: JobRunsList{
 				Runs: []JobRun{},
 			},
 		},
 		{
 			Method:   "GET",
 			Resource: "/api/2.0/jobs/runs/list?active_only=true&job_id=123",
-			Response: JobRunsList {
+			Response: JobRunsList{
 				Runs: []JobRun{
 					{
 						RunID: 567,
@@ -697,13 +697,13 @@ func TestJobRestarts(t *testing.T) {
 		{
 			Method:   "POST",
 			Resource: "/api/2.0/jobs/runs/cancel",
-			ExpectedRequest: map[string]interface {}{
+			ExpectedRequest: map[string]interface{}{
 				"run_id": 567,
 			},
 		},
 		{
-			Method:   "GET",
-			Resource: "/api/2.0/jobs/runs/get?run_id=567",
+			Method:       "GET",
+			Resource:     "/api/2.0/jobs/runs/get?run_id=567",
 			ReuseRequest: true,
 			Response: JobRun{
 				State: RunState{
@@ -714,7 +714,7 @@ func TestJobRestarts(t *testing.T) {
 		{
 			Method:   "GET",
 			Resource: "/api/2.0/jobs/runs/list?active_only=true&job_id=678",
-			Response: JobRunsList {
+			Response: JobRunsList{
 				Runs: []JobRun{
 					{
 						RunID: 789,
@@ -745,7 +745,7 @@ func TestJobRestarts(t *testing.T) {
 		assert.NoError(t, err)
 
 		err = ja.Restart("678")
-		assert.EqualError(t, err, "`always_running` must be specified only " + 
+		assert.EqualError(t, err, "`always_running` must be specified only "+
 			"with `max_concurrent_runs = 1`. There are 2 active runs")
 	})
 }

--- a/compute/resource_job_test.go
+++ b/compute/resource_job_test.go
@@ -766,38 +766,38 @@ func TestJobRestarts(t *testing.T) {
 		},
 	}, func(ctx context.Context, client *common.DatabricksClient) {
 		ja := NewJobsAPI(ctx, client)
-		ja.timeout = 500 * time.Millisecond
+		timeout := 500 * time.Millisecond
 
-		err := ja.Start(123)
+		err := ja.Start(123, timeout)
 		assert.NoError(t, err)
 
-		err = ja.waitForRunState(345, "RUNNING")
+		err = ja.waitForRunState(345, "RUNNING", timeout)
 		assert.EqualError(t, err, "cannot get job RUNNING: nope")
 
-		err = ja.waitForRunState(456, "TERMINATED")
+		err = ja.waitForRunState(456, "TERMINATED", timeout)
 		assert.EqualError(t, err, "cannot get job TERMINATED: Quota exceeded")
 
-		err = ja.waitForRunState(890, "RUNNING")
+		err = ja.waitForRunState(890, "RUNNING", timeout)
 		assert.EqualError(t, err, "run is SOMETHING: Checking...")
 
 		// no active runs for the first time
-		err = ja.Restart("123")
+		err = ja.Restart("123", timeout)
 		assert.NoError(t, err)
 
 		// one active run for the second time
-		err = ja.Restart("123")
+		err = ja.Restart("123", timeout)
 		assert.NoError(t, err)
 
-		err = ja.Restart("111")
+		err = ja.Restart("111", timeout)
 		assert.EqualError(t, err, "cannot cancel run 567: nope")
 
-		err = ja.Restart("a")
+		err = ja.Restart("a", timeout)
 		assert.EqualError(t, err, "strconv.ParseInt: parsing \"a\": invalid syntax")
 
-		err = ja.Restart("222")
+		err = ja.Restart("222", timeout)
 		assert.EqualError(t, err, "nope")
 
-		err = ja.Restart("678")
+		err = ja.Restart("678", timeout)
 		assert.EqualError(t, err, "`always_running` must be specified only "+
 			"with `max_concurrent_runs = 1`. There are 2 active runs")
 	})

--- a/compute/resource_job_test.go
+++ b/compute/resource_job_test.go
@@ -503,7 +503,7 @@ func TestAccRestartJob(t *testing.T) {
 	// TODO: remove this test after functionality is ready
 	client := common.CommonEnvironmentClient()
 	jobsAPI := NewJobsAPI(context.Background(), client)
-	err := restartJob(jobsAPI, "210")
+	err := jobsAPI.Restart("210")
 	assert.NoError(t, err)
 }
 

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -54,13 +54,13 @@ The following arguments are required:
 * `name` - (Optional) An optional name for the job. The default value is Untitled.
 * `new_cluster` - (Optional) Same set of parameters as for [databricks_cluster](cluster.md) resource.
 * `existing_cluster_id` - (Optional) If existing_cluster_id, the ID of an existing [cluster](cluster.md) that will be used for all runs of this job. When running jobs on an existing cluster, you may need to manually restart the cluster if it stops responding. We strongly suggest to use `new_cluster` for greater reliability.
+* `always_running` - (Optional) (Bool) Whenever the job is always running, like a Spark Streaming application, on every update restart the current active run or start it again, if nothing it is not running. False by default. Any job runs are started with `parameters` specified in `spark_jar_task` or `spark_submit_task` or `spark_python_task` or `notebook_task` blocks.
 * `library` - (Optional) (Set) An optional list of libraries to be installed on the cluster that will execute the job. Please consult [libraries section](cluster.md#libraries) for [databricks_cluster](cluster.md) resource.
 * `retry_on_timeout` - (Optional) (Bool) An optional policy to specify whether to retry a job when it times out. The default behavior is to not retry on timeout.
 * `max_retries` - (Optional) (Integer) An optional maximum number of times to retry an unsuccessful run. A run is considered to be unsuccessful if it completes with a FAILED result_state or INTERNAL_ERROR life_cycle_state. The value -1 means to retry indefinitely and the value 0 means to never retry. The default behavior is to never retry.
 * `timeout_seconds` - (Optional) (Integer) An optional timeout applied to each run of this job. The default behavior is to have no timeout.
 * `min_retry_interval_millis` - (Optional) (Integer) An optional minimal interval in milliseconds between the start of the failed run and the subsequent retry run. The default behavior is that unsuccessful runs are immediately retried.
 * `max_concurrent_runs` - (Optional) (Integer) An optional maximum allowed number of concurrent runs of the job.
-* `always_running` - (Optional) (Bool) Whenever the job is always running, like a Spark Streaming application, on every update restart the current active run or start it again, if nothing it is not running. False by default.
 * `email_notifications` - (Optional) (List) An optional set of email addresses notified when runs of this job begin and complete and when this job is deleted. The default behavior is to not send any emails. This field is a block and is documented below.
 * `schedule` - (Optional) (List) An optional periodic schedule for this job. The default behavior is that the job runs when triggered by clicking Run Now in the Jobs UI or sending an API request to runNow. This field is a block and is documented below.
 
@@ -104,6 +104,17 @@ By default, all users can create and modify jobs unless an administrator [enable
 
 * [databricks_permissions](permissions.md#Job-usage) can control which groups or individual users can *Can View*, *Can Manage Run*, and *Can Manage*.
 * [databricks_cluster_policy](cluster_policy.md) can control which kinds of clusters users can create for jobs.
+
+## Timeouts
+
+The `timeouts` block allows you to specify `create` and `update` timeouts if you have an `always_running` job. Please launch `TF_LOG=DEBUG terraform apply` whenever you observe timeout issues.
+
+```hcl
+timeouts {
+  create = "20m"
+  update = "20m
+}
+```
 
 ## Import
 

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -60,6 +60,7 @@ The following arguments are required:
 * `timeout_seconds` - (Optional) (Integer) An optional timeout applied to each run of this job. The default behavior is to have no timeout.
 * `min_retry_interval_millis` - (Optional) (Integer) An optional minimal interval in milliseconds between the start of the failed run and the subsequent retry run. The default behavior is that unsuccessful runs are immediately retried.
 * `max_concurrent_runs` - (Optional) (Integer) An optional maximum allowed number of concurrent runs of the job.
+* `always_running` - (Optional) (Bool) Whenever the job is always running, like a Spark Streaming application, on every update restart the current active run or start it again, if nothing it is not running. False by default.
 * `email_notifications` - (Optional) (List) An optional set of email addresses notified when runs of this job begin and complete and when this job is deleted. The default behavior is to not send any emails. This field is a block and is documented below.
 * `schedule` - (Optional) (List) An optional periodic schedule for this job. The default behavior is that the job runs when triggered by clicking Run Now in the Jobs UI or sending an API request to runNow. This field is a block and is documented below.
 


### PR DESCRIPTION
* Implements feature #389
* Functionality is triggered only if `always_running` attribute is present
* Uses RunsList, RunsCancel and RunNow methods from Jobs API