### PR TITLE
clarify cluster options to apply `databricks_sql_permissions`

### DIFF
--- a/access/resource_sql_permissions.go
+++ b/access/resource_sql_permissions.go
@@ -259,14 +259,14 @@ func (ta *SqlPermissions) getOrCreateCluster(clustersAPI compute.ClustersAPI) (s
 	nodeType := clustersAPI.GetSmallestNodeType(compute.NodeTypeRequest{LocalDisk: true})
 	aclCluster, err := clustersAPI.GetOrCreateRunningCluster(
 		"terrraform-table-acl", compute.Cluster{
-			ClusterName:            "terrraform-table-acl",
+			ClusterName:            "terraform-table-acl",
 			SparkVersion:           sparkVersion,
 			NodeTypeID:             nodeType,
 			AutoterminationMinutes: 10,
 			SparkConf: map[string]string{
 				"spark.databricks.acl.dfAclsEnabled":     "true",
 				"spark.databricks.repl.allowedLanguages": "python,sql",
-				"spark.databricks.cluster.profile":       "serverless",
+				"spark.databricks.cluster.profile":       "singleNode",
 				"spark.master":                           "local[*]",
 			},
 			CustomTags: map[string]string{

--- a/access/resource_sql_permissions_test.go
+++ b/access/resource_sql_permissions_test.go
@@ -204,7 +204,7 @@ var createHighConcurrencyCluster = []qa.HTTPFixture{
 		Resource:     "/api/2.0/clusters/create",
 		ExpectedRequest: compute.Cluster{
 			AutoterminationMinutes: 10,
-			ClusterName:            "terrraform-table-acl",
+			ClusterName:            "terraform-table-acl",
 			NodeTypeID:             "Standard_F4s",
 			SparkVersion:           "7.3.x-scala2.12",
 			CustomTags: map[string]string{
@@ -213,7 +213,7 @@ var createHighConcurrencyCluster = []qa.HTTPFixture{
 			SparkConf: map[string]string{
 				"spark.databricks.acl.dfAclsEnabled":     "true",
 				"spark.databricks.repl.allowedLanguages": "python,sql",
-				"spark.databricks.cluster.profile":       "serverless",
+				"spark.databricks.cluster.profile":       "singleNode",
 				"spark.master":                           "local[*]",
 			},
 		},

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -119,6 +119,36 @@ resource "databricks_cluster" "single_node" {
 }
 ```
 
+### High-Concurrency clusters
+
+To create High-Concurrency cluster, following settings should be provided:
+
+* `spark_conf` should have following items:
+  * `spark.databricks.repl.allowedLanguages` set to a list of supported languages, for example: `python,sql`, or `python,sql,r`.  Scala is not supported!
+  * `spark.databricks.cluster.profile` set to `serverless`
+* `custom_tags` should have tag `ResourceClass` set to value `Serverless`
+
+For example:
+
+```
+esource "databricks_cluster" "cluster_with_table_access_control" {
+  cluster_name            = "Shared High-Concurrency"
+  spark_version           = data.databricks_spark_version.latest_lts.id
+  node_type_id            = data.databricks_node_type.smallest.id
+  autotermination_minutes = 20
+
+  spark_conf = {
+    "spark.databricks.repl.allowedLanguages": "python,sql",
+    "spark.databricks.cluster.profile": "serverless"
+  }
+
+  custom_tags = {
+    "ResourceClass" = "Serverless"
+  }
+}  
+```
+
+
 ### library Configuration Block
 
 To install libraries, one must specify each library in a separate configuration block. Each different type of library has a slightly different syntax. It's possible to set only one type of library within one config block. Otherwise, the plan will fail with an error.

--- a/docs/resources/sql_permissions.md
+++ b/docs/resources/sql_permissions.md
@@ -12,13 +12,21 @@ resource "databricks_cluster" "cluster_with_table_access_control" {
   spark_conf = {
     "spark.databricks.acl.dfAclsEnabled": "true",
     "spark.databricks.repl.allowedLanguages": "python,sql",
-    "spark.databricks.cluster.profile": "serverless"
   }
 
-  custom_tags = {
-    "ResourceClass" = "Serverless"
-  }
 }  
+```
+
+It could be combined with creation of High-Concurrency and Single-Node clusters - in this case it should have corresponding `custom_tags` and `spark.databricks.cluster.profile` in Spark configuration as described in [documentation for `databricks_cluster` resource](cluster.md).
+
+The created cluster could be referred by providing its ID as `cluster_id` property.
+
+
+```hcl
+resource "databricks_sql_permissions" "foo_table" {
+  cluster_id = databricks_cluster.cluster_name.id
+  ...
+}
 ```
 
 ## Example Usage


### PR DESCRIPTION
Also:
* added example of creation of high-concurrency cluster
* switched to single-node cluster for setting SQL permissions

this fixes #680