### PR TITLE
Fix #649 - Improve workspace update logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.3.7
 
 * Added `databricks_obo_token` resource to create On-Behalf-Of tokens for a Service Principal in Databricks workspaces on AWS. It is very useful, when you want to provision resources within a workspace through narrowly-scoped service principal, that has no access to other workspaces within the same Databricks Account ([#736](https://github.com/databrickslabs/terraform-provider-databricks/pull/736))
+* Fixed incorrect workspace update bug and added more validation error messaging ([#649](https://github.com/databrickslabs/terraform-provider-databricks/pull/649))
 
 Updated dependency versions:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Added `databricks_obo_token` resource to create On-Behalf-Of tokens for a Service Principal in Databricks workspaces on AWS. It is very useful, when you want to provision resources within a workspace through narrowly-scoped service principal, that has no access to other workspaces within the same Databricks Account ([#736](https://github.com/databrickslabs/terraform-provider-databricks/pull/736))
 * Fixed incorrect workspace update bug and added more validation error messaging ([#649](https://github.com/databrickslabs/terraform-provider-databricks/pull/649))
+* Clarify network modification procedure on active workspaces ([#732](https://github.com/databrickslabs/terraform-provider-databricks/issues/732))
+* Various bug fixes in Databricks SQL resources
 
 Updated dependency versions:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,7 +207,9 @@ func ResourceExample() *schema.Resource {
 
 *Add the resource to the top-level provider.* Simply add the resource to the provider definition in `provider/provider.go`.
 
-*Write unit tests for your resource.* To write your unit tests, you can make use of `ResourceFixture` and `HTTPFixture` structs defined in the `qa` package. This starts a fake HTTP server, asserting that your resource provdier generates the correct request for a given HCL template body for your resource. An example:
+*Write unit tests for your resource.* To write your unit tests, you can make use of `ResourceFixture` and `HTTPFixture` structs defined in the `qa` package. This starts a fake HTTP server, asserting that your resource provdier generates the correct request for a given HCL template body for your resource. Update tests should have `InstanceState` field in order to test various corner-cases, like `ForceNew` schemas. It's possible to expect fixture to require new resource by specifying `RequiresNew` field.
+
+A simple example:
 
 ```go
 func TestExampleResourceCreate(t *testing.T) {

--- a/access/resource_permissions_test.go
+++ b/access/resource_permissions_test.go
@@ -726,6 +726,9 @@ func TestResourcePermissionsUpdate(t *testing.T) {
 				},
 			},
 		},
+		InstanceState: map[string]string{
+			"job_id": "9",
+		},
 		HCL: `
 		job_id = 9
 

--- a/access/resource_sql_permissions_test.go
+++ b/access/resource_sql_permissions_test.go
@@ -386,6 +386,9 @@ func TestResourceSqlPermissions_Update(t *testing.T) {
 			"REVOKE ALL PRIVILEGES ON TABLE `default`.`foo` FROM `interns`":              {},
 			"GRANT READ, MODIFY, SELECT ON TABLE `default`.`foo` TO `serge@example.com`": {},
 		}.toCommandMock(),
+		InstanceState: map[string]string{
+			"table": "foo",
+		},
 		HCL: `
 		table = "foo"
 		privilege_assignments {

--- a/compute/resource_instance_pool_test.go
+++ b/compute/resource_instance_pool_test.go
@@ -234,6 +234,7 @@ func TestResourceInstancePoolUpdate(t *testing.T) {
 				Method:   "GET",
 				Resource: "/api/2.0/instance-pools/get?instance_pool_id=abc",
 				Response: InstancePoolAndStats{
+					EnableElasticDisk:                  true,
 					InstancePoolID:                     "abc",
 					MaxCapacity:                        500,
 					NodeTypeID:                         "i3.xlarge",
@@ -250,6 +251,10 @@ func TestResourceInstancePoolUpdate(t *testing.T) {
 			"max_capacity":                          500,
 			"min_idle_instances":                    5,
 			"node_type_id":                          "i3.xlarge",
+		},
+		InstanceState: map[string]string{
+			"node_type_id":        "i3.xlarge",
+			"enable_elastic_disk": "true",
 		},
 		Update: true,
 		ID:     "abc",
@@ -278,8 +283,9 @@ func TestResourceInstancePoolUpdate_Error(t *testing.T) {
 			"min_idle_instances":                    5,
 			"node_type_id":                          "i3.xlarge",
 		},
-		Update: true,
-		ID:     "abc",
+		Update:      true,
+		RequiresNew: true,
+		ID:          "abc",
 	}.Apply(t)
 	qa.AssertErrorStartsWith(t, err, "Internal error happened")
 	assert.Equal(t, "abc", d.Id())

--- a/docs/resources/mws_networks.md
+++ b/docs/resources/mws_networks.md
@@ -80,6 +80,14 @@ In order to create a VPC [that leverages AWS PrivateLink](https://docs.databrick
 }
   ```
 
+## Modifying networks on running workspaces
+
+Due to specifics of platform APIs, changing any attribute of network configuration would cause `databricks_mws_networks` to be re-created - deleted & added again with special case for running workspaces. Once network configuration is attached to a running [databricks_mws_workspaces](mws_workspaces.md), you cannot delete it and `terraform apply` would result in `INVALID_STATE: Unable to delete, Network is being used by active workspace X` error. In order to modify any attributes of a network, you have to perform three different `terraform apply` steps:
+
+1. Create a new `databricks_mws_networks` resource.
+2. Update the `databricks_mws_workspaces` to point to the new `network_id`.
+3. Delete the old `databricks_mws_networks` resource.
+
 ## Argument Reference
 
 The following arguments are available:

--- a/docs/resources/mws_workspaces.md
+++ b/docs/resources/mws_workspaces.md
@@ -176,19 +176,23 @@ In order to create a [Databricks Workspace that leverages AWS PrivateLink](https
 
 -> **Note** All workspaces would be verified to get into runnable state or deleted upon failure. You can only update `credentials_id`, `network_id`, and `storage_customer_managed_key_id` on a running workspace.
 
-The following arguments are available:
+The following arguments are available and cannot be changed after workspace is created:
 
-* `network_id` - (Optional) `network_id` from [networks](mws_networks.md)
 * `account_id` - Account Id that could be found in the bottom left corner of [Accounts Console](https://accounts.cloud.databricks.com/).
-* `credentials_id` - `credentials_id` from [credentials](mws_credentials.md)
 * `customer_managed_key_id` - (Optional, **Deprecated**, see `managed_services_customer_managed_key_id` and `storage_customer_managed_key_id`) `customer_managed_key_id` from [customer managed keys](mws_customer_managed_keys.md)
 * `managed_services_customer_managed_key_id` - (Optional) `customer_managed_key_id` from [customer managed keys](mws_customer_managed_keys.md) with `use_cases` set to `MANAGED_SERVICES`. This is used to encrypt the workspace's notebook and secret data in the control plane.
-* `storage_customer_managed_key_id` - (Optional) `customer_managed_key_id` from [customer managed keys](mws_customer_managed_keys.md) with `use_cases` set to `STORAGE`. This is used to encrypt the DBFS Storage & Cluster EBS Volumes.
 * `deployment_name` - (Optional) part of URL: `https://<deployment-name>.cloud.databricks.com`
 * `workspace_name` - name of the workspace, will appear on UI
 * `aws_region` - AWS region of VPC
 * `storage_configuration_id` - `storage_configuration_id` from [storage configuration](mws_storage_configurations.md)
 * `private_access_settings_id` - (Optional) Canonical unique identifier of [databricks_mws_private_access_settings](mws_private_access_settings.md) in Databricks Account
+
+The following arguments could be modified after the workspace is running:
+
+* `network_id` - (Optional) `network_id` from [networks](mws_networks.md). Modifying [networks on running workspaces](mws_networks.md#modifying-networks-on-running-workspaces) would require three separate `terraform apply` steps.
+* `credentials_id` - `credentials_id` from [credentials](mws_credentials.md)
+* `storage_customer_managed_key_id` - (Optional) `customer_managed_key_id` from [customer managed keys](mws_customer_managed_keys.md) with `use_cases` set to `STORAGE`. This is used to encrypt the DBFS Storage & Cluster EBS Volumes.
+
 
 ## Attribute Reference
 

--- a/docs/resources/mws_workspaces.md
+++ b/docs/resources/mws_workspaces.md
@@ -174,7 +174,7 @@ In order to create a [Databricks Workspace that leverages AWS PrivateLink](https
 
 ## Argument Reference
 
--> **Note** All workspaces would be verified to get into runnable state or cleaned up upon failure.
+-> **Note** All workspaces would be verified to get into runnable state or deleted upon failure. You can only update `credentials_id`, `network_id`, and `storage_customer_managed_key_id` on a running workspace.
 
 The following arguments are available:
 
@@ -183,7 +183,7 @@ The following arguments are available:
 * `credentials_id` - `credentials_id` from [credentials](mws_credentials.md)
 * `customer_managed_key_id` - (Optional, **Deprecated**, see `managed_services_customer_managed_key_id` and `storage_customer_managed_key_id`) `customer_managed_key_id` from [customer managed keys](mws_customer_managed_keys.md)
 * `managed_services_customer_managed_key_id` - (Optional) `customer_managed_key_id` from [customer managed keys](mws_customer_managed_keys.md) with `use_cases` set to `MANAGED_SERVICES`. This is used to encrypt the workspace's notebook and secret data in the control plane.
-* `storage_customer_managed_key_id` - (Optional, **Deprecated**) `customer_managed_key_id` from [customer managed keys](mws_customer_managed_keys.md) with `use_cases` set to `STORAGE`. This is used to encrypt the DBFS Storage & Cluster EBS Volumes.
+* `storage_customer_managed_key_id` - (Optional) `customer_managed_key_id` from [customer managed keys](mws_customer_managed_keys.md) with `use_cases` set to `STORAGE`. This is used to encrypt the DBFS Storage & Cluster EBS Volumes.
 * `deployment_name` - (Optional) part of URL: `https://<deployment-name>.cloud.databricks.com`
 * `workspace_name` - name of the workspace, will appear on UI
 * `aws_region` - AWS region of VPC

--- a/identity/resource_group.go
+++ b/identity/resource_group.go
@@ -12,7 +12,6 @@ func ResourceGroup() *schema.Resource {
 	groupSchema := map[string]*schema.Schema{
 		"display_name": {
 			Type:     schema.TypeString,
-			ForceNew: true,
 			Required: true,
 		},
 		"url": {

--- a/identity/resource_user_test.go
+++ b/identity/resource_user_test.go
@@ -245,6 +245,10 @@ func TestResourceUserUpdate(t *testing.T) {
 		Resource: ResourceUser(),
 		Update:   true,
 		ID:       "abc",
+		InstanceState: map[string]string{
+			"user_name":    "me@example.com",
+			"display_name": "Old Name",
+		},
 		HCL: `
 		user_name    = "me@example.com"
 		display_name = "Changed Name"

--- a/mws/mws.go
+++ b/mws/mws.go
@@ -83,7 +83,7 @@ type Workspace struct {
 	CustomerManagedKeyID                string `json:"customer_managed_key_id,omitempty"` // just for compatibility, will be removed
 	StorageConfigurationID              string `json:"storage_configuration_id"`
 	ManagedServicesCustomerManagedKeyID string `json:"managed_services_customer_managed_key_id,omitempty"`
-	StoragexCustomerManagedKeyID        string `json:"storage_customer_managed_key_id,omitempty"`
+	StorageCustomerManagedKeyID         string `json:"storage_customer_managed_key_id,omitempty"`
 	PricingTier                         string `json:"pricing_tier,omitempty" tf:"computed"`
 	PrivateAccessSettingsID             string `json:"private_access_settings_id,omitempty"`
 	NetworkID                           string `json:"network_id,omitempty"`

--- a/mws/resource_workspace_test.go
+++ b/mws/resource_workspace_test.go
@@ -420,6 +420,19 @@ func TestResourceWorkspaceUpdate(t *testing.T) {
 			},
 		},
 		Resource: ResourceWorkspace(),
+		InstanceState: map[string]string{
+			"account_id":     "abc",
+			"aws_region":     "us-east-1",
+			"credentials_id": "__OLDER__",
+			"managed_services_customer_managed_key_id": "def",
+			"storage_customer_managed_key_id":          "__OLDER__",
+			"deployment_name":                          "900150983cd24fb0",
+			"workspace_name":                           "labdata",
+			"is_no_public_ip_enabled":                  "true",
+			"network_id":                               "fgh",
+			"storage_configuration_id":                 "ghi",
+			"workspace_id":                             "1234",
+		},
 		State: map[string]interface{}{
 			"account_id":     "abc",
 			"aws_region":     "us-east-1",
@@ -472,7 +485,7 @@ func TestResourceWorkspaceUpdate_NotAllowed(t *testing.T) {
 		},
 		Update: true,
 		ID:     "abc/1234",
-	}.ExpectError(t, "it is not allowed to change account_id on a running workspace")
+	}.ExpectError(t, "changes require new: account_id")
 }
 
 func TestResourceWorkspaceUpdateLegacyConfig(t *testing.T) {
@@ -506,6 +519,18 @@ func TestResourceWorkspaceUpdateLegacyConfig(t *testing.T) {
 			},
 		},
 		Resource: ResourceWorkspace(),
+		InstanceState: map[string]string{
+			"account_id":               "abc",
+			"aws_region":               "us-east-1",
+			"credentials_id":           "bcd",
+			"customer_managed_key_id":  "def",
+			"deployment_name":          "900150983cd24fb0",
+			"is_no_public_ip_enabled":  "true",
+			"workspace_name":           "labdata",
+			"network_id":               "fgh",
+			"storage_configuration_id": "ghi",
+			"workspace_id":             "1234",
+		},
 		State: map[string]interface{}{
 			"account_id":               "abc",
 			"aws_region":               "us-east-1",
@@ -525,7 +550,7 @@ func TestResourceWorkspaceUpdateLegacyConfig(t *testing.T) {
 }
 
 func TestResourceWorkspaceUpdate_Error(t *testing.T) {
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "PATCH",
@@ -550,11 +575,10 @@ func TestResourceWorkspaceUpdate_Error(t *testing.T) {
 			"storage_configuration_id":                 "ghi",
 			"workspace_id":                             1234,
 		},
-		Update: true,
-		ID:     "abc/1234",
-	}.Apply(t)
-	qa.AssertErrorStartsWith(t, err, "Internal error happened")
-	assert.Equal(t, "abc/1234", d.Id())
+		Update:      true,
+		RequiresNew: true,
+		ID:          "abc/1234",
+	}.ExpectError(t, "Internal error happened")
 }
 
 func TestResourceWorkspaceDelete(t *testing.T) {

--- a/qa/testing_test.go
+++ b/qa/testing_test.go
@@ -202,7 +202,7 @@ func TestResourceFixture_ApplyDelete(t *testing.T) {
 }
 
 func TestResourceFixture_InstanceState(t *testing.T) {
-	_, err := ResourceFixture{
+	ResourceFixture{
 		Resource: noopContextResource,
 		ID:       "x",
 		Update:   true,
@@ -214,8 +214,7 @@ func TestResourceFixture_InstanceState(t *testing.T) {
 			"dummy":   "true",
 			"trigger": "x",
 		},
-	}.Apply(t)
-	AssertErrorStartsWith(t, err, "changes from backend require new")
+	}.ExpectError(t, "changes require new: trigger")
 }
 
 func TestResourceFixture_Apply_Fail(t *testing.T) {

--- a/workspace/resource_directory_test.go
+++ b/workspace/resource_directory_test.go
@@ -220,10 +220,13 @@ func TestResourceDirectoryUpdate(t *testing.T) {
 			},
 		},
 		Resource: ResourceDirectory(),
-		State: map[string]interface{}{
-			"object_id":        object_id,
+		InstanceState: map[string]string{
 			"path":             path,
-			"delete_recursive": true,
+			"delete_recursive": "true",
+		},
+		State: map[string]interface{}{
+			"object_id": object_id,
+			"path":      path,
 		},
 		ID:     path,
 		Update: true,

--- a/workspace/resource_notebook_test.go
+++ b/workspace/resource_notebook_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/databrickslabs/terraform-provider-databricks/qa"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestResourceNotebookRead(t *testing.T) {
@@ -236,7 +235,7 @@ func TestResourceNotebookDelete_Error(t *testing.T) {
 }
 
 func TestResourceNotebookUpdate(t *testing.T) {
-	_, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "POST",
@@ -266,8 +265,8 @@ func TestResourceNotebookUpdate(t *testing.T) {
 			"language":       "R",
 			"path":           "/path.py",
 		},
-		ID:     "abc",
-		Update: true,
-	}.Apply(t)
-	require.NoError(t, err)
+		ID:          "abc",
+		RequiresNew: true,
+		Update:      true,
+	}.ApplyNoError(t)
 }


### PR DESCRIPTION
* Each time there's a workspace change diff, it's checked only for the allowed fields to be updated
* `PATCH /accounts/.../workspaces/..` only contains allowed fields

This PR fixes #649 