### PR TITLE
Prepare release 0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 * Azure CLI auth is now forcing JSON output ([#717](https://github.com/databrickslabs/terraform-provider-databricks/pull/717))
 * `databricks_permissions` are getting validation on `terraform plan` stage ([#706](https://github.com/databrickslabs/terraform-provider-databricks/pull/706))
 * Added `databricks_directory` resource ([#690](https://github.com/databrickslabs/terraform-provider-databricks/pull/690))
-* Added support for hybrid instance pools ([#689](https://github.com/databrickslabs/terraform-provider-databricks/pull/689))
 * Added `run_as_role` field to `databricks_sql_query` ([#684](https://github.com/databrickslabs/terraform-provider-databricks/pull/684))
 * Added `user_id` attribute for `databricks_user` data resource, so that it's possible to dynamically create resources based on members of the group ([#714](https://github.com/databrickslabs/terraform-provider-databricks/pull/714))
 * Added more selectors to `databricks_node_type` data source ([#723](https://github.com/databrickslabs/terraform-provider-databricks/pull/723))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Added more selectors to `databricks_node_type` data source ([#723](https://github.com/databrickslabs/terraform-provider-databricks/pull/723))
 * Azure auth with SPN now uses AAD token by default instead of PAT. Previous behavior (using PAT) could be restored by setting `azure_use_pat_for_spn` to `true` ([#721](https://github.com/databrickslabs/terraform-provider-databricks/pull/721))
 * `deployment_name` for `databricks_mws_workspaces` is now optional, how it should have been. This enables creation of Databricks workspaces without an account prefix.
+* To replicate default behavior of Databricks SQL UI, `enable_photon` is now `true` by default for `databricks_sql_endpoint`.
 * Various documentation and bugfixes
 
 Updated dependency versions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 * Added `user_id` attribute for `databricks_user` data resource, so that it's possible to dynamically create resources based on members of the group ([#714](https://github.com/databrickslabs/terraform-provider-databricks/pull/714))
 * Added more selectors to `databricks_node_type` data source ([#723](https://github.com/databrickslabs/terraform-provider-databricks/pull/723))
 * Azure auth with SPN now uses AAD token by default instead of PAT. Previous behavior (using PAT) could be restored by setting `azure_use_pat_for_spn` to `true` ([#721](https://github.com/databrickslabs/terraform-provider-databricks/pull/721))
+* `deployment_name` for `databricks_mws_workspaces` is now optional, how it should have been. This enables creation of Databricks workspaces without an account prefix.
+* Various documentation and bugfixes
 
 Updated dependency versions:
 

--- a/access/resource_sql_permissions.go
+++ b/access/resource_sql_permissions.go
@@ -258,7 +258,7 @@ func (ta *SqlPermissions) getOrCreateCluster(clustersAPI compute.ClustersAPI) (s
 	})
 	nodeType := clustersAPI.GetSmallestNodeType(compute.NodeTypeRequest{LocalDisk: true})
 	aclCluster, err := clustersAPI.GetOrCreateRunningCluster(
-		"terrraform-table-acl", compute.Cluster{
+		"terraform-table-acl", compute.Cluster{
 			ClusterName:            "terraform-table-acl",
 			SparkVersion:           sparkVersion,
 			NodeTypeID:             nodeType,

--- a/access/resource_sql_permissions.go
+++ b/access/resource_sql_permissions.go
@@ -122,7 +122,7 @@ func (ta *SqlPermissions) read() error {
 			strings.Contains(failure, "RESOURCE_DOES_NOT_EXIST") {
 			return common.NotFound(failure)
 		}
-		return fmt.Errorf(failure)
+		return fmt.Errorf("cannot read current grants: %s", failure)
 	}
 	// clear any previous entries
 	ta.PrivilegeAssignments = []PrivilegeAssignment{}
@@ -218,7 +218,10 @@ func (ta *SqlPermissions) apply(qb func(objType, key string) string) error {
 	sqlQuery := qb(objType, key)
 	log.Printf("[INFO] Executing SQL: %s", sqlQuery)
 	r := ta.exec.Execute(ta.ClusterID, "sql", sqlQuery)
-	return r.Err()
+	if !r.Failed() {
+		return nil
+	}
+	return fmt.Errorf("cannot execute %s: %s", sqlQuery, r.Error())
 }
 
 func (ta *SqlPermissions) initCluster(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) (err error) {

--- a/access/resource_sql_permissions_test.go
+++ b/access/resource_sql_permissions_test.go
@@ -113,7 +113,7 @@ func TestTableACL_NotFound(t *testing.T) {
 func TestTableACL_OtherError(t *testing.T) {
 	ta := SqlPermissions{Table: "foo", exec: failedCommand("Some error")}
 	err := ta.read()
-	assert.EqualError(t, err, "Some error")
+	assert.EqualError(t, err, "cannot read current grants: Some error")
 }
 
 func TestTableACL_Revoke(t *testing.T) {
@@ -273,7 +273,7 @@ func TestResourceSqlPermissions_Read_ErrorCommand(t *testing.T) {
 		ID:          "database/foo",
 		Read:        true,
 		New:         true,
-	}.ExpectError(t, "does not compute")
+	}.ExpectError(t, "cannot read current grants: does not compute")
 }
 
 func TestResourceSqlPermissions_Create(t *testing.T) {
@@ -340,7 +340,7 @@ func TestResourceSqlPermissions_Create_Error(t *testing.T) {
 		Fixtures:    createHighConcurrencyCluster,
 		Resource:    ResourceSqlPermissions(),
 		Create:      true,
-	}.ExpectError(t, "Some error")
+	}.ExpectError(t, "cannot read current grants: Some error")
 }
 
 func TestResourceSqlPermissions_Create_Error2(t *testing.T) {
@@ -366,7 +366,7 @@ func TestResourceSqlPermissions_Create_Error2(t *testing.T) {
 		Fixtures: createHighConcurrencyCluster,
 		Resource: ResourceSqlPermissions(),
 		Create:   true,
-	}.ExpectError(t, "Action Unknown ActionType READ cannot be granted on tab... (127 more bytes)")
+	}.ExpectError(t, "cannot execute GRANT READ, MODIFY, SELECT ON TABLE `default`.`foo` TO `serge@example.com`: Action Unknown ActionType READ cannot be granted on tab... (127 more bytes)")
 }
 
 func TestResourceSqlPermissions_Update(t *testing.T) {

--- a/common/azure_auth.go
+++ b/common/azure_auth.go
@@ -152,22 +152,17 @@ func (aa *AzureAuth) addSpManagementTokenVisitor(r *http.Request, management aut
 	if tokenProvider == nil {
 		return fmt.Errorf("token provider is nil")
 	}
-	accessToken := tokenProvider.OAuthToken()
-	if accessToken == "" {
-		// DATABRICKS_HOST was provided, so request to Management API is not made,
-		// therefore we manually need to ensure token refresh here
-		var err error
-		switch rf := tokenProvider.(type) {
-		case adal.RefresherWithContext:
-			err = rf.EnsureFreshWithContext(r.Context())
-		case adal.Refresher:
-			err = rf.EnsureFresh()
-		}
-		if err != nil {
-			return err
-		}
-		accessToken = tokenProvider.OAuthToken()
+	var err error
+	switch rf := tokenProvider.(type) {
+	case adal.RefresherWithContext:
+		err = rf.EnsureFreshWithContext(r.Context())
+	case adal.Refresher:
+		err = rf.EnsureFresh()
 	}
+	if err != nil {
+		return err
+	}
+	accessToken := tokenProvider.OAuthToken()
 	r.Header.Set("X-Databricks-Azure-SP-Management-Token", accessToken)
 	return nil
 }

--- a/compute/model.go
+++ b/compute/model.go
@@ -278,7 +278,7 @@ type Cluster struct {
 	NodeTypeID             string           `json:"node_type_id,omitempty" tf:"group:node_type,computed"`
 	DriverNodeTypeID       string           `json:"driver_node_type_id,omitempty" tf:"group:node_type,computed"`
 	InstancePoolID         string           `json:"instance_pool_id,omitempty" tf:"group:node_type"`
-	DriverInstancePoolID   string           `json:"driver_instance_pool_id,omitempty" tf:"group:node_type"`
+	DriverInstancePoolID   string           `json:"driver_instance_pool_id,omitempty" tf:"group:node_type,computed"`
 	PolicyID               string           `json:"policy_id,omitempty"`
 	AwsAttributes          *AwsAttributes   `json:"aws_attributes,omitempty" tf:"conflicts:instance_pool_id"`
 	AzureAttributes        *AzureAttributes `json:"azure_attributes,omitempty" tf:"conflicts:instance_pool_id"`
@@ -330,7 +330,7 @@ type ClusterInfo struct {
 	EnableElasticDisk         bool               `json:"enable_elastic_disk,omitempty"`
 	EnableLocalDiskEncryption bool               `json:"enable_local_disk_encryption,omitempty"`
 	InstancePoolID            string             `json:"instance_pool_id,omitempty"`
-	DriverInstancePoolID      string             `json:"driver_instance_pool_id,omitempty"`
+	DriverInstancePoolID      string             `json:"driver_instance_pool_id,omitempty" tf:"computed"`
 	PolicyID                  string             `json:"policy_id,omitempty"`
 	SingleUserName            string             `json:"single_user_name,omitempty"`
 	ClusterSource             Availability       `json:"cluster_source,omitempty"`

--- a/docs/resources/sql_endpoint.md
+++ b/docs/resources/sql_endpoint.md
@@ -38,7 +38,7 @@ The following arguments are supported:
 * `instance_profile_arn` - [databricks_instance_profile](instance_profile.md) used to access storage from the SQL endpoint. This field is optional.
 * `tags` - Databricks tags all endpoint resources with these tags.
 * `spot_instance_policy` - The spot policy to use for allocating instances to clusters: `COST_OPTIMIZED` or `RELIABILITY_OPTIMIZED`. This field is optional. Default is `COST_OPTIMIZED`.
-* `enable_photon` - Whether to enable [Photon](https://databricks.com/product/delta-engine). This field is optional.
+* `enable_photon` - Whether to enable [Photon](https://databricks.com/product/delta-engine). This field is optional and is enabled by default.
 
 ## Attribute Reference
 

--- a/identity/acceptance/group_test.go
+++ b/identity/acceptance/group_test.go
@@ -33,11 +33,6 @@ func TestAccGroupResource(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 				Destroy:            false,
 			},
-			{
-				ResourceName:      "databricks_group.my_group",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
 		},
 	})
 }

--- a/identity/acceptance/resource_user_test.go
+++ b/identity/acceptance/resource_user_test.go
@@ -30,10 +30,6 @@ func TestAccUserResource(t *testing.T) {
 		user_name = "derde+{var.RANDOM}@example.com"
 		display_name = "Derde {var.RANDOM}"
 		allow_instance_pool_create = true
-	}
-	
-	resource "databricks_group" "first" {
-		display_name = "Vierde {var.RANDOM}"
 	}`)
 	acceptance.AccTest(t, resource.TestCase{
 		Steps: []resource.TestStep{

--- a/identity/groups.go
+++ b/identity/groups.go
@@ -49,7 +49,7 @@ func (a GroupsAPI) Filter(filter string) (GroupList, error) {
 	return groups, err
 }
 
-func (a GroupsAPI) PatchR(groupID string, r patchRequest) error {
+func (a GroupsAPI) Patch(groupID string, r patchRequest) error {
 	return a.client.Scim(a.context, http.MethodPatch, fmt.Sprintf("/preview/scim/v2/Groups/%v", groupID), r, nil)
 }
 

--- a/identity/groups_test.go
+++ b/identity/groups_test.go
@@ -28,7 +28,6 @@ func TestAccGroup(t *testing.T) {
 	user2, err := usersAPI.Create(ScimUser{UserName: qa.RandomEmail()})
 	require.NoError(t, err, err)
 
-	//Create empty group
 	group, err := groupsAPI.Create(ScimGroup{
 		DisplayName: qa.RandomName("tf-"),
 	})
@@ -45,11 +44,21 @@ func TestAccGroup(t *testing.T) {
 
 	group, err = groupsAPI.Read(group.ID)
 	require.NoError(t, err, err)
+	assert.True(t, len(group.Members) == 0)
+
+	err = groupsAPI.Patch(group.ID, scimPatchRequest("add", "members", user.ID))
+	assert.NoError(t, err, err)
 
 	group, err = groupsAPI.Read(group.ID)
 	assert.NoError(t, err, err)
 	assert.True(t, len(group.Members) == 1)
-	assert.True(t, group.Members[0].Value == user2.ID)
+
+	err = groupsAPI.Patch(group.ID, scimPatchRequest("add", "members", user2.ID))
+	assert.NoError(t, err, err)
+
+	group, err = groupsAPI.Read(group.ID)
+	assert.NoError(t, err, err)
+	assert.True(t, len(group.Members) == 2)
 }
 
 func TestAccFilterGroup(t *testing.T) {

--- a/identity/resource_group_instance_profile.go
+++ b/identity/resource_group_instance_profile.go
@@ -25,10 +25,10 @@ func ResourceGroupInstanceProfile() *schema.Resource {
 			return err
 		},
 		CreateContext: func(ctx context.Context, groupID, roleARN string, c *common.DatabricksClient) error {
-			return NewGroupsAPI(ctx, c).PatchR(groupID, scimPatchRequest("add", "roles", roleARN))
+			return NewGroupsAPI(ctx, c).Patch(groupID, scimPatchRequest("add", "roles", roleARN))
 		},
 		DeleteContext: func(ctx context.Context, groupID, roleARN string, c *common.DatabricksClient) error {
-			return NewGroupsAPI(ctx, c).PatchR(groupID, scimPatchRequest(
+			return NewGroupsAPI(ctx, c).Patch(groupID, scimPatchRequest(
 				"remove", fmt.Sprintf(`roles[value eq "%s"]`, roleARN), ""))
 		},
 	})

--- a/identity/resource_group_member.go
+++ b/identity/resource_group_member.go
@@ -13,7 +13,7 @@ import (
 func ResourceGroupMember() *schema.Resource {
 	return common.NewPairID("group_id", "member_id").BindResource(common.BindResource{
 		CreateContext: func(ctx context.Context, groupID, memberID string, c *common.DatabricksClient) error {
-			return NewGroupsAPI(ctx, c).PatchR(groupID, scimPatchRequest("add", "members", memberID))
+			return NewGroupsAPI(ctx, c).Patch(groupID, scimPatchRequest("add", "members", memberID))
 		},
 		ReadContext: func(ctx context.Context, groupID, memberID string, c *common.DatabricksClient) error {
 			group, err := NewGroupsAPI(ctx, c).Read(groupID)
@@ -24,7 +24,7 @@ func ResourceGroupMember() *schema.Resource {
 			return err
 		},
 		DeleteContext: func(ctx context.Context, groupID, memberID string, c *common.DatabricksClient) error {
-			return NewGroupsAPI(ctx, c).PatchR(groupID, scimPatchRequest(
+			return NewGroupsAPI(ctx, c).Patch(groupID, scimPatchRequest(
 				"remove", fmt.Sprintf(`members[value eq "%s"]`, memberID), ""))
 		},
 	})

--- a/identity/resource_service_principal.go
+++ b/identity/resource_service_principal.go
@@ -93,9 +93,6 @@ func ResourceServicePrincipal() *schema.Resource {
 			if client.IsAzure() && sp.ApplicationID == "" {
 				return fmt.Errorf("application_id is required for service principals in Azure Databricks")
 			}
-			if client.IsAws() && sp.ApplicationID != "" {
-				return fmt.Errorf("application_id is not allowed for service principals in Databricks on AWS")
-			}
 			if client.IsAws() && sp.DisplayName == "" {
 				return fmt.Errorf("display_name is required for service principals in Databricks on AWS")
 			}
@@ -105,6 +102,9 @@ func ResourceServicePrincipal() *schema.Resource {
 			sp, err := spFromData(d)
 			if err != nil {
 				return err
+			}
+			if c.IsAws() && sp.ApplicationID != "" {
+				return fmt.Errorf("application_id is not allowed for service principals in Databricks on AWS")
 			}
 			servicePrincipal, err := NewServicePrincipalsAPI(ctx, c).Create(sp)
 			if err != nil {

--- a/identity/resource_service_principal_test.go
+++ b/identity/resource_service_principal_test.go
@@ -121,16 +121,6 @@ func TestResourceServicePrincipalRead_Invalid_AWS(t *testing.T) {
 	}.ExpectError(t, "display_name is required for service principals in Databricks on AWS")
 }
 
-func TestResourceServicePrincipalRead_Invalid2_AWS(t *testing.T) {
-	qa.ResourceFixture{
-		Resource: ResourceServicePrincipal(),
-		New:      true,
-		Read:     true,
-		ID:       "abc",
-		HCL:      `application_id = "discobot"`,
-	}.ExpectError(t, "application_id is not allowed for service principals in Databricks on AWS")
-}
-
 func TestResourceServicePrincipalRead_Error(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{

--- a/identity/scim.go
+++ b/identity/scim.go
@@ -42,13 +42,16 @@ var entitlementMapping = map[string]string{
 	"allow-cluster-create":       "allow_cluster_create",
 	"allow-instance-pool-create": "allow_instance_pool_create",
 	"databricks-sql-access":      "allow_sql_analytics_access", // TODO: state change
+	"workspace-access":           "workspace_access",
 }
 
 // order is important for tests
 var possibleEntitlements = []string{
 	"allow-cluster-create",
 	"allow-instance-pool-create",
-	"databricks-sql-access"}
+	"databricks-sql-access",
+	"workspace-access",
+}
 
 type entitlements []ComplexValue
 
@@ -81,6 +84,7 @@ func addEntitlementsToSchema(s *map[string]*schema.Schema) {
 		(*s)[field_name] = &schema.Schema{
 			Type:     schema.TypeBool,
 			Optional: true,
+			Default: false,
 		}
 	}
 }

--- a/identity/scim.go
+++ b/identity/scim.go
@@ -84,7 +84,7 @@ func addEntitlementsToSchema(s *map[string]*schema.Schema) {
 		(*s)[field_name] = &schema.Schema{
 			Type:     schema.TypeBool,
 			Optional: true,
-			Default: false,
+			Default:  false,
 		}
 	}
 }

--- a/sqlanalytics/resource_sql_endpoint.go
+++ b/sqlanalytics/resource_sql_endpoint.go
@@ -189,6 +189,7 @@ func ResourceSQLEndpoint() *schema.Resource {
 		m["min_num_clusters"].Default = 1
 		m["num_clusters"].Default = 1
 		m["spot_instance_policy"].Default = "COST_OPTIMIZED"
+		m["enable_photon"].Default = true
 		m["tags"].DiffSuppressFunc = common.MakeEmptyBlockSuppressFunc("tags.#")
 		return m
 	})

--- a/sqlanalytics/resource_sql_endpoint_test.go
+++ b/sqlanalytics/resource_sql_endpoint_test.go
@@ -78,6 +78,7 @@ func TestResourceSQLEndpointCreate(t *testing.T) {
 					AutoStopMinutes:    120,
 					MinNumClusters:     1,
 					NumClusters:        1,
+					EnablePhoton:       true,
 					SpotInstancePolicy: "COST_OPTIMIZED",
 				},
 				Response: SQLEndpoint{
@@ -116,16 +117,7 @@ func TestResourceSQLEndpointCreate_ErrorDisabled(t *testing.T) {
 			{
 				Method:   "POST",
 				Resource: "/api/2.0/sql/endpoints",
-				ExpectedRequest: SQLEndpoint{
-					Name:               "foo",
-					ClusterSize:        "Small",
-					AutoStopMinutes:    120,
-					MaxNumClusters:     1,
-					MinNumClusters:     1,
-					NumClusters:        1,
-					SpotInstancePolicy: "COST_OPTIMIZED",
-				},
-				Status: 404,
+				Status:   404,
 				Response: common.APIError{
 					ErrorCode: "FEATURE_DISABLED",
 					Message:   "Databricks SQL is not supported",
@@ -184,6 +176,7 @@ func TestResourceSQLEndpointUpdate(t *testing.T) {
 					MaxNumClusters:     1,
 					MinNumClusters:     1,
 					NumClusters:        1,
+					EnablePhoton:       true,
 					SpotInstancePolicy: "COST_OPTIMIZED",
 				},
 			},

--- a/storage/mounts.go
+++ b/storage/mounts.go
@@ -44,7 +44,14 @@ func (mp MountPoint) Source() (string, error) {
 // Delete removes mount from workspace
 func (mp MountPoint) Delete() error {
 	result := mp.exec.Execute(mp.clusterID, "python", fmt.Sprintf(`
+		found = False
 		mount_point = "/mnt/%s"
+		dbutils.fs.refreshMounts()
+		for mount in dbutils.fs.mounts():
+			if mount.mountPoint == mount_point:
+				found = True
+		if not found:
+			dbutils.notebook.exit("success")
 		dbutils.fs.unmount(mount_point)
 		dbutils.fs.refreshMounts()
 		for mount in dbutils.fs.mounts():

--- a/storage/mounts_test.go
+++ b/storage/mounts_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/databrickslabs/terraform-provider-databricks/access"

--- a/storage/mounts_test.go
+++ b/storage/mounts_test.go
@@ -201,7 +201,14 @@ func TestMountPoint_Source(t *testing.T) {
 func TestMountPoint_Delete(t *testing.T) {
 	mountName := "this_mount"
 	expectedCommand := fmt.Sprintf(`
+		found = False
 		mount_point = "/mnt/%s"
+		dbutils.fs.refreshMounts()
+		for mount in dbutils.fs.mounts():
+			if mount.mountPoint == mount_point:
+				found = True
+		if not found:
+			dbutils.notebook.exit("success")
 		dbutils.fs.unmount(mount_point)
 		dbutils.fs.refreshMounts()
 		for mount in dbutils.fs.mounts():

--- a/storage/mounts_test.go
+++ b/storage/mounts_test.go
@@ -71,12 +71,6 @@ func testMounting(t *testing.T, mp MountPoint, m Mount) {
 	require.Equalf(t, m.Source(), source, "Error: %v", err)
 }
 
-func TestAccDeleteInvalidMountFails(t *testing.T) {
-	_, mp := mountPointThroughReusedCluster(t)
-	err := mp.Delete()
-	assert.True(t, strings.Contains(err.Error(), "Directory not mounted"), err.Error())
-}
-
 func TestAccSourceOnInvalidMountFails(t *testing.T) {
 	_, mp := mountPointThroughReusedCluster(t)
 	source, err := mp.Source()


### PR DESCRIPTION
# Version changelog

## 0.3.6

* Added support for hybrid pools ([#689](https://github.com/databrickslabs/terraform-provider-databricks/pull/689))
* Added support for `always_running` jobs, which are restarted on resource updates ([#715](https://github.com/databrickslabs/terraform-provider-databricks/pull/715))
* Azure CLI auth is now forcing JSON output ([#717](https://github.com/databrickslabs/terraform-provider-databricks/pull/717))
* `databricks_permissions` are getting validation on `terraform plan` stage ([#706](https://github.com/databrickslabs/terraform-provider-databricks/pull/706))
* Added `databricks_directory` resource ([#690](https://github.com/databrickslabs/terraform-provider-databricks/pull/690))
* Added support for hybrid instance pools ([#689](https://github.com/databrickslabs/terraform-provider-databricks/pull/689))
* Added `run_as_role` field to `databricks_sql_query` ([#684](https://github.com/databrickslabs/terraform-provider-databricks/pull/684))
* Added `user_id` attribute for `databricks_user` data resource, so that it's possible to dynamically create resources based on members of the group ([#714](https://github.com/databrickslabs/terraform-provider-databricks/pull/714))
* Added more selectors to `databricks_node_type` data source ([#723](https://github.com/databrickslabs/terraform-provider-databricks/pull/723))
* Azure auth with SPN now uses AAD token by default instead of PAT. Previous behavior (using PAT) could be restored by setting `azure_use_pat_for_spn` to `true` ([#721](https://github.com/databrickslabs/terraform-provider-databricks/pull/721))
* `deployment_name` for `databricks_mws_workspaces` is now optional, how it should have been. This enables creation of Databricks workspaces without an account prefix.
* Various documentation and bugfixes

Updated dependency versions:

* Bump github.com/aws/aws-sdk-go from 1.38.51 to 1.38.71
* Bump github.com/Azure/go-autorest/autorest/azure/auth from 0.5.7 to 0.5.8
* Bump github.com/Azure/go-autorest/autorest from 0.11.18 to 0.11.19
* Bump github.com/Azure/go-autorest/autorest/adal from 0.9.13 to 0.9.14
* Bump github.com/zclconf/go-cty from 1.8.3 to 1.8.4 
* Bump github.com/hashicorp/terraform-plugin-sdk/v2 from 2.6.1 to 2.7.0

awsmt
---
 * [x] TestAccClusterResource_CreateClusterWithLibraries (235.71s)
 * [x] TestAccClusterResource_CreateSingleNodeCluster (64.42s)
 * [x] TestAccGroup (14.77s)
 * [x] TestAccUserResource (7.24s)
 * [x] TestAwsAccServicePrincipalResource (6.90s)
 * [x] access.TestAccIPACL (1.44s)
 * [x] access.TestAccPermissionsClusterPolicy (13.06s)
 * [x] access.TestAccPermissionsClusters (197.83s)
 * [x] access.TestAccPermissionsInstancePool (14.08s)
 * [x] access.TestAccPermissionsJobs (16.38s)
 * [x] access.TestAccPermissionsNotebooks (16.66s)
 * [x] access.TestAccPermissionsTokens (14.25s)
 * [x] access/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (49.77s)
 * [x] access/acceptance.TestAccInitialManagePrincipals (1.97s)
 * [x] access/acceptance.TestAccInitialManagePrincipalsGroup (2.16s)
 * [x] access/acceptance.TestAccSecretAclResource (16.33s)
 * [x] access/acceptance.TestAccSecretAclResourceDefaultPrincipal (8.55s)
 * [x] access/acceptance.TestAccSecretResource (6.50s)
 * [x] access/acceptance.TestAccSecretScopeResource (8.78s)
 * [x] access/acceptance.TestAccTableACL (904.17s)
 * [x] compute.TestAccContext (110.26s)
 * [x] compute.TestAccInstancePools (4.28s)
 * [x] compute.TestAccLibraryCreate (142.89s)
 * [x] compute.TestAccListClustersIntegration (209.27s)
 * [x] compute.TestAwsAccSmallestNodeType (0.21s)
 * [x] compute/acceptance.TestAccClusterPolicyResourceFullLifecycle (12.67s)
 * [x] compute/acceptance.TestAccJobResource (3.33s)
 * [x] compute/acceptance.TestAwsAccJobResource_NoInstancePool (3.41s)
 * [x] compute/acceptance.TestAwsAccJobsCreate (2.46s)
 * [x] identity/acceptance.TestAccComplexValueResource (25.24s)
 * [x] identity/acceptance.TestAccGroupResource (22.36s)
 * [x] identity/acceptance.TestAccGroupResource_verify_entitlements (13.71s)
 * [x] identity/acceptance.TestAccTokenResource (4.00s)
 * [x] identity/acceptance.TestAwsAccGroupInstanceProfileResource (329.34s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace (5.32s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies (0.30s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies_Delete (0.49s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Clusters (0.39s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/DBFS_Files (0.94s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Groups (0.52s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Instance_Pools (0.15s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Instance_Profiles (0.40s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Jobs (0.15s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Notebooks (0.31s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_ACLs (0.21s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_Scopes (0.20s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secrets (0.07s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Tokens (1.18s)
 * [x] internal/sanity.TestAccMutiworkspaceUsedFromNormalMode (2.85s)
 * [x] storage.TestAccCreateFile (4.74s)
 * [x] storage.TestAccDeleteInvalidMountFails (4.00s)
 * [x] storage.TestAccInvalidSecretScopeFails (3.73s)
 * [x] storage.TestAccSourceOnInvalidMountFails (31.54s)
 * [x] storage.TestAwsAccS3Mount (339.95s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (5.24s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (2.84s)
 * [x] storage/acceptance.TestAwsAccS3IamMount_NoClusterGiven (578.04s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (5.07s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (6.27s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (3.64s)

azsp
---
 * [x] TestAccGroupResource (18.99s)
 * [x] TestAccTableACL (690.91s)
 * [x] TestAzureAccADLSv2Mount (41.74s)
 * [x] TestAzureAccAdlsGen2Mount_correctly_mounts (15.64s)
 * [x] access.TestAccIPACL (2.86s)
 * [x] access.TestAccPermissionsClusterPolicy (12.25s)
 * [x] access.TestAccPermissionsClusters (230.34s)
 * [x] access.TestAccPermissionsInstancePool (11.96s)
 * [x] access.TestAccPermissionsJobs (13.26s)
 * [x] access.TestAccPermissionsNotebooks (14.19s)
 * [x] access.TestAccPermissionsTokens (10.95s)
 * [x] access/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (46.37s)
 * [x] access/acceptance.TestAccInitialManagePrincipals (2.05s)
 * [x] access/acceptance.TestAccInitialManagePrincipalsGroup (1.24s)
 * [x] access/acceptance.TestAccSecretAclResource (10.87s)
 * [x] access/acceptance.TestAccSecretAclResourceDefaultPrincipal (7.73s)
 * [x] access/acceptance.TestAccSecretResource (9.26s)
 * [x] access/acceptance.TestAccSecretScopeResource (9.17s)
 * [x] compute.TestAccContext (34.05s)
 * [x] compute.TestAccInstancePools (2.71s)
 * [x] compute.TestAccLibraryCreate (58.08s)
 * [x] compute.TestAccListClustersIntegration (225.99s)
 * [x] compute.TestAzureAccNodeTypes (0.52s)
 * [x] compute/acceptance.TestAccClusterPolicyResourceFullLifecycle (13.07s)
 * [x] compute/acceptance.TestAccJobResource (5.76s)
 * [x] identity.TestAccCreateToken (1.17s)
 * [x] identity.TestAccCreateToken_NoExpiration (1.17s)
 * [x] identity.TestAccCreateUser (7.43s)
 * [x] identity.TestAccFilterGroup (1.61s)
 * [x] identity.TestAccGroup (17.35s)
 * [x] identity.TestAccReadUser (1.43s)
 * [x] identity.TestAzureAccSP (5.44s)
 * [x] identity/acceptance.TestAccComplexValueResource (19.08s)
 * [x] identity/acceptance.TestAccGroupResource_verify_entitlements (11.64s)
 * [x] identity/acceptance.TestAccTokenResource (7.60s)
 * [x] identity/acceptance.TestAccUserResource (9.76s)
 * [x] identity/acceptance.TestAzureAccServicePrincipalResource (6.67s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace (4.94s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies (0.43s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies_Delete (0.46s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Clusters (0.29s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/DBFS_Files (0.70s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Groups (0.38s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Instance_Pools (0.21s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Jobs (0.21s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Notebooks (0.27s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_ACLs (0.68s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_Scopes (0.81s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secrets (0.14s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Tokens (0.37s)
 * [x] internal/sanity.TestAccMutiworkspaceUsedFromNormalMode (6.96s)
 * [x] storage.TestAccCreateFile (6.24s)
 * [x] storage.TestAccDeleteInvalidMountFails (5.76s)
 * [x] storage.TestAccInvalidSecretScopeFails (4.87s)
 * [x] storage.TestAccSourceOnInvalidMountFails (27.48s)
 * [x] storage.TestAzureAccADLSv1Mount (358.65s)
 * [x] storage.TestAzureAccBlobMount (121.12s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (8.13s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (3.98s)
 * [x] storage/acceptance.TestAzureAccAdlsGen1Mount_correctly_mounts (358.36s)
 * [x] storage/acceptance.TestAzureAccBlobMount_correctly_mounts (379.24s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (6.19s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (10.27s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (5.19s)

mws
---

 * [x] mws.TestMwsAccCreds (2.38s)
 * [x] mws.TestMwsAccCustomerManagedKeys (3.09s)
 * [x] mws.TestMwsAccLogDelivery (6.19s)
 * [x] mws.TestMwsAccMissingResources (3.39s)
 * [x] mws.TestMwsAccMissingResources/Credential (1.14s)
 * [x] mws.TestMwsAccMissingResources/Customer_Managed_Key (0.54s)
 * [x] mws.TestMwsAccMissingResources/Network (0.53s)
 * [x] mws.TestMwsAccMissingResources/Storage (0.60s)
 * [x] mws.TestMwsAccMissingResources/Workspace (0.59s)
 * [x] mws.TestMwsAccPAS (2.24s)
 * [x] mws.TestMwsAccStorageConfigurations (1.97s)
 * [x] mws.TestMwsAccVPCEndpointIntegration (118.36s)
 * [x] mws.TestMwsAccWorkspace (0.53s)
 * [x] mws/acceptance.TestMwsAccCredentials (4.82s)
 * [x] mws/acceptance.TestMwsAccCustomerManagedKeys (10.44s)
 * [x] mws/acceptance.TestMwsAccLogDelivery (10.35s)
 * [x] mws/acceptance.TestMwsAccNetworks (4.65s)
 * [x] mws/acceptance.TestMwsAccPrivateAccessSettings (4.80s)
 * [x] mws/acceptance.TestMwsAccStorageConfigurations (4.63s)
 * [x] mws/acceptance.TestMwsAccVpcEndpoint (105.50s)
 * [x] mws/acceptance.TestMwsAccWorkspaces (133.30s)

preview
---
 * ~TestPreviewAccDashboard~ - to be fixed in #730
 * [x] compute/acceptance.TestPreviewAccPipelineResource_CreatePipeline (12.65s)
 * [x] sqlanalytics.TestPreviewAccSQLEndpoints (292.08s)
 * [x] sqlanalytics/acceptance.TestPreviewAccQuery (353.14s)
 * [x] sqlanalytics/acceptance.TestPreviewAccSQLEndpoint (379.30s)

azcli
---
 * [x] TestAccTableACL (509.09s)
 * [x] access.TestAccIPACL (19.32s)
 * [x] access.TestAccPermissionsClusterPolicy (14.25s)
 * [x] access.TestAccPermissionsClusters (384.10s)
 * [x] access.TestAccPermissionsInstancePool (16.71s)
 * [x] access.TestAccPermissionsJobs (14.48s)
 * [x] access.TestAccPermissionsNotebooks (14.91s)
 * [x] access.TestAccPermissionsTokens (12.38s)
 * [x] access/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (80.44s)
 * [x] access/acceptance.TestAccInitialManagePrincipals (3.51s)
 * [x] access/acceptance.TestAccInitialManagePrincipalsGroup (2.33s)
 * [x] access/acceptance.TestAccSecretAclResource (18.62s)
 * [x] access/acceptance.TestAccSecretAclResourceDefaultPrincipal (14.19s)
 * [x] access/acceptance.TestAccSecretResource (16.97s)
 * [x] access/acceptance.TestAccSecretScopeResource (20.90s)
 * [x] access/acceptance.TestAzureAccKeyVaultSimple (4.18s)
 * [x] compute.TestAccContext (31.09s)
 * [x] compute.TestAccInstancePools (4.23s)
 * [x] compute.TestAccLibraryCreate (129.77s)
 * [x] compute.TestAccListClustersIntegration (316.69s)
 * [x] compute.TestAzureAccNodeTypes (0.57s)
 * [x] compute/acceptance.TestAccClusterPolicyResourceFullLifecycle (36.98s)
 * [x] compute/acceptance.TestAccJobResource (11.96s)
 * [x] identity.TestAccCreateToken (4.27s)
 * [x] identity.TestAccCreateToken_NoExpiration (2.87s)
 * [x] identity.TestAccCreateUser (7.48s)
 * [x] identity.TestAccFilterGroup (3.41s)
 * [x] identity.TestAccGroup (33.99s)
 * [x] identity.TestAccReadUser (3.86s)
 * [x] identity.TestAzureAccSP (7.10s)
 * [x] identity/acceptance.TestAccComplexValueResource (27.80s)
 * [x] identity/acceptance.TestAccGroupResource (33.71s)
 * [x] identity/acceptance.TestAccGroupResource_verify_entitlements (19.86s)
 * [x] identity/acceptance.TestAccTokenResource (13.36s)
 * [x] identity/acceptance.TestAccUserResource (18.91s)
 * [x] identity/acceptance.TestAzureAccServicePrincipalResource (12.82s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace (6.10s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies (0.73s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies_Delete (0.82s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Clusters (0.29s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/DBFS_Files (0.71s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Groups (0.20s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Instance_Pools (0.48s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Jobs (0.28s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Notebooks (0.52s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_ACLs (0.52s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_Scopes (0.35s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secrets (0.46s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Tokens (0.74s)
 * [x] internal/sanity.TestAccMutiworkspaceUsedFromNormalMode (18.53s)
 * [x] storage.TestAccCreateFile (6.63s)
 * [x] storage.TestAccInvalidSecretScopeFails (5.55s)
 * [x] storage.TestAccSourceOnInvalidMountFails (26.87s)
 * [x] storage.TestAzureAccBlobMount (189.61s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (18.57s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (8.76s)
 * [x] storage/acceptance.TestAzureAccBlobMount_correctly_mounts (642.00s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (19.33s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (22.35s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (10.56s)
