### PR TITLE
Skip common error clarity for alternative accounts console deployments

### DIFF
--- a/common/client.go
+++ b/common/client.go
@@ -38,6 +38,7 @@ type DatabricksClient struct {
 	AccountID          string
 	AzureAuth          AzureAuth
 	InsecureSkipVerify bool
+	DevelopmentMode    bool
 	HTTPTimeoutSeconds int
 	DebugTruncateBytes int
 	DebugHeaders       bool

--- a/common/http.go
+++ b/common/http.go
@@ -129,6 +129,9 @@ func (c *DatabricksClient) parseUnknownError(
 }
 
 func (c *DatabricksClient) commonErrorClarity(resp *http.Response) *APIError {
+	if c.DevelopmentMode {
+		return nil
+	}
 	isAccountsAPI := strings.HasPrefix(resp.Request.URL.Path, "/api/2.0/accounts")
 	isAccountsClient := strings.Contains(c.Host, accountsHost)
 	isTesting := strings.HasPrefix(resp.Request.URL.Host, "127.0.0.1")

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -229,6 +229,13 @@ func DatabricksProvider() *schema.Provider {
 				Optional:    true,
 				Default:     false,
 			},
+			"development_mode": {
+				Type:        schema.TypeBool,
+				Description: "Turn off certain error checks. Reserved for internal use only.",
+				DefaultFunc: schema.EnvDefaultFunc("DATABRICKS_DEV", false),
+				Optional:    true,
+				Default:     false,
+			},
 			"debug_truncate_bytes": {
 				Optional:    true,
 				Type:        schema.TypeInt,
@@ -339,6 +346,9 @@ func configureDatabricksClient(ctx context.Context, d *schema.ResourceData) (int
 	}
 	if v, ok := d.GetOk("skip_verify"); ok {
 		pc.InsecureSkipVerify = v.(bool)
+	}
+	if v, ok := d.GetOk("development_mode"); ok {
+		pc.DevelopmentMode = v.(bool)
 	}
 	if v, ok := d.GetOk("debug_truncate_bytes"); ok {
 		pc.DebugTruncateBytes = v.(int)


### PR DESCRIPTION
This PR makes it possible to use different URLs for accounts console when `development_mode = true` is added to provider. Reserved for internal use.