### PR TITLE
Azure auth with SPN now uses AAD token by default instead of PAT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Added `run_as_role` field to `databricks_sql_query` ([#684](https://github.com/databrickslabs/terraform-provider-databricks/pull/684))
 * Added `user_id` attribute for `databricks_user` data resource, so that it's possible to dynamically create resources based on members of the group ([#714](https://github.com/databrickslabs/terraform-provider-databricks/pull/714))
 * Added more selectors to `databricks_node_type` data source ([#723](https://github.com/databrickslabs/terraform-provider-databricks/pull/723))
+* Azure auth with SPN now uses AAD token by default instead of PAT. Previous behavior (using PAT) could be restored by setting `azure_use_pat_for_spn` to `true` ([#721](https://github.com/databrickslabs/terraform-provider-databricks/pull/721))
 
 Updated dependency versions:
 

--- a/access/resource_permissions.go
+++ b/access/resource_permissions.go
@@ -14,7 +14,6 @@ import (
 	"github.com/databrickslabs/terraform-provider-databricks/workspace"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pkg/errors"
 )
@@ -366,32 +365,30 @@ func ResourcePermissions() *schema.Resource {
 	}
 	return &schema.Resource{
 		Schema: s,
-		CustomizeDiff: customdiff.Sequence(
-			func(ctx context.Context, diff *schema.ResourceDiff, m interface{}) error {
-				me, err := identity.NewUsersAPI(ctx, m).Me()
-				if err != nil {
-					return err
+		CustomizeDiff: func(ctx context.Context, diff *schema.ResourceDiff, m interface{}) error {
+			me, err := identity.NewUsersAPI(ctx, m).Me()
+			if err != nil {
+				return err
+			}
+			// Plan time validation for object permission levels
+			for _, mapping := range permissionsResourceIDFields(ctx) {
+				if _, ok := diff.GetOk(mapping.field); !ok {
+					continue
 				}
-				// Plan time validation for object permission levels
-				for _, mapping := range permissionsResourceIDFields(ctx) {
-					if _, ok := diff.GetOk(mapping.field); !ok {
-						continue
+				access_control_list := diff.Get("access_control").(*schema.Set).List()
+				for _, access_control := range access_control_list {
+					m := access_control.(map[string]interface{})
+					permission_level := m["permission_level"].(string)
+					if !stringInSlice(permission_level, mapping.allowedPermissionLevels) {
+						return fmt.Errorf(`permission_level %s is not supported with %s objects`, permission_level, mapping.field)
 					}
-					access_control_list := diff.Get("access_control").(*schema.Set).List()
-					for _, access_control := range access_control_list {
-						m := access_control.(map[string]interface{})
-						permission_level := m["permission_level"].(string)
-						if !stringInSlice(permission_level, mapping.allowedPermissionLevels) {
-							return fmt.Errorf(`permission_level %s is not supported with %s objects`, permission_level, mapping.field)
-						}
-						if m["user_name"].(string) == me.UserName {
-							return fmt.Errorf("it is not possible to decrease administrative permissions for the current user: %s", me.UserName)
-						}
+					if m["user_name"].(string) == me.UserName {
+						return fmt.Errorf("it is not possible to decrease administrative permissions for the current user: %s", me.UserName)
 					}
 				}
-				return nil
-			},
-		),
+			}
+			return nil
+		},
 		ReadContext: readContext,
 		CreateContext: func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 			var entity PermissionsEntity

--- a/access/resource_permissions_test.go
+++ b/access/resource_permissions_test.go
@@ -24,8 +24,8 @@ var (
 	TestingAdminUser = "admin"
 	me               = qa.HTTPFixture{
 		ReuseRequest: true,
-		Method:   "GET",
-		Resource: "/api/2.0/preview/scim/v2/Me",
+		Method:       "GET",
+		Resource:     "/api/2.0/preview/scim/v2/Me",
 		Response: identity.ScimUser{
 			UserName: TestingAdminUser,
 		},

--- a/common/azure_auth.go
+++ b/common/azure_auth.go
@@ -3,7 +3,6 @@ package common
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -278,12 +277,9 @@ func (aa *AzureAuth) patRequest() tokenRequest {
 }
 
 func maybeExtendAuthzError(err error) error {
-	var ae APIError
-	fmtString := "Azure authorization error.  Does your SPN  have Contributor access to Databricks workspace. %v"
-	if errors.As(err, &ae) {
-		if ae.ErrorCode == "403" {
-			return fmt.Errorf(fmtString, err)
-		}
+	fmtString := "Azure authorization error. Does your SPN have Contributor access to Databricks workspace? %v"
+	if e, ok := err.(APIError); ok && e.StatusCode == 403 {
+		return fmt.Errorf(fmtString, err)
 	} else if strings.Contains(err.Error(), "does not have authorization to perform action") {
 		return fmt.Errorf(fmtString, err)
 	}

--- a/common/azure_auth_test.go
+++ b/common/azure_auth_test.go
@@ -404,3 +404,20 @@ func TestInvalidAzureEnvironment(t *testing.T) {
 	_, err = aa.getClientSecretAuthorizer("")
 	assert.Equal(t, envErr, err)
 }
+
+func TestMaybeExtendError(t *testing.T) {
+	err := fmt.Errorf("Some test")
+	err2 := maybeExtendAuthzError(err)
+
+	assert.EqualError(t, err2, err.Error())
+
+	msg := "Azure authorization error. Does your SPN"
+
+	err = fmt.Errorf("something does not have authorization to perform action abc")
+	err2 = maybeExtendAuthzError(err)
+	assert.True(t, strings.HasPrefix(err2.Error(), msg), err2.Error())
+
+	err = APIError{StatusCode: 403}
+	err2 = maybeExtendAuthzError(err)
+	assert.True(t, strings.HasPrefix(err2.Error(), msg), err2.Error())
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,7 +179,7 @@ To work with Azure Databricks workspace, the provider must know its `azure_works
 
 ### Authenticating with Azure Service Principal
 
-!> **Warning** Please note that the azure service principal authentication currently uses a generated Databricks PAT token and not an AAD token for the authentication. Azure Databricks does not yet support AAD tokens for [secret scopes](https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/latest/secrets#--create-secret-scope). Databricks Labs team will refactor it transparently once that support is available. The only impacted field is `pat_token_duration_seconds`, which will be deprecated and fully supported after AAD support. 
+!> **Warning** Please note that the azure service principal authentication currently (since version 0.3.6) uses the AAD token for the authentication (SPN should have **Contributor** role on Databricks workspace).  You can restore previous functionality (generating the PAT for service principal)  by setting `azure_use_pat_for_spn` to `true` (you can regulate the lifetime of generated PAT with `pat_token_duration_seconds` setting). Azure Databricks does not yet support AAD tokens for [secret scopes](https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/latest/secrets#--create-secret-scope). Databricks Labs team will refactor it transparently once that support is available. The only impacted field is `pat_token_duration_seconds`, which will be deprecated and fully supported after AAD support. 
 
 ```hcl
 provider "azurerm" {

--- a/docs/index.md
+++ b/docs/index.md
@@ -276,6 +276,7 @@ The following configuration attributes can be passed via environment variables:
 |         `azure_client_secret` | `DATABRICKS_AZURE_CLIENT_SECRET` or `ARM_CLIENT_SECRET`     |
 |             `azure_client_id` | `DATABRICKS_AZURE_CLIENT_ID` or `ARM_CLIENT_ID`             |
 |             `azure_tenant_id` | `DATABRICKS_AZURE_TENANT_ID` or `ARM_TENANT_ID`             |
+|       `azure_use_pat_for_spn` | `DATABRICKS_AZURE_USE_PAT_FOR_SPN`                          |
 |           `azure_environment` | `ARM_ENVIRONMENT`                                           |
 |        `debug_truncate_bytes` | `DATABRICKS_DEBUG_TRUNCATE_BYTES`                           |
 |               `debug_headers` | `DATABRICKS_DEBUG_HEADERS`                                  |

--- a/identity/data_user_test.go
+++ b/identity/data_user_test.go
@@ -53,15 +53,15 @@ func TestDataSourceUserGerUser(t *testing.T) {
 		{
 			Method:   "GET",
 			Resource: "/api/2.0/preview/scim/v2/Users?filter=userName%20eq%20%27searching_error%27",
-			Status: 404,
-			Response: common.APIError {
+			Status:   404,
+			Response: common.APIError{
 				Message: "searching_error",
 			},
 		},
 		{
 			Method:   "GET",
 			Resource: "/api/2.0/preview/scim/v2/Users?filter=userName%20eq%20%27empty_search%27",
-			Response: UserList {},
+			Response: UserList{},
 		},
 	}, func(ctx context.Context, client *common.DatabricksClient) {
 		usersAPI := NewUsersAPI(ctx, client)

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -216,6 +216,7 @@ func DatabricksProvider() *schema.Provider {
 				Optional:    true,
 				Default:     false,
 				Description: "Create ephemeral PAT tokens instead of AAD tokens for SPN",
+				DefaultFunc: schema.EnvDefaultFunc("DATABRICKS_AZURE_USE_PAT_FOR_SPN", false),
 			},
 			"azure_environment": {
 				Type:        schema.TypeString,

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -211,6 +211,12 @@ func DatabricksProvider() *schema.Provider {
 				Default:     false,
 				Description: "Create ephemeral PAT tokens also for AZ CLI authenticated requests",
 			},
+			"azure_use_pat_for_spn": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Create ephemeral PAT tokens instead of AAD tokens for SPN",
+			},
 			"azure_environment": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -344,6 +350,9 @@ func configureDatabricksClient(ctx context.Context, d *schema.ResourceData) (int
 	}
 	if v, ok := d.GetOk("azure_use_pat_for_cli"); ok {
 		pc.AzureAuth.UsePATForCLI = v.(bool)
+	}
+	if v, ok := d.GetOk("azure_use_pat_for_spn"); ok {
+		pc.AzureAuth.UsePATForSPN = v.(bool)
 	}
 	if v, ok := d.GetOk("azure_environment"); ok {
 		pc.AzureAuth.Environment = v.(string)

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -352,11 +352,12 @@ func configureProviderAndReturnClient(t *testing.T, tt providerConfigTest) (*com
 		return nil, fmt.Errorf(strings.Join(issues, ", "))
 	}
 	client := p.Meta().(*common.DatabricksClient)
+	client.AzureAuth.UsePATForSPN = tt.usePATForSPN
 	err := client.Authenticate()
 	if err != nil {
 		return nil, err
 	}
-	client.AzureAuth.UsePATForSPN = tt.usePATForSPN
+
 	return client, nil
 }
 

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -32,6 +32,7 @@ type providerConfigTest struct {
 	assertToken              string
 	assertHost               string
 	assertAzure              bool
+	usePATForSPN             bool
 }
 
 func (tt providerConfigTest) rawConfig() map[string]interface{} {
@@ -74,6 +75,9 @@ func (tt providerConfigTest) rawConfig() map[string]interface{} {
 	}
 	if tt.azureWorkspaceResourceID != "" {
 		rawConfig["azure_workspace_resource_id"] = tt.azureWorkspaceResourceID
+	}
+	if tt.usePATForSPN {
+		rawConfig["azure_use_pat_for_spn"] = true
 	}
 	return rawConfig
 }
@@ -285,9 +289,10 @@ func TestProviderConfigurationOptions(t *testing.T) {
 				"PATH": "../common/testdata",
 				"HOME": "../common/testdata",
 			},
-			assertAzure: true,
-			assertHost:  "",
-			assertToken: "",
+			assertAzure:  true,
+			usePATForSPN: true,
+			assertHost:   "",
+			assertToken:  "",
 		},
 		{
 			// https://github.com/databrickslabs/terraform-provider-databricks/issues/294
@@ -301,9 +306,10 @@ func TestProviderConfigurationOptions(t *testing.T) {
 				"HOME":                "../common/testdata",
 				"PATH":                "../common/testdata",
 			},
-			assertAzure: true,
-			assertHost:  "",
-			assertToken: "",
+			assertAzure:  true,
+			usePATForSPN: true,
+			assertHost:   "",
+			assertToken:  "",
 		},
 		{
 			env: map[string]string{
@@ -350,6 +356,7 @@ func configureProviderAndReturnClient(t *testing.T, tt providerConfigTest) (*com
 	if err != nil {
 		return nil, err
 	}
+	client.AzureAuth.UsePATForSPN = tt.usePATForSPN
 	return client, nil
 }
 

--- a/qa/testing.go
+++ b/qa/testing.go
@@ -86,7 +86,8 @@ type ResourceFixture struct {
 	NonWritable bool
 	Azure       bool
 	// new resource
-	New bool
+	New       bool
+	AzureAuth *common.AzureAuth
 }
 
 // Apply runs tests from fixture
@@ -101,6 +102,9 @@ func (f ResourceFixture) Apply(t *testing.T) (*schema.ResourceData, error) {
 	}
 	if f.Azure {
 		client.AzureAuth.ResourceID = "/subscriptions/a/resourceGroups/b/providers/Microsoft.Databricks/workspaces/c"
+	}
+	if f.AzureAuth != nil {
+		client.AzureAuth = *f.AzureAuth
 	}
 	if len(f.HCL) > 0 {
 		var out interface{}


### PR DESCRIPTION
* PAT token still could be used by setting `azure_use_pat_for_spn` to `true`
* Check was added to make sure that Azure KeyVault + SPN is detected during plan, not during execution