### PR TITLE
`databricks_obo_token` resource to manage PAT tokens on behalf of service principals in E2 workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version changelog
 
+## 0.3.7
+
+* Added `databricks_obo_token` resource to create On-Behalf-Of tokens for a Service Principal in Databricks workspaces on AWS. It is very useful, when you want to provision resources within a workspace through narrowly-scoped service principal, that has no access to other workspaces within the same Databricks Account ([#736](https://github.com/databrickslabs/terraform-provider-databricks/pull/736))
+
 ## 0.3.6
 
 * Added support for hybrid pools ([#689](https://github.com/databrickslabs/terraform-provider-databricks/pull/689))

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 | [databricks_notebook](docs/resources/notebook.md)
 | [databricks_notebook](docs/data-sources/notebook.md) data
 | [databricks_notebook_paths](docs/data-sources/notebook_paths.md) data
+| [databricks_obo_token](docs/resources/obo_token.md)
 | [databricks_permissions](docs/resources/permissions.md)
 | [databricks_pipeline](docs/resources/pipeline.md)
 | [databricks_secret](docs/resources/secret.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,7 @@ Storage
 
 Security
 * Organize [databricks_user](resources/user.md) into [databricks_group](resources/group.md) through [databricks_group_member](resources/group_member.md), also reading [metadata](data-sources/group.md)
+* Create [databricks_service_principal](resources/service_principal.md) with [databricks_obo_token](resources/obo_token.md) to enable even more restricted access control.
 * Manage data access with [databricks_instance_profile](resources/instance_profile.md), which can be assigned through [databricks_group_instance_profile](resources/group_instance_profile.md) and [databricks_user_instance_profile](resources/user_instance_profile.md)
 * Control which networks can access workspace with [databricks_ip_access_list](resources/ip_access_list.md)
 * Generically manage [databricks_permissions](resources/permissions.md)

--- a/docs/resources/obo_token.md
+++ b/docs/resources/obo_token.md
@@ -1,0 +1,49 @@
+---
+subcategory: "Security"
+---
+# databricks_obo_token Resource
+
+This resource creates On-Behalf-Of-Token for a Service Principal in AWS workspaces.
+
+## Example Usage
+
+```hcl
+resource "databricks_service_principal" "this" {
+  display_name = "Automation-only SP"
+}
+
+resource "databricks_permissions" "token_usage" {
+  authorization = "tokens"
+  access_control {
+    service_principal_name = databricks_service_principal.this.application_id
+    permission_level = "CAN_USE"
+  }
+}
+
+resource "databricks_obo_token" "this" {
+  depends_on = [databricks_permissions.token_usage]
+  application_id = databricks_service_principal.this.application_id
+  comment = "PAT on behalf of ${databricks_service_principal.this.display_name}"
+  lifetime_seconds = 3600
+}
+
+output "obo" {
+  value = databricks_obo_token.this.token_value
+  sensitive = true
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `application_id` - Application ID of [databricks_service_principal](service_principal.md#application_id) to create PAT token for.
+* `lifetime_seconds` - (Integer) The number of seconds before the token expires. Token resource is re-created when it expires.
+* `comment` - (String) Comment that describes the purpose of the token.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Canonical unique identifier for the token.
+* `token_value` - **Sensitive** value of the newly-created token.

--- a/docs/resources/obo_token.md
+++ b/docs/resources/obo_token.md
@@ -7,7 +7,7 @@ This resource creates On-Behalf-Of tokens for a Service Principal in Databricks 
 
 ## Example Usage
 
-Creating a token for a narrowly-scoped service principal
+Creating a token for a narrowly-scoped service principal, that would be the only one (besides admins) allowed to use PAT token in this given workspace, keeping your automated deployment highly secure. Keep in mind, that given declaration of `databricks_permissions.token_usage` would remove permissions to use PAT tokens from `users` group.
 
 ```hcl
 resource "databricks_service_principal" "this" {

--- a/docs/resources/workspace_conf.md
+++ b/docs/resources/workspace_conf.md
@@ -12,6 +12,8 @@ Manages workspace configuration for expert usage. Currently, more than one insta
 Allows specification of custom configuration properties for expert usage:
 
  * `enableIpAccessLists` - enables the use of [databricks_ip_access_list](ip_access_list.md) resources
+ * `maxTokenLifetimeDays` - (string) Maximum token lifetime of new tokens in days, as an integer. If zero, new tokens are permitted to have no lifetime limit. Negative numbers are unsupported. **WARNING:** This limit only applies to new tokens, so there may be tokens with lifetimes longer than this value, including unlimited lifetime. Such tokens may have been created before the current maximum token lifetime was set. 
+ * `enableTokensConfig` - (boolean) Enable or disable personal access tokens for this workspace.
 
 ```hcl
 resource "databricks_workspace_conf" "this" {

--- a/identity/acceptance/obo_test.go
+++ b/identity/acceptance/obo_test.go
@@ -1,0 +1,34 @@
+package acceptance
+
+import (
+	"github.com/databrickslabs/terraform-provider-databricks/internal/acceptance"
+
+	"testing"
+)
+
+func TestAwsAccOboTokenResource(t *testing.T) {
+	acceptance.Test(t, []acceptance.Step{
+		{
+			Template: `
+			resource "databricks_service_principal" "this" {
+				display_name = "tf-{var.RANDOM}"
+			}
+
+			data "databricks_group" "admins" {
+				display_name = "admins"
+			}
+			
+			resource "databricks_group_member" "this" {
+				group_id = data.databricks_group.admins.id
+				member_id = databricks_service_principal.this.id
+			}
+
+			resource "databricks_obo_token" "this" {
+				depends_on = [databricks_group_member.this]
+				application_id = databricks_service_principal.this.application_id
+				comment = "PAT on behalf of ${databricks_service_principal.this.display_name}"
+				lifetime_seconds = 3600
+			}`,
+		},
+	})
+}

--- a/identity/groups.go
+++ b/identity/groups.go
@@ -49,6 +49,19 @@ func (a GroupsAPI) Filter(filter string) (GroupList, error) {
 	return groups, err
 }
 
+func (a GroupsAPI) ReadByDisplayName(displayName string) (group ScimGroup, err error) {
+	groupList, err := a.Filter(fmt.Sprintf("displayName eq '%s'", displayName))
+	if err != nil {
+		return
+	}
+	if len(groupList.Resources) == 0 {
+		err = fmt.Errorf("cannot find group: %s", displayName)
+		return
+	}
+	group = groupList.Resources[0]
+	return
+}
+
 func (a GroupsAPI) Patch(groupID string, r patchRequest) error {
 	return a.client.Scim(a.context, http.MethodPatch, fmt.Sprintf("/preview/scim/v2/Groups/%v", groupID), r, nil)
 }

--- a/identity/resource_obo_token.go
+++ b/identity/resource_obo_token.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/databrickslabs/terraform-provider-databricks/common"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 type OboToken struct {
@@ -34,4 +35,42 @@ func (a TokenManagementAPI) Delete(tokenID string) error {
 func (a TokenManagementAPI) Read(tokenID string) (ti TokenResponse, err error) {
 	err = a.client.Get(a.context, fmt.Sprintf("/token-management/tokens/%s", tokenID), nil, &ti)
 	return
+}
+
+func ResourceOboToken() *schema.Resource {
+	oboTokenSchema := common.StructToSchema(OboToken{},
+		func(m map[string]*schema.Schema) map[string]*schema.Schema {
+			m["token_value"] = &schema.Schema{
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			}
+			return m
+		})
+	return common.Resource{
+		Schema: oboTokenSchema,
+		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			var request OboToken
+			if err := common.DataToStructPointer(d, oboTokenSchema, &request); err != nil {
+				return err
+			}
+			ot, err := NewTokenManagementAPI(ctx, c).CreateTokenOnBehalfOfServicePrincipal(request)
+			if err != nil {
+				return err
+			}
+			d.SetId(ot.TokenInfo.TokenID)
+			return d.Set("token_value", ot.TokenValue)
+		},
+		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			ot, err := NewTokenManagementAPI(ctx, c).Read(d.Id())
+			if err != nil {
+				return err
+			}
+			// this method is just a shim to check if token does still exist
+			return d.Set("comment", ot.TokenInfo.Comment)
+		},
+		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			return NewTokenManagementAPI(ctx, c).Delete(d.Id())
+		},
+	}.ToResource()
 }

--- a/identity/resource_obo_token.go
+++ b/identity/resource_obo_token.go
@@ -1,0 +1,37 @@
+package identity
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databrickslabs/terraform-provider-databricks/common"
+)
+
+type OboToken struct {
+	ApplicationID   string `json:"application_id"`
+	LifetimeSeconds int32  `json:"lifetime_seconds"`
+	Comment         string `json:"comment"`
+}
+
+func NewTokenManagementAPI(ctx context.Context, m interface{}) TokenManagementAPI {
+	return TokenManagementAPI{m.(*common.DatabricksClient), ctx}
+}
+
+type TokenManagementAPI struct {
+	client  *common.DatabricksClient
+	context context.Context
+}
+
+func (a TokenManagementAPI) CreateTokenOnBehalfOfServicePrincipal(request OboToken) (token TokenResponse, err error) {
+	err = a.client.Post(a.context, "/token-management/on-behalf-of/tokens", request, &token)
+	return
+}
+
+func (a TokenManagementAPI) Delete(tokenID string) error {
+	return a.client.Delete(a.context, fmt.Sprintf("/token-management/tokens/%s", tokenID), map[string]interface{}{})
+}
+
+func (a TokenManagementAPI) Read(tokenID string) (ti TokenResponse, err error) {
+	err = a.client.Get(a.context, fmt.Sprintf("/token-management/tokens/%s", tokenID), nil, &ti)
+	return
+}

--- a/identity/resource_obo_token_test.go
+++ b/identity/resource_obo_token_test.go
@@ -2,6 +2,7 @@ package identity
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/databrickslabs/terraform-provider-databricks/common"
@@ -12,6 +13,9 @@ import (
 )
 
 func TestAwsAccOboFlow(t *testing.T) {
+	if _, ok := os.LookupEnv("CLOUD_ENV"); !ok {
+		t.Skip("Acceptance tests skipped unless env 'CLOUD_ENV' is set")
+	}
 	ctx := context.Background()
 	client := common.CommonEnvironmentClient()
 	tmAPI := NewTokenManagementAPI(ctx, client)

--- a/identity/resource_obo_token_test.go
+++ b/identity/resource_obo_token_test.go
@@ -59,3 +59,121 @@ func TestAwsAccOboFlow(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, r.TokenInfo.TokenID, oboToken.TokenInfo.TokenID)
 }
+
+func TestResourceOboTokenRead(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/token-management/tokens/abc",
+
+				Response: TokenResponse{
+					TokenInfo: &TokenInfo{
+						Comment: "Hello, world!",
+					},
+				},
+			},
+		},
+		Resource: ResourceOboToken(),
+		Read:     true,
+		New:      true,
+		ID:       "abc",
+	}.Apply(t)
+	assert.NoError(t, err, err)
+	assert.Equal(t, "abc", d.Id(), "Id should not be empty")
+	assert.Equal(t, "Hello, world!", d.Get("comment"))
+}
+
+func TestResourceOboTokenRead_Error(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/token-management/tokens/abc",
+				Status:   500,
+				Response: common.APIError{
+					Message: "nope",
+				},
+			},
+		},
+		Resource: ResourceOboToken(),
+		Read:     true,
+		New:      true,
+		ID:       "abc",
+	}.ExpectError(t, "nope")
+}
+
+func TestResourceOboTokenCreate_Error(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/token-management/on-behalf-of/tokens",
+				Status:   500,
+				Response: common.APIError{
+					Message: "nope",
+				},
+			},
+		},
+		Resource: ResourceOboToken(),
+		Create:   true,
+		New:      true,
+	}.ExpectError(t, "nope")
+}
+
+func TestResourceOboTokenCreate(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/token-management/on-behalf-of/tokens",
+				ExpectedRequest: OboToken{
+					ApplicationID:   "abc",
+					LifetimeSeconds: 60,
+					Comment:         "e",
+				},
+				Response: TokenResponse{
+					TokenValue: "s#Cr3t!11",
+					TokenInfo: &TokenInfo{
+						TokenID: "bcd",
+					},
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/token-management/tokens/bcd",
+				Response: TokenResponse{
+					TokenInfo: &TokenInfo{
+						Comment: "Hello, world!",
+					},
+				},
+			},
+		},
+		Resource: ResourceOboToken(),
+		Create:   true,
+		HCL: `
+		application_id = "abc"
+		comment = "e"
+		lifetime_seconds = 60
+		`,
+		New: true,
+	}.Apply(t)
+	assert.NoError(t, err, err)
+	assert.Equal(t, "bcd", d.Id(), "Id should not be empty")
+	assert.Equal(t, "Hello, world!", d.Get("comment"))
+}
+
+func TestResourceOboTokenDelete(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "DELETE",
+				Resource: "/api/2.0/token-management/tokens/abc",
+			},
+		},
+		Resource: ResourceOboToken(),
+		Delete:   true,
+		New:      true,
+		ID:       "abc",
+	}.ApplyNoError(t)
+}

--- a/identity/resource_obo_token_test.go
+++ b/identity/resource_obo_token_test.go
@@ -1,0 +1,57 @@
+package identity
+
+import (
+	"context"
+	"testing"
+
+	"github.com/databrickslabs/terraform-provider-databricks/common"
+	"github.com/databrickslabs/terraform-provider-databricks/qa"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAwsAccOboFlow(t *testing.T) {
+	ctx := context.Background()
+	client := common.CommonEnvironmentClient()
+	tmAPI := NewTokenManagementAPI(ctx, client)
+	spAPI := NewServicePrincipalsAPI(ctx, client)
+	groupsAPI := NewGroupsAPI(ctx, client)
+
+	sp, err := spAPI.Create(ScimUser{
+		DisplayName: qa.RandomName("tf"),
+	})
+	require.NoError(t, err)
+	defer spAPI.Delete(sp.ID)
+
+	admins, err := groupsAPI.ReadByDisplayName("admins")
+	require.NoError(t, err)
+
+	// add new SP to admins, as it's the easiest way to give it permissions to do so,
+	// because importing access package will create circular import dependency
+	err = groupsAPI.Patch(admins.ID, scimPatchRequest("add", "members", sp.ID))
+	require.NoError(t, err)
+
+	oboToken, err := tmAPI.CreateTokenOnBehalfOfServicePrincipal(OboToken{
+		ApplicationID:   sp.ApplicationID,
+		Comment:         qa.RandomLongName(),
+		LifetimeSeconds: 60,
+	})
+	require.NoError(t, err)
+	defer tmAPI.Delete(oboToken.TokenInfo.TokenID)
+
+	spClient := &common.DatabricksClient{
+		Host:  client.Host,
+		Token: oboToken.TokenValue,
+	}
+	err = spClient.Configure()
+	require.NoError(t, err)
+
+	newMe, err := NewUsersAPI(ctx, spClient).Me()
+	require.NoError(t, err)
+	assert.Equal(t, newMe.DisplayName, sp.DisplayName)
+
+	r, err := tmAPI.Read(oboToken.TokenInfo.TokenID)
+	require.NoError(t, err)
+	assert.Equal(t, r.TokenInfo.TokenID, oboToken.TokenInfo.TokenID)
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -56,6 +56,7 @@ func DatabricksProvider() *schema.Provider {
 			"databricks_user_instance_profile":  identity.ResourceUserInstanceProfile(),
 			"databricks_instance_profile":       identity.ResourceInstanceProfile(),
 			"databricks_group_member":           identity.ResourceGroupMember(),
+			"databricks_obo_token":              identity.ResourceOboToken(),
 			"databricks_token":                  identity.ResourceToken(),
 			"databricks_user":                   identity.ResourceUser(),
 			"databricks_service_principal":      identity.ResourceServicePrincipal(),


### PR DESCRIPTION
This resource creates On-Behalf-Of tokens for a Service Principal in Databricks workspaces on AWS. It is very useful, when you want to provision resources within a workspace through narrowly-scoped service principal, that has no access to other workspaces within the same Databricks Account.

## Example Usage

Creating a token for a narrowly-scoped service principal

```hcl
resource "databricks_service_principal" "this" {
  display_name = "Automation-only SP"
}

resource "databricks_permissions" "token_usage" {
  authorization = "tokens"
  access_control {
    service_principal_name = databricks_service_principal.this.application_id
    permission_level = "CAN_USE"
  }
}

resource "databricks_obo_token" "this" {
  depends_on = [databricks_permissions.token_usage]
  application_id = databricks_service_principal.this.application_id
  comment = "PAT on behalf of ${databricks_service_principal.this.display_name}"
  lifetime_seconds = 3600
}

output "obo" {
  value = databricks_obo_token.this.token_value
  sensitive = true
}
```

Creating a token for a service principal with admin privileges

```hcl
resource "databricks_service_principal" "this" {
  display_name = "Terraform"
}

data "databricks_group" "admins" {
  display_name = "admins"
}

resource "databricks_group_member" "this" {
  group_id = data.databricks_group.admins.id
  member_id = databricks_service_principal.this.id
}

resource "databricks_obo_token" "this" {
  depends_on = [databricks_group_member.this]
  application_id = databricks_service_principal.this.application_id
  comment = "PAT on behalf of ${databricks_service_principal.this.display_name}"
  lifetime_seconds = 3600
}
```

## Argument Reference

The following arguments are required:

* `application_id` - Application ID of [databricks_service_principal](service_principal.md#application_id) to create PAT token for.
* `lifetime_seconds` - (Integer) The number of seconds before the token expires. Token resource is re-created when it expires.
* `comment` - (String) Comment that describes the purpose of the token.

## Attribute Reference

In addition to all arguments above, the following attributes are exported:

* `id` - Canonical unique identifier for the token.
* `token_value` - **Sensitive** value of the newly-created token.