### PR TITLE
Implementation of the generic resource for mounts, cloud independent

### DIFF
--- a/common/azure_auth.go
+++ b/common/azure_auth.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 // List of management information
@@ -37,6 +38,54 @@ type tokenInfo struct {
 	CreationTime int64  `json:"creation_time,omitempty"`
 	ExpiryTime   int64  `json:"expiry_time,omitempty"`
 	Comment      string `json:"comment,omitempty"`
+}
+
+//
+func (aa *DatabricksClient) GetAzureJwtProperty(key string) (interface{}, error) {
+	if !aa.IsAzure() {
+		return "", fmt.Errorf("can't get Azure JWT token in non-Azure environment")
+	}
+	if key == "tid" && aa.AzureTenantID != "" {
+		return aa.AzureTenantID, nil
+	}
+	err := aa.Authenticate(context.TODO())
+	if err != nil {
+		return nil, err
+	}
+
+	request, err := http.NewRequest("GET", aa.Host, nil)
+	if err != nil {
+		return nil, err
+	}
+	if err = aa.authVisitor(request); err != nil {
+		return nil, err
+	}
+
+	header := request.Header.Get("Authorization")
+	var stoken string
+	if len(header) > 0 && strings.HasPrefix(string(header), "Bearer ") {
+		log.Printf("Got Bearer token")
+		stoken = strings.TrimSpace(strings.TrimPrefix(string(header), "Bearer "))
+		if strings.HasPrefix(stoken, "dapi") {
+			return nil, fmt.Errorf("can't use Databricks PAT")
+		}
+	}
+
+	if stoken != "" {
+		parser := jwt.Parser{SkipClaimsValidation: true}
+		token, _, err := parser.ParseUnverified(stoken, jwt.MapClaims{})
+		if err != nil {
+			return nil, err
+		}
+		claims := token.Claims.(jwt.MapClaims)
+		for k, v := range claims {
+			if k == key {
+				return v, nil
+			}
+		}
+		return nil, fmt.Errorf("can't find field '%s' in parsed JWT", key)
+	}
+	return nil, fmt.Errorf("can't obtain Azure JWT token")
 }
 
 func (aa *DatabricksClient) getAzureEnvironment() (azure.Environment, error) {

--- a/common/testdata/az-bad-token1/az
+++ b/common/testdata/az-bad-token1/az
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [ "yes" == "$FAIL" ]; then 
+    >&2 /bin/echo "This is just a failing script."
+    exit 1
+fi
+
+if [ "corrupt" == "$FAIL" ]; then 
+    /bin/echo "{accessToken: ..corrupt"
+    exit
+fi
+
+# Macos
+EXP="$(/bin/date -v+${EXPIRE:=10S} +'%F %T' 2>/dev/null)"
+if [ "" = "${EXP}" ]; then
+  # Linux
+  EXPIRE=$(/bin/echo $EXPIRE | /bin/sed 's/S/seconds/')
+  EXPIRE=$(/bin/echo $EXPIRE | /bin/sed 's/M/minutes/')
+  EXP=$(/bin/date --date=+${EXPIRE:=10seconds} +'%FT%TZ')
+fi
+
+/bin/echo "{
+  \"accessToken\": \"dapi123\",
+  \"expiresOn\": \"${EXP}\",
+  \"subscription\": \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\",
+  \"tenant\": \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\",
+  \"tokenType\": \"Bearer\"
+}"

--- a/common/testdata/az-bad-token2/az
+++ b/common/testdata/az-bad-token2/az
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [ "yes" == "$FAIL" ]; then 
+    >&2 /bin/echo "This is just a failing script."
+    exit 1
+fi
+
+if [ "corrupt" == "$FAIL" ]; then 
+    /bin/echo "{accessToken: ..corrupt"
+    exit
+fi
+
+# Macos
+EXP="$(/bin/date -v+${EXPIRE:=10S} +'%F %T' 2>/dev/null)"
+if [ "" = "${EXP}" ]; then
+  # Linux
+  EXPIRE=$(/bin/echo $EXPIRE | /bin/sed 's/S/seconds/')
+  EXPIRE=$(/bin/echo $EXPIRE | /bin/sed 's/M/minutes/')
+  EXP=$(/bin/date --date=+${EXPIRE:=10seconds} +'%FT%TZ')
+fi
+
+/bin/echo "{
+  \"accessToken\": \"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MzU3OTMwOTksImV4cCI6MTY2NzMyOTA5OSwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSJ9.bWKxWSNburEQPGx71pxO1xTa8cuGue5PeXn407voUMI\",
+  \"expiresOn\": \"${EXP}\",
+  \"subscription\": \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\",
+  \"tenant\": \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\",
+  \"tokenType\": \"Bearer\"
+}"

--- a/common/testdata/az-bad-token3/az
+++ b/common/testdata/az-bad-token3/az
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [ "yes" == "$FAIL" ]; then 
+    >&2 /bin/echo "This is just a failing script."
+    exit 1
+fi
+
+if [ "corrupt" == "$FAIL" ]; then 
+    /bin/echo "{accessToken: ..corrupt"
+    exit
+fi
+
+# Macos
+EXP="$(/bin/date -v+${EXPIRE:=10S} +'%F %T' 2>/dev/null)"
+if [ "" = "${EXP}" ]; then
+  # Linux
+  EXPIRE=$(/bin/echo $EXPIRE | /bin/sed 's/S/seconds/')
+  EXPIRE=$(/bin/echo $EXPIRE | /bin/sed 's/M/minutes/')
+  EXP=$(/bin/date --date=+${EXPIRE:=10seconds} +'%FT%TZ')
+fi
+
+/bin/echo "{
+  \"accessToken\": \"   \",
+  \"expiresOn\": \"${EXP}\",
+  \"subscription\": \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\",
+  \"tenant\": \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\",
+  \"tokenType\": \"Bearer\"
+}"

--- a/common/testdata/az-good-token/az
+++ b/common/testdata/az-good-token/az
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [ "yes" == "$FAIL" ]; then 
+    >&2 /bin/echo "This is just a failing script."
+    exit 1
+fi
+
+if [ "corrupt" == "$FAIL" ]; then 
+    /bin/echo "{accessToken: ..corrupt"
+    exit
+fi
+
+# Macos
+EXP="$(/bin/date -v+${EXPIRE:=10S} +'%F %T' 2>/dev/null)"
+if [ "" = "${EXP}" ]; then
+  # Linux
+  EXPIRE=$(/bin/echo $EXPIRE | /bin/sed 's/S/seconds/')
+  EXPIRE=$(/bin/echo $EXPIRE | /bin/sed 's/M/minutes/')
+  EXP=$(/bin/date --date=+${EXPIRE:=10seconds} +'%FT%TZ')
+fi
+
+/bin/echo "{
+  \"accessToken\": \"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MzU2OTU4MzksImV4cCI6MTY2NzIzMTgzOSwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsInRpZCI6ImFiYyJ9._G1DrR4DspidISpsra8UnecV_FV4zMlJDtSNzaS0UxI\",
+  \"expiresOn\": \"${EXP}\",
+  \"subscription\": \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\",
+  \"tenant\": \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\",
+  \"tokenType\": \"Bearer\"
+}"

--- a/docs/resources/aws_s3_mount.md
+++ b/docs/resources/aws_s3_mount.md
@@ -3,7 +3,7 @@ subcategory: "AWS"
 ---
 # databricks_aws_s3_mount Resource
 
--> **Warning** This resource is deprecated by [databricks_mount resource](mount.md) and will be removed in v0.4.0!
+-> **Warning** This resource is deprecated by [databricks_mount resource](mount.md) and will be removed in the future versions!
 
 -> **Note** This resource has an evolving API, which may change in future versions of the provider.
 

--- a/docs/resources/aws_s3_mount.md
+++ b/docs/resources/aws_s3_mount.md
@@ -3,7 +3,7 @@ subcategory: "AWS"
 ---
 # databricks_aws_s3_mount Resource
 
--> **Warning** This resource is deprecated by [databricks_mount resource](mount.md) and will be removed in the future versions!
+-> **Warning** This resource is deprecated by [databricks_mount](mount.md) and will be removed in the future versions!
 
 -> **Note** This resource has an evolving API, which may change in future versions of the provider.
 

--- a/docs/resources/aws_s3_mount.md
+++ b/docs/resources/aws_s3_mount.md
@@ -3,6 +3,8 @@ subcategory: "AWS"
 ---
 # databricks_aws_s3_mount Resource
 
+-> **Warning** This resource is deprecated by [databricks_mount resource](mount.md) and will be removed in v0.4.0!
+
 -> **Note** This resource has an evolving API, which may change in future versions of the provider.
 
 This resource will mount your S3 bucket on `dbfs:/mnt/yourname`. It is important to understand that this will start up the [cluster](cluster.md) if the cluster is terminated. The read and refresh terraform command will require a cluster and may take some time to validate the mount. If cluster_id is not specified, it will create the smallest possible cluster called `terraform-mount` for the shortest possible amount of time.

--- a/docs/resources/azure_adls_gen1_mount.md
+++ b/docs/resources/azure_adls_gen1_mount.md
@@ -3,7 +3,7 @@ subcategory: "Azure"
 ---
 # databricks_azure_adls_gen1_mount Resource
 
--> **Warning** This resource is deprecated by [databricks_mount resource](mount.md) and will be removed in the future versions!
+-> **Warning** This resource is deprecated by [databricks_mount](mount.md) and will be removed in the future versions!
 
 -> **Note** This resource has an evolving API, which may change in future versions of the provider.
 

--- a/docs/resources/azure_adls_gen1_mount.md
+++ b/docs/resources/azure_adls_gen1_mount.md
@@ -3,7 +3,7 @@ subcategory: "Azure"
 ---
 # databricks_azure_adls_gen1_mount Resource
 
--> **Warning** This resource is deprecated by [databricks_mount resource](mount.md) and will be removed in v0.4.0!
+-> **Warning** This resource is deprecated by [databricks_mount resource](mount.md) and will be removed in the future versions!
 
 -> **Note** This resource has an evolving API, which may change in future versions of the provider.
 

--- a/docs/resources/azure_adls_gen1_mount.md
+++ b/docs/resources/azure_adls_gen1_mount.md
@@ -3,6 +3,8 @@ subcategory: "Azure"
 ---
 # databricks_azure_adls_gen1_mount Resource
 
+-> **Warning** This resource is deprecated by [databricks_mount resource](mount.md) and will be removed in v0.4.0!
+
 -> **Note** This resource has an evolving API, which may change in future versions of the provider.
 
 This resource will mount your ADLS v1 bucket on `dbfs:/mnt/yourname`. It is important to understand that this will start up the [cluster](cluster.md) if the cluster is terminated. The read and refresh terraform command will require a cluster and may take some time to validate the mount. If cluster_id is not specified, it will create the smallest possible cluster called `terraform-mount` for the shortest possible amount of time.

--- a/docs/resources/azure_adls_gen2_mount.md
+++ b/docs/resources/azure_adls_gen2_mount.md
@@ -3,7 +3,7 @@ subcategory: "Azure"
 ---
 # databricks_azure_adls_gen2_mount Resource
 
--> **Warning** This resource is deprecated by [databricks_mount resource](mount.md) and will be removed in the future versions!
+-> **Warning** This resource is deprecated by [databricks_mount](mount.md) and will be removed in the future versions!
 
 -> **Note** This resource has an evolving API, which may change in future versions of the provider.
 

--- a/docs/resources/azure_adls_gen2_mount.md
+++ b/docs/resources/azure_adls_gen2_mount.md
@@ -3,6 +3,8 @@ subcategory: "Azure"
 ---
 # databricks_azure_adls_gen2_mount Resource
 
+-> **Warning** This resource is deprecated by [databricks_mount resource](mount.md) and will be removed in v0.4.0!
+
 -> **Note** This resource has an evolving API, which may change in future versions of the provider.
 
 This resource will mount your ADLS v2 bucket on `dbfs:/mnt/yourname`. It is important to understand that this will start up the [cluster](cluster.md) if the cluster is terminated. The read and refresh terraform command will require a cluster and may take some time to validate the mount. If cluster_id is not specified, it will create the smallest possible cluster called `terraform-mount` for the shortest possible amount of time.

--- a/docs/resources/azure_adls_gen2_mount.md
+++ b/docs/resources/azure_adls_gen2_mount.md
@@ -3,7 +3,7 @@ subcategory: "Azure"
 ---
 # databricks_azure_adls_gen2_mount Resource
 
--> **Warning** This resource is deprecated by [databricks_mount resource](mount.md) and will be removed in v0.4.0!
+-> **Warning** This resource is deprecated by [databricks_mount resource](mount.md) and will be removed in the future versions!
 
 -> **Note** This resource has an evolving API, which may change in future versions of the provider.
 

--- a/docs/resources/azure_blob_mount.md
+++ b/docs/resources/azure_blob_mount.md
@@ -3,7 +3,7 @@ subcategory: "Azure"
 ---
 # databricks_azure_blob_mount Resource
 
--> **Warning** This resource is deprecated by [databricks_mount resource](mount.md) and will be removed in v0.4.0!
+-> **Warning** This resource is deprecated by [databricks_mount resource](mount.md) and will be removed in the future versions!
 
 -> **Note** This resource has an evolving API, which may change in future versions of the provider.
 
@@ -53,7 +53,7 @@ resource "databricks_azure_blob_mount" "marketing" {
 
 The following arguments are required:
 
-* `auth_type` - (Required) (String) This is the auth type for blob storage. This can either be SAS tokens or account access keys.
+* `auth_type` - (Required) (String) This is the auth type for blob storage. This can either be SAS tokens (`SAS`) or account access keys (`ACCESS_KEY`).
 * `token_secret_scope` - (Required) (String) This is the secret scope in which your auth type token is stored.
 * `token_secret_key` - (Required) (String) This is the secret key in which your auth type token is stored.
 * `container_name` - (Required) (String) The container in which the data is. This is what you are trying to mount.

--- a/docs/resources/azure_blob_mount.md
+++ b/docs/resources/azure_blob_mount.md
@@ -3,7 +3,7 @@ subcategory: "Azure"
 ---
 # databricks_azure_blob_mount Resource
 
--> **Warning** This resource is deprecated by [databricks_mount resource](mount.md) and will be removed in the future versions!
+-> **Warning** This resource is deprecated by [databricks_mount](mount.md) and will be removed in the future versions!
 
 -> **Note** This resource has an evolving API, which may change in future versions of the provider.
 

--- a/docs/resources/azure_blob_mount.md
+++ b/docs/resources/azure_blob_mount.md
@@ -3,6 +3,8 @@ subcategory: "Azure"
 ---
 # databricks_azure_blob_mount Resource
 
+-> **Warning** This resource is deprecated by [databricks_mount resource](mount.md) and will be removed in v0.4.0!
+
 -> **Note** This resource has an evolving API, which may change in future versions of the provider.
 
 This resource will mount your Azure Blob Storage bucket on `dbfs:/mnt/yourname`. It is important to understand that this will start up the [cluster](cluster.md) if the cluster is terminated. The read and refresh terraform command will require a cluster and may take some time to validate the mount. If cluster_id is not specified, it will create the smallest possible cluster called `terraform-mount` for the shortest possible amount of time. This resource will help you create, get and delete an azure blob storage mount using SAS token or storage account access keys.

--- a/docs/resources/mount.md
+++ b/docs/resources/mount.md
@@ -1,0 +1,84 @@
+
+
+
+
+
+# Examples
+
+## Creating mount to ADLS Gen2 with AAD passthrough
+
+(See [documentation](https://docs.microsoft.com/en-us/azure/databricks/security/credential-passthrough/adls-passthrough#--mount-azure-data-lake-storage-to-dbfs-using-credential-passthrough) for more details).
+
+```hcl
+provider "azurerm" {
+  features {}
+}
+
+variable "resource_group" {
+  type = string
+  description = "Resource group for Databricks Workspace"
+}
+
+variable "workspace_name" {
+  type = string
+  description = "Name of the Databricks Workspace"
+}
+
+data "azurerm_databricks_workspace" "this" {
+  name                = var.workspace_name
+  resource_group_name = var.resource_group
+}
+
+# it works only with AAD token!
+provider "databricks" {
+  azure_workspace_resource_id = data.azurerm_databricks_workspace.this.id
+}
+
+
+data "databricks_node_type" "smallest" {
+  local_disk = true
+}
+
+data "databricks_spark_version" "latest" {
+}
+
+resource "databricks_cluster" "shared_passthrough" {
+  cluster_name            = "Shared Passthrough for mount"
+  spark_version           = data.databricks_spark_version.latest.id
+  node_type_id            = data.databricks_node_type.smallest.id
+  autotermination_minutes = 10
+  num_workers = 1
+  
+  spark_conf = {
+    "spark.databricks.cluster.profile":"serverless",
+    "spark.databricks.repl.allowedLanguages":"python,sql",
+    "spark.databricks.passthrough.enabled": "true",
+    "spark.databricks.pyspark.enableProcessIsolation": "true"
+  }
+  
+  custom_tags = {
+    "ResourceClass": "Serverless"
+  }
+}
+
+variable "storage_acc" {
+  type = string
+  description = "Name of the ADLS Gen2 storage container"
+}
+
+variable "container" {
+  type = string
+  description = "Name of container inside storage account"
+}
+
+resource "databricks_mount" "passthrough" {
+  mount_name = "passthrough-test"
+  cluster_id = databricks_cluster.shared_passthrough.id
+  
+  source = "abfss://${var.container}@${var.storage_acc}.dfs.core.windows.net"
+  extra_configs = {
+    "fs.azure.account.auth.type": "CustomAccessToken",
+    "fs.azure.account.custom.token.provider.class": "{{sparkconf/spark.databricks.passthrough.adls.gen2.tokenProviderClassName}}",
+  }
+}
+```

--- a/docs/resources/mount.md
+++ b/docs/resources/mount.md
@@ -1,13 +1,229 @@
+---
+subcategory: "Storage"
+---
+# databricks_mount Resource
+
+-> **Note** This resource has an evolving API, which may change in future versions of the provider.
+
+This resource will mount your cloud storage account on `dbfs:/mnt/yourname`. Right now it supports mounting AWS S3, Azure (Blob Storage, ADLS Gen1 & Gen2), Google Cloud Storage.  It is important to understand that this will start up the [cluster](cluster.md) if the cluster is terminated. The read and refresh terraform command will require a cluster and may take some time to validate the mount. If `cluster_id` is not specified, it will create the smallest possible cluster with name equal or starting with `terraform-mount` for the shortest possible amount of time.
+
+This resource provides two ways of mounting a storage account:
+1. Use a storage-specific configuration block - this could be used for the most cases, as it will fill most of necessary details. Currently we support following configuration blocks:
+  * `s3` - to mount AWS S3
+  * `gcs` - to mount Google Cloud Storage
+  * `abfss` - to mount ADLS Gen2
+  * `adl` - to  mount ADLS Gen1
+  * `wasbs`  - to mount Azure Blob Storage
+1. Use generic arguments - you have a responsibility for providing all necessary parameters that are required to mount specific storage. This is most flexible option
 
 
+## Common arguments
+
+* `cluster_id` - (Optional) (String) Cluster to use for mounting. If no cluster is specified, a new cluster will be created and will mount the bucket for all of the clusters in this workspace. If the cluster is not running - it's going to be started, so be aware to set auto-termination rules on it.
+* `mount_name` - (Required) (String) Name, under which mount will be accessible in `dbfs:/mnt/<MOUNT_NAME>`.
+
+## Generic mounting arguments
+
+* `uri` - (Optional, String) the URI for accessing specific storage (`s3a://....`, `abfss://....`, `gs://....`, etc.)
+* `extra_configs` - (Optional, String map) configuration parameters that are necessary for mounting of specific storage 
+
+## s3 block
+
+This block allows to specify parameters for mounting of the ADLS Gen2. The following arguments are required inside the `s3` block:
+
+* `instance_profile` - (Optional) (String) ARN of registered [instance profile](instance_profile.md) for data access.  If it's not specified, then the `cluster_id` should be provided, and cluster should have instance profile attached to it. 
+* `bucket_name` - (Required) (String) S3 bucket name to be mounted.
 
 
+## abfss block
 
-# Examples
+This block allows to specify parameters for mounting of the ADLS Gen2. The following arguments are required inside the `abfss` block:
 
-## Creating mount to ADLS Gen2 with AAD passthrough
+* `client_id` - (Required) (String) This is the client_id (Application Object ID) for the enterprise application for the service principal. 
+* `tenant_id` - (Required) (String) This is your azure directory tenant id. This is required for creating the mount.
+* `client_secret_key` - (Required) (String) This is the secret key in which your service principal/enterprise app client secret will be stored.
+* `client_secret_scope` - (Required) (String) This is the secret scope in which your service principal/enterprise app client secret will be stored.
+* `container_name` - (Required) (String) ADLS gen2 container name
+* `storage_account_name` - (Required) (String) The name of the storage resource in which the data is.
+* `directory` - (Computed) (String) This is optional if you don't want to add an additional directory that you wish to mount. This must start with a "/".
+* `initialize_file_system` - (Required) (Bool) either or not initialize FS for the first use
 
-(See [documentation](https://docs.microsoft.com/en-us/azure/databricks/security/credential-passthrough/adls-passthrough#--mount-azure-data-lake-storage-to-dbfs-using-credential-passthrough) for more details).
+
+## gcs block
+
+This block allows to specify parameters for mounting of the Google Cloud Storage. The following arguments are required inside the `gcs` block:
+
+* `service_account` - (Optional) (String) email of registered [Google Service Account](https://docs.gcp.databricks.com/data/data-sources/google/gcs.html#step-1-set-up-google-cloud-service-account-using-google-cloud-console) for data access.  If it's not specified, then the `cluster_id` should be provided, and cluster should have Google service account attached to it. 
+* `bucket_name` - (Required) (String) GCS bucket name to be mounted.
+
+
+## adl block
+
+This block allows to specify parameters for mounting of the ADLS Gen1. The following arguments are required inside the `adl` block:
+
+* `client_id` - (Required) (String) This is the client_id for the enterprise application for the service principal. 
+* `tenant_id` - (Required) (String) This is your azure directory tenant id. This is required for creating the mount.
+* `client_secret_key` - (Required) (String) This is the secret key in which your service principal/enterprise app client secret will be stored.
+* `client_secret_scope` - (Required) (String) This is the secret scope in which your service principal/enterprise app client secret will be stored.
+
+* `storage_resource_name` - (Required) (String) The name of the storage resource in which the data is for ADLS gen 1. This is what you are trying to mount.
+* `spark_conf_prefix` - (Optional) (String) This is the spark configuration prefix for adls gen 1 mount. The options are `fs.adl`, `dfs.adls`. Use `fs.adl` for runtime 6.0 and above for the clusters. Otherwise use `dfs.adls`. The default value is: `fs.adl`.
+* `directory` - (Computed) (String) This is optional if you don't want to add an additional directory that you wish to mount. This must start with a "/".
+
+## wasbs block
+
+This block allows to specify parameters for mounting of the Azure Blob Storage. The following arguments are required inside the `wasbs` block:
+
+* `auth_type` - (Required) (String) This is the auth type for blob storage. This can either be SAS tokens or account access keys (`ACCESS_KEY`).
+* `token_secret_scope` - (Required) (String) This is the secret scope in which your auth type token is stored.
+* `token_secret_key` - (Required) (String) This is the secret key in which your auth type token is stored.
+* `container_name` - (Required) (String) The container in which the data is. This is what you are trying to mount.
+* `storage_account_name` - (Required) (String) The name of the storage resource in which the data is.
+* `directory` - (Computed) (String) This is optional if you don't want to add an additional directory that you wish to mount. This must start with a "/".
+
+
+## Example Usage
+
+### Creating mount for AWS S3
+
+```hcl
+// now you can do `%fs ls /mnt/experiments` in notebooks
+resource "databricks_aws_s3_mount" "this" {
+    mount_name = "experiments"
+    s3 {
+      instance_profile = databricks_instance_profile.ds.id
+      bucket_name = aws_s3_bucket.this.bucket
+   }
+}
+```
+
+### Creating mount for ADLS Gen2
+
+```hcl
+resource "databricks_secret_scope" "terraform" {
+    name                     = "application"
+    initial_manage_principal = "users"
+}
+
+resource "databricks_secret" "service_principal_key" {
+    key          = "service_principal_key"
+    string_value = "${var.ARM_CLIENT_SECRET}"
+    scope        = databricks_secret_scope.terraform.name
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_storage_account" "this" {
+  name                     = "${var.prefix}datalake"
+  resource_group_name      = var.resource_group_name
+  location                 = var.resource_group_location
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+  account_kind             = "StorageV2"
+  is_hns_enabled           = true
+}
+
+resource "azurerm_role_assignment" "this" {
+  scope                = azurerm_storage_account.this.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = data.azurerm_client_config.current.object_id
+}
+
+resource "azurerm_storage_container" "this" {
+  name                  = "marketing"
+  storage_account_name  = azurerm_storage_account.this.name
+  container_access_type = "private"
+}
+
+resource "databricks_azure_adls_gen2_mount" "marketing" {
+    mount_name             = "marketing"
+    abfss {
+      container_name         = azurerm_storage_container.this.name
+      storage_account_name   = azurerm_storage_account.this.name
+      tenant_id              = data.azurerm_client_config.current.tenant_id
+      client_id              = data.azurerm_client_config.current.client_id
+      client_secret_scope    = databricks_secret_scope.terraform.name
+      client_secret_key      = databricks_secret.service_principal_key.key
+      initialize_file_system = true
+    }
+}
+```
+
+### Creating mount for ADLS Gen1
+
+```hcl
+resource "databricks_azure_adls_gen1_mount" "mount" {
+    mount_name           = "{var.RANDOM}"
+    adl {
+      storage_resource_name = "{env.TEST_STORAGE_ACCOUNT_NAME}"
+      tenant_id              = data.azurerm_client_config.current.tenant_id
+      client_id              = data.azurerm_client_config.current.client_id
+      client_secret_scope    = databricks_secret_scope.terraform.name
+      client_secret_key      = databricks_secret.service_principal_key.key
+      spark_conf_prefix      = "fs.adl"
+    }
+}
+
+```
+
+## Creating mount for Azure Blob Storage
+
+```hcl
+resource "azurerm_storage_account" "blobaccount" {
+  name                     = "${var.prefix}blob"
+  resource_group_name      = var.resource_group_name
+  location                 = var.resource_group_location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  account_kind             = "StorageV2"
+}
+
+resource "azurerm_storage_container" "marketing" {
+  name                  = "marketing"
+  storage_account_name  = azurerm_storage_account.blobaccount.name
+  container_access_type = "private"
+}
+
+resource "databricks_secret_scope" "terraform" {
+    name                     = "application"
+    initial_manage_principal = "users"
+}
+
+resource "databricks_secret" "storage_key" {
+    key          = "blob_storage_key"
+    string_value = azurerm_storage_account.blobaccount.primary_access_key
+    scope        = databricks_secret_scope.terraform.name
+}
+
+resource "databricks_azure_blob_mount" "marketing" {
+    mount_name           = "marketing"
+    wasbs {
+      container_name       = azurerm_storage_container.marketing.name
+      storage_account_name = azurerm_storage_account.blobaccount.name
+      auth_type            = "ACCESS_KEY"
+      token_secret_scope   = databricks_secret_scope.terraform.name
+      token_secret_key     = databricks_secret.storage_key.key
+    }
+}
+```
+
+## Creating mount for Google Cloud Storage
+
+```hcl
+resource "databricks_mount" "this_gcs" {
+  mount_name = "gcs-mount"
+  gcs {
+    service_account = "acc@company.iam.gserviceaccount.com"
+    bucket_name = "mybucket"
+  }
+}
+```
+
+
+### Creating mount for ADLS Gen2 with AAD passthrough
+
+To mount ALDS Gen2 with Azure Active Directory Credentials passthrough we need to execute the mount commands using the cluster configured with AAD Credentials passthrough & provide necessary configuration parameters (see [documentation](https://docs.microsoft.com/en-us/azure/databricks/security/credential-passthrough/adls-passthrough#--mount-azure-data-lake-storage-to-dbfs-using-credential-passthrough) for more details).
 
 ```hcl
 provider "azurerm" {
@@ -81,4 +297,20 @@ resource "databricks_mount" "passthrough" {
     "fs.azure.account.custom.token.provider.class": "{{sparkconf/spark.databricks.passthrough.adls.gen2.tokenProviderClassName}}",
   }
 }
+```
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - mount name
+* `source` - (String) HDFS-compatible url
+
+
+## Import
+
+The resource can be imported using it's mount name
+
+```bash
+$ terraform import databricks_mount.this <mount_name>
 ```

--- a/docs/resources/mount.md
+++ b/docs/resources/mount.md
@@ -75,7 +75,7 @@ resource "databricks_mount" "passthrough" {
   mount_name = "passthrough-test"
   cluster_id = databricks_cluster.shared_passthrough.id
   
-  source = "abfss://${var.container}@${var.storage_acc}.dfs.core.windows.net"
+  uri = "abfss://${var.container}@${var.storage_acc}.dfs.core.windows.net"
   extra_configs = {
     "fs.azure.account.auth.type": "CustomAccessToken",
     "fs.azure.account.custom.token.provider.class": "{{sparkconf/spark.databricks.passthrough.adls.gen2.tokenProviderClassName}}",

--- a/docs/resources/mount.md
+++ b/docs/resources/mount.md
@@ -5,10 +5,10 @@ subcategory: "Storage"
 
 -> **Note** This resource has an evolving API, which may change in future versions of the provider.
 
-This resource will mount your cloud storage account on `dbfs:/mnt/yourname`. Right now it supports mounting AWS S3, Azure (Blob Storage, ADLS Gen1 & Gen2), Google Cloud Storage.  It is important to understand that this will start up the [cluster](cluster.md) if the cluster is terminated. The read and refresh terraform command will require a cluster and may take some time to validate the mount. If `cluster_id` is not specified, it will create the smallest possible cluster with name equal or starting with `terraform-mount` for the shortest possible amount of time.
+This resource will mount your cloud storage account on `dbfs:/mnt/yourname`. Right now it supports mounting AWS S3, Azure (Blob Storage, ADLS Gen1 & Gen2), Google Cloud Storage.  It is important to understand that this will start up the [cluster](cluster.md) if the cluster is terminated. The read and refresh terraform command will require a cluster and may take some time to validate the mount. If `cluster_id` is not specified, it will create the smallest possible cluster with name equal to or starting with `terraform-mount` for the shortest possible amount of time.
 
 This resource provides two ways of mounting a storage account:
-1. Use a storage-specific configuration block - this could be used for the most cases, as it will fill most of necessary details. Currently we support following configuration blocks:
+1. Use a storage-specific configuration block - this could be used for the most cases, as it will fill most of the necessary details. Currently we support following configuration blocks:
   * `s3` - to mount AWS S3
   * `gs` - to mount Google Cloud Storage
   * `abfs` - to mount ADLS Gen2 using [Azure Blob Filesystem (ABFS) driver](https://hadoop.apache.org/docs/current/hadoop-azure/index.html)
@@ -20,207 +20,43 @@ This resource provides two ways of mounting a storage account:
 ## Common arguments
 
 * `cluster_id` - (Optional, String) Cluster to use for mounting. If no cluster is specified, a new cluster will be created and will mount the bucket for all of the clusters in this workspace. If the cluster is not running - it's going to be started, so be aware to set auto-termination rules on it.
-* `name` - (Optional, String) Name, under which mount will be accessible in `dbfs:/mnt/<MOUNT_NAME>`. If not specified, provider will try to infer it from the bucket name, storage account name, etc. 
+* `name` - (Optional, String) Name, under which mount will be accessible in `dbfs:/mnt/<MOUNT_NAME>`. If not specified, provider will try to infer it from depending on the resource type:
+  * bucket name for AWS S3 and Google Cloud Storage
+  * container name for ADLS Gen2 and Azure Blob Storage
+  * storage resource name for ADLS Gen1
 * `uri` - (Optional, String) the URI for accessing specific storage (`s3a://....`, `abfss://....`, `gs://....`, etc.)
 * `extra_configs` - (Optional, String map) configuration parameters that are necessary for mounting of specific storage
 * `resource_id` - (Optional, String) 
 * `encryption_type` - (Optional, String) 
 
-## s3 block
-
-This block allows to specify parameters for mounting of the ADLS Gen2. The following arguments are required inside the `s3` block:
-
-* `instance_profile` - (Optional) (String) ARN of registered [instance profile](instance_profile.md) for data access.  If it's not specified, then the `cluster_id` should be provided, and cluster should have instance profile attached to it. 
-* `bucket_name` - (Required) (String) S3 bucket name to be mounted.
-
-
-## abfs block
-
-This block allows to specify parameters for mounting of the ADLS Gen2. The following arguments are required inside the `abfs` block:
-
-* `client_id` - (Required) (String) This is the client_id (Application Object ID) for the enterprise application for the service principal. 
-* `tenant_id` - (Required) (String) This is your azure directory tenant id. This is required for creating the mount.
-* `client_secret_key` - (Required) (String) This is the secret key in which your service principal/enterprise app client secret will be stored.
-* `client_secret_scope` - (Required) (String) This is the secret scope in which your service principal/enterprise app client secret will be stored.
-* `container_name` - (Required) (String) ADLS gen2 container name
-* `storage_account_name` - (Required) (String) The name of the storage resource in which the data is.
-* `directory` - (Computed) (String) This is optional if you don't want to add an additional directory that you wish to mount. This must start with a "/".
-* `initialize_file_system` - (Required) (Bool) either or not initialize FS for the first use
-
-
-## gs block
-
-This block allows to specify parameters for mounting of the Google Cloud Storage. The following arguments are required inside the `gs` block:
-
-* `service_account` - (Optional) (String) email of registered [Google Service Account](https://docs.gcp.databricks.com/data/data-sources/google/gcs.html#step-1-set-up-google-cloud-service-account-using-google-cloud-console) for data access.  If it's not specified, then the `cluster_id` should be provided, and cluster should have Google service account attached to it. 
-* `bucket_name` - (Required) (String) GCS bucket name to be mounted.
-
-
-## adl block
-
-This block allows to specify parameters for mounting of the ADLS Gen1. The following arguments are required inside the `adl` block:
-
-* `client_id` - (Required) (String) This is the client_id for the enterprise application for the service principal. 
-* `tenant_id` - (Required) (String) This is your azure directory tenant id. This is required for creating the mount.
-* `client_secret_key` - (Required) (String) This is the secret key in which your service principal/enterprise app client secret will be stored.
-* `client_secret_scope` - (Required) (String) This is the secret scope in which your service principal/enterprise app client secret will be stored.
-
-* `storage_resource_name` - (Required) (String) The name of the storage resource in which the data is for ADLS gen 1. This is what you are trying to mount.
-* `spark_conf_prefix` - (Optional) (String) This is the spark configuration prefix for adls gen 1 mount. The options are `fs.adl`, `dfs.adls`. Use `fs.adl` for runtime 6.0 and above for the clusters. Otherwise use `dfs.adls`. The default value is: `fs.adl`.
-* `directory` - (Computed) (String) This is optional if you don't want to add an additional directory that you wish to mount. This must start with a "/".
-
-## wasb block
-
-This block allows to specify parameters for mounting of the Azure Blob Storage. The following arguments are required inside the `wasb` block:
-
-* `auth_type` - (Required) (String) This is the auth type for blob storage. This can either be SAS tokens (`SAS`) or account access keys (`ACCESS_KEY`).
-* `token_secret_scope` - (Required) (String) This is the secret scope in which your auth type token is stored.
-* `token_secret_key` - (Required) (String) This is the secret key in which your auth type token is stored.
-* `container_name` - (Required) (String) The container in which the data is. This is what you are trying to mount.
-* `storage_account_name` - (Required) (String) The name of the storage resource in which the data is.
-* `directory` - (Computed) (String) This is optional if you don't want to add an additional directory that you wish to mount. This must start with a "/".
-
-
-## Example Usage
-
-### Creating mount for AWS S3
+### Example mounting ADLS Gen2 using uri and extra_configs
 
 ```hcl
-// now you can do `%fs ls /mnt/experiments` in notebooks
+locals {
+  tenant_id = "8f35a392-f2ae-4280-9796-f1864a10eeec"
+  client_id = "d1b2a25b-86c4-451a-a0eb-0808be121957"
+  secret_scope = "some-kv"
+  secret_key = "some-sp-secret"
+  container = "test"
+  storage_acc = "lrs"
+}
+
 resource "databricks_mount" "this" {
-    mount_name = "experiments"
-    s3 {
-      instance_profile = databricks_instance_profile.ds.id
-      bucket_name = aws_s3_bucket.this.bucket
-   }
-}
-```
+  name = "tf-abfss"
 
-### Creating mount for ADLS Gen2
-
-```hcl
-resource "databricks_secret_scope" "terraform" {
-    name                     = "application"
-    initial_manage_principal = "users"
-}
-
-resource "databricks_secret" "service_principal_key" {
-    key          = "service_principal_key"
-    string_value = "${var.ARM_CLIENT_SECRET}"
-    scope        = databricks_secret_scope.terraform.name
-}
-
-data "azurerm_client_config" "current" {
-}
-
-resource "azurerm_storage_account" "this" {
-  name                     = "${var.prefix}datalake"
-  resource_group_name      = var.resource_group_name
-  location                 = var.resource_group_location
-  account_tier             = "Standard"
-  account_replication_type = "GRS"
-  account_kind             = "StorageV2"
-  is_hns_enabled           = true
-}
-
-resource "azurerm_role_assignment" "this" {
-  scope                = azurerm_storage_account.this.id
-  role_definition_name = "Storage Blob Data Contributor"
-  principal_id         = data.azurerm_client_config.current.object_id
-}
-
-resource "azurerm_storage_container" "this" {
-  name                  = "marketing"
-  storage_account_name  = azurerm_storage_account.this.name
-  container_access_type = "private"
-}
-
-resource "databricks_mount" "marketing" {
-    mount_name             = "marketing"
-    abfs {
-      container_name         = azurerm_storage_container.this.name
-      storage_account_name   = azurerm_storage_account.this.name
-      tenant_id              = data.azurerm_client_config.current.tenant_id
-      client_id              = data.azurerm_client_config.current.client_id
-      client_secret_scope    = databricks_secret_scope.terraform.name
-      client_secret_key      = databricks_secret.service_principal_key.key
-      initialize_file_system = true
-    }
-}
-```
-
-### Creating mount for ADLS Gen1
-
-```hcl
-resource "databricks_mount" "mount" {
-    mount_name           = "{var.RANDOM}"
-    adl {
-      storage_resource_name = "{env.TEST_STORAGE_ACCOUNT_NAME}"
-      tenant_id              = data.azurerm_client_config.current.tenant_id
-      client_id              = data.azurerm_client_config.current.client_id
-      client_secret_scope    = databricks_secret_scope.terraform.name
-      client_secret_key      = databricks_secret.service_principal_key.key
-      spark_conf_prefix      = "fs.adl"
-    }
-}
-
-```
-
-## Creating mount for Azure Blob Storage
-
-```hcl
-resource "azurerm_storage_account" "blobaccount" {
-  name                     = "${var.prefix}blob"
-  resource_group_name      = var.resource_group_name
-  location                 = var.resource_group_location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-  account_kind             = "StorageV2"
-}
-
-resource "azurerm_storage_container" "marketing" {
-  name                  = "marketing"
-  storage_account_name  = azurerm_storage_account.blobaccount.name
-  container_access_type = "private"
-}
-
-resource "databricks_secret_scope" "terraform" {
-    name                     = "application"
-    initial_manage_principal = "users"
-}
-
-resource "databricks_secret" "storage_key" {
-    key          = "blob_storage_key"
-    string_value = azurerm_storage_account.blobaccount.primary_access_key
-    scope        = databricks_secret_scope.terraform.name
-}
-
-resource "databricks_mount" "marketing" {
-    mount_name           = "marketing"
-    wasb {
-      container_name       = azurerm_storage_container.marketing.name
-      storage_account_name = azurerm_storage_account.blobaccount.name
-      auth_type            = "ACCESS_KEY"
-      token_secret_scope   = databricks_secret_scope.terraform.name
-      token_secret_key     = databricks_secret.storage_key.key
-    }
-}
-```
-
-## Creating mount for Google Cloud Storage
-
-```hcl
-resource "databricks_mount" "this_gs" {
-  mount_name = "gs-mount"
-  gs {
-    service_account = "acc@company.iam.gserviceaccount.com"
-    bucket_name = "mybucket"
+  uri = "abfss://${local.container}@${local.storage_acc}.dfs.core.windows.net"
+  extra_configs = {
+    "fs.azure.account.auth.type":                          "OAuth",
+    "fs.azure.account.oauth.provider.type":                "org.apache.hadoop.fs.azurebfs.oauth2.ClientCredsTokenProvider",
+    "fs.azure.account.oauth2.client.id":                   local.client_id,
+    "fs.azure.account.oauth2.client.secret":               "{{secrets/${local.secret_scope}/${local.secret_key}}}",
+    "fs.azure.account.oauth2.client.endpoint":             "https://login.microsoftonline.com/${local.tenant_id}/oauth2/token",
+    "fs.azure.createRemoteFileSystemDuringInitialization": "false",
   }
 }
 ```
 
-
-### Creating mount for ADLS Gen2 with AAD passthrough
+### Example mounting ADLS Gen2 with AAD passthrough
 
 To mount ALDS Gen2 with Azure Active Directory Credentials passthrough we need to execute the mount commands using the cluster configured with AAD Credentials passthrough & provide necessary configuration parameters (see [documentation](https://docs.microsoft.com/en-us/azure/databricks/security/credential-passthrough/adls-passthrough#--mount-azure-data-lake-storage-to-dbfs-using-credential-passthrough) for more details).
 
@@ -298,13 +134,198 @@ resource "databricks_mount" "passthrough" {
 }
 ```
 
+## s3 block
+
+This block allows specifying parameters for mounting of the ADLS Gen2. The following arguments are required inside the `s3` block:
+
+* `instance_profile` - (Optional) (String) ARN of registered [instance profile](instance_profile.md) for data access.  If it's not specified, then the `cluster_id` should be provided, and the cluster should have an instance profile attached to it. 
+* `bucket_name` - (Required) (String) S3 bucket name to be mounted.
+
+### Example of mounting S3
+
+```hcl
+// now you can do `%fs ls /mnt/experiments` in notebooks
+resource "databricks_mount" "this" {
+    mount_name = "experiments"
+    s3 {
+      instance_profile = databricks_instance_profile.ds.id
+      bucket_name = aws_s3_bucket.this.bucket
+   }
+}
+```
+
+## abfs block
+
+This block allows specifying parameters for mounting of the ADLS Gen2. The following arguments are required inside the `abfs` block:
+
+* `client_id` - (Required) (String) This is the client_id (Application Object ID) for the enterprise application for the service principal. 
+* `tenant_id` - (Required) (String) This is your azure directory tenant id. This is required for creating the mount.
+* `client_secret_key` - (Required) (String) This is the secret key in which your service principal/enterprise app client secret will be stored.
+* `client_secret_scope` - (Required) (String) This is the secret scope in which your service principal/enterprise app client secret will be stored.
+* `container_name` - (Required) (String) ADLS gen2 container name. (Could be omitted if `resource_id` is provided)
+* `storage_account_name` - (Required) (String) The name of the storage resource in which the data is. (Could be omitted if `resource_id` is provided)
+* `directory` - (Computed) (String) This is optional if you don't want to add an additional directory that you wish to mount. This must start with a "/".
+* `initialize_file_system` - (Required) (Bool) either or not initialize FS for the first use
+
+### Creating mount for ADLS Gen2 using abfs block
+
+```hcl
+resource "databricks_secret_scope" "terraform" {
+    name                     = "application"
+    initial_manage_principal = "users"
+}
+
+resource "databricks_secret" "service_principal_key" {
+    key          = "service_principal_key"
+    string_value = "${var.ARM_CLIENT_SECRET}"
+    scope        = databricks_secret_scope.terraform.name
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_storage_account" "this" {
+  name                     = "${var.prefix}datalake"
+  resource_group_name      = var.resource_group_name
+  location                 = var.resource_group_location
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+  account_kind             = "StorageV2"
+  is_hns_enabled           = true
+}
+
+resource "azurerm_role_assignment" "this" {
+  scope                = azurerm_storage_account.this.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = data.azurerm_client_config.current.object_id
+}
+
+resource "azurerm_storage_container" "this" {
+  name                  = "marketing"
+  storage_account_name  = azurerm_storage_account.this.name
+  container_access_type = "private"
+}
+
+resource "databricks_mount" "marketing" {
+    mount_name             = "marketing"
+    abfs {
+      container_name         = azurerm_storage_container.this.name
+      storage_account_name   = azurerm_storage_account.this.name
+      tenant_id              = data.azurerm_client_config.current.tenant_id
+      client_id              = data.azurerm_client_config.current.client_id
+      client_secret_scope    = databricks_secret_scope.terraform.name
+      client_secret_key      = databricks_secret.service_principal_key.key
+      initialize_file_system = true
+    }
+}
+```
+
+## gs block
+
+This block allows specifying parameters for mounting of the Google Cloud Storage. The following arguments are required inside the `gs` block:
+
+* `service_account` - (Optional) (String) email of registered [Google Service Account](https://docs.gcp.databricks.com/data/data-sources/google/gcs.html#step-1-set-up-google-cloud-service-account-using-google-cloud-console) for data access.  If it's not specified, then the `cluster_id` should be provided, and the cluster should have a Google service account attached to it. 
+* `bucket_name` - (Required) (String) GCS bucket name to be mounted.
+
+### Example mounting Google Cloud Storage
+
+```hcl
+resource "databricks_mount" "this_gs" {
+  mount_name = "gs-mount"
+  gs {
+    service_account = "acc@company.iam.gserviceaccount.com"
+    bucket_name = "mybucket"
+  }
+}
+```
+
+## adl block
+
+This block allows specifying parameters for mounting of the ADLS Gen1. The following arguments are required inside the `adl` block:
+
+* `client_id` - (Required) (String) This is the client_id for the enterprise application for the service principal. 
+* `tenant_id` - (Required) (String) This is your azure directory tenant id. This is required for creating the mount.
+* `client_secret_key` - (Required) (String) This is the secret key in which your service principal/enterprise app client secret will be stored.
+* `client_secret_scope` - (Required) (String) This is the secret scope in which your service principal/enterprise app client secret will be stored.
+
+* `storage_resource_name` - (Required) (String) The name of the storage resource in which the data is for ADLS gen 1. This is what you are trying to mount. (Could be omitted if `resource_id` is provided)
+* `spark_conf_prefix` - (Optional) (String) This is the spark configuration prefix for adls gen 1 mount. The options are `fs.adl`, `dfs.adls`. Use `fs.adl` for runtime 6.0 and above for the clusters. Otherwise use `dfs.adls`. The default value is: `fs.adl`.
+* `directory` - (Computed) (String) This is optional if you don't want to add an additional directory that you wish to mount. This must start with a "/".
+
+### Example mounting ADLS Gen1
+
+```hcl
+resource "databricks_mount" "mount" {
+    mount_name           = "{var.RANDOM}"
+    adl {
+      storage_resource_name = "{env.TEST_STORAGE_ACCOUNT_NAME}"
+      tenant_id              = data.azurerm_client_config.current.tenant_id
+      client_id              = data.azurerm_client_config.current.client_id
+      client_secret_scope    = databricks_secret_scope.terraform.name
+      client_secret_key      = databricks_secret.service_principal_key.key
+      spark_conf_prefix      = "fs.adl"
+    }
+}
+```
+
+## wasb block
+
+This block allows specifying parameters for mounting of the Azure Blob Storage. The following arguments are required inside the `wasb` block:
+
+* `auth_type` - (Required) (String) This is the auth type for blob storage. This can either be SAS tokens (`SAS`) or account access keys (`ACCESS_KEY`).
+* `token_secret_scope` - (Required) (String) This is the secret scope in which your auth type token is stored.
+* `token_secret_key` - (Required) (String) This is the secret key in which your auth type token is stored.
+* `container_name` - (Required) (String) The container in which the data is. This is what you are trying to mount. (Could be omitted if `resource_id` is provided)
+* `storage_account_name` - (Required) (String) The name of the storage resource in which the data is. (Could be omitted if `resource_id` is provided)
+* `directory` - (Computed) (String) This is optional if you don't want to add an additional directory that you wish to mount. This must start with a "/".
+
+### Example mounting Azure Blob Storage
+
+```hcl
+resource "azurerm_storage_account" "blobaccount" {
+  name                     = "${var.prefix}blob"
+  resource_group_name      = var.resource_group_name
+  location                 = var.resource_group_location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  account_kind             = "StorageV2"
+}
+
+resource "azurerm_storage_container" "marketing" {
+  name                  = "marketing"
+  storage_account_name  = azurerm_storage_account.blobaccount.name
+  container_access_type = "private"
+}
+
+resource "databricks_secret_scope" "terraform" {
+    name                     = "application"
+    initial_manage_principal = "users"
+}
+
+resource "databricks_secret" "storage_key" {
+    key          = "blob_storage_key"
+    string_value = azurerm_storage_account.blobaccount.primary_access_key
+    scope        = databricks_secret_scope.terraform.name
+}
+
+resource "databricks_mount" "marketing" {
+    mount_name           = "marketing"
+    wasb {
+      container_name       = azurerm_storage_container.marketing.name
+      storage_account_name = azurerm_storage_account.blobaccount.name
+      auth_type            = "ACCESS_KEY"
+      token_secret_scope   = databricks_secret_scope.terraform.name
+      token_secret_key     = databricks_secret.storage_key.key
+    }
+}
+```
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - mount name
 * `source` - (String) HDFS-compatible url
-
 
 ## Import
 

--- a/docs/resources/mount.md
+++ b/docs/resources/mount.md
@@ -169,6 +169,8 @@ This block allows specifying parameters for mounting of the ADLS Gen2. The follo
 
 ### Creating mount for ADLS Gen2 using abfs block
 
+In this example, we're using Azure authentication, so we can omit some parameters (`tenant_id`, `storage_account_name`, and `container_name`) that will be detected automatically.
+
 ```hcl
 resource "databricks_secret_scope" "terraform" {
     name                     = "application"
@@ -179,9 +181,6 @@ resource "databricks_secret" "service_principal_key" {
     key          = "service_principal_key"
     string_value = "${var.ARM_CLIENT_SECRET}"
     scope        = databricks_secret_scope.terraform.name
-}
-
-data "azurerm_client_config" "current" {
 }
 
 resource "azurerm_storage_account" "this" {
@@ -208,10 +207,8 @@ resource "azurerm_storage_container" "this" {
 
 resource "databricks_mount" "marketing" {
     name             = "marketing"
+    resource_id      = azurerm_storage_container.this.id
     abfs {
-      container_name         = azurerm_storage_container.this.name
-      storage_account_name   = azurerm_storage_account.this.name
-      tenant_id              = data.azurerm_client_config.current.tenant_id
       client_id              = data.azurerm_client_config.current.client_id
       client_secret_scope    = databricks_secret_scope.terraform.name
       client_secret_key      = databricks_secret.service_principal_key.key

--- a/docs/resources/mount.md
+++ b/docs/resources/mount.md
@@ -20,7 +20,7 @@ This resource provides two ways of mounting a storage account:
 ## Common arguments
 
 * `cluster_id` - (Optional, String) Cluster to use for mounting. If no cluster is specified, a new cluster will be created and will mount the bucket for all of the clusters in this workspace. If the cluster is not running - it's going to be started, so be aware to set auto-termination rules on it.
-* `mount_name` - (Optional, String) Name, under which mount will be accessible in `dbfs:/mnt/<MOUNT_NAME>`. If not specified, provider will try to infer it from the bucket name, storage account name, etc. 
+* `name` - (Optional, String) Name, under which mount will be accessible in `dbfs:/mnt/<MOUNT_NAME>`. If not specified, provider will try to infer it from the bucket name, storage account name, etc. 
 * `uri` - (Optional, String) the URI for accessing specific storage (`s3a://....`, `abfss://....`, `gs://....`, etc.)
 * `extra_configs` - (Optional, String map) configuration parameters that are necessary for mounting of specific storage
 * `resource_id` - (Optional, String) 

--- a/docs/resources/mount.md
+++ b/docs/resources/mount.md
@@ -19,13 +19,12 @@ This resource provides two ways of mounting a storage account:
 
 ## Common arguments
 
-* `cluster_id` - (Optional) (String) Cluster to use for mounting. If no cluster is specified, a new cluster will be created and will mount the bucket for all of the clusters in this workspace. If the cluster is not running - it's going to be started, so be aware to set auto-termination rules on it.
-* `mount_name` - (Required) (String) Name, under which mount will be accessible in `dbfs:/mnt/<MOUNT_NAME>`.
-
-## Generic mounting arguments
-
+* `cluster_id` - (Optional, String) Cluster to use for mounting. If no cluster is specified, a new cluster will be created and will mount the bucket for all of the clusters in this workspace. If the cluster is not running - it's going to be started, so be aware to set auto-termination rules on it.
+* `mount_name` - (Optional, String) Name, under which mount will be accessible in `dbfs:/mnt/<MOUNT_NAME>`. If not specified, provider will try to infer it from the bucket name, storage account name, etc. 
 * `uri` - (Optional, String) the URI for accessing specific storage (`s3a://....`, `abfss://....`, `gs://....`, etc.)
-* `extra_configs` - (Optional, String map) configuration parameters that are necessary for mounting of specific storage 
+* `extra_configs` - (Optional, String map) configuration parameters that are necessary for mounting of specific storage
+* `resource_id` - (Optional, String) 
+* `encryption_type` - (Optional, String) 
 
 ## s3 block
 

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -58,7 +58,7 @@ The following arguments are required:
 * `name` - A user-friendly name for this pipeline. The name can be used to identify pipeline jobs in the UI.
 * `storage` - A location on DBFS or cloud storage where output data and metadata required for pipeline execution are stored. By default, tables are stored in a subdirectory of this location.
 * `configuration` - An optional list of values to apply to the entire pipeline. Elements must be formatted as key:value pairs.
-* `library` blocks - Specifies ipeline code and required artifacts. Syntax resembles [library](cluster.md#library-configuration-block) configuration block with the addition of a special `notebook` type of library that should have `path` attribute.
+* `library` blocks - Specifies pipeline code and required artifacts. Syntax resembles [library](cluster.md#library-configuration-block) configuration block with the addition of a special `notebook` type of library that should have `path` attribute.
 * `cluster` blocks - [Clusters](cluster.md) to run the pipeline. If none is specified, pipelines will automatically select a default cluster configuration for the pipeline.
 * `continuous` - A flag indicating whether to run the pipeline continuously. The default value is `false`.
 * `target` - The name of a database for persisting pipeline output data. Configuring the target setting allows you to view and query the pipeline output data from the Databricks UI.

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Azure/go-autorest/autorest/adal v0.9.16
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.8
 	github.com/Azure/go-autorest/autorest/azure/cli v0.4.3
+	github.com/golang-jwt/jwt/v4 v4.0.0
 	github.com/google/go-querystring v1.1.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-retryablehttp v0.7.0

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -77,6 +77,7 @@ func DatabricksProvider() *schema.Provider {
 			"databricks_azure_adls_gen2_mount": storage.ResourceAzureAdlsGen2Mount(),
 			"databricks_azure_blob_mount":      storage.ResourceAzureBlobMount(),
 			"databricks_dbfs_file":             storage.ResourceDBFSFile(),
+			"databricks_mount":                 storage.ResourceDatabricksMount(),
 
 			"databricks_sql_dashboard":     sqlanalytics.ResourceDashboard(),
 			"databricks_sql_endpoint":      sqlanalytics.ResourceSQLEndpoint(),

--- a/qa/testing_test.go
+++ b/qa/testing_test.go
@@ -189,6 +189,24 @@ func TestResourceFixture_Apply(t *testing.T) {
 	}.ApplyNoError(t)
 }
 
+func TestResourceFixture_Apply_Token(t *testing.T) {
+	ResourceFixture{
+		CommandMock: func(commandStr string) common.CommandResults {
+			return common.CommandResults{
+				ResultType: "text",
+				Data:       "yes",
+			}
+		},
+		Azure:    true,
+		Resource: noopResource,
+		ID:       "x",
+		New:      true,
+		Read:     true,
+		HCL:      `dummy = true`,
+		Token:    "test",
+	}.ApplyNoError(t)
+}
+
 func TestResourceFixture_ApplyDelete(t *testing.T) {
 	d, err := ResourceFixture{
 		CommandMock: func(commandStr string) common.CommandResults {

--- a/storage/adls_gen1_mount.go
+++ b/storage/adls_gen1_mount.go
@@ -31,7 +31,7 @@ func (m AzureADLSGen1Mount) Config(client *common.DatabricksClient) map[string]s
 		m.PrefixType + ".oauth2.access.token.provider.type": "ClientCredential",
 
 		m.PrefixType + ".oauth2.client.id":   m.ClientID,
-		m.PrefixType + ".oauth2.credential":  fmt.Sprintf("{secrets/%s/%s}", m.SecretScope, m.SecretKey),
+		m.PrefixType + ".oauth2.credential":  fmt.Sprintf("{{secrets/%s/%s}}", m.SecretScope, m.SecretKey),
 		m.PrefixType + ".oauth2.refresh.url": fmt.Sprintf("%s/%s/oauth2/token", aadEndpoint, m.TenantID),
 	}
 }

--- a/storage/adls_gen1_mount.go
+++ b/storage/adls_gen1_mount.go
@@ -10,18 +10,26 @@ import (
 
 // AzureADLSGen1Mount describes the object for a azure datalake gen 1 storage mount
 type AzureADLSGen1Mount struct {
-	StorageResource string `json:"storage_resource_name" tf:"force_new"`
-	Directory       string `json:"directory,omitempty" tf:"force_new"`
-	PrefixType      string `json:"spark_conf_prefix,omitempty" tf:"default:fs.adl,force_new"`
-	ClientID        string `json:"client_id" tf:"force_new"`
-	TenantID        string `json:"tenant_id" tf:"force_new"`
-	SecretScope     string `json:"client_secret_scope" tf:"force_new"`
-	SecretKey       string `json:"client_secret_key" tf:"force_new"`
+	StorageResource string `json:"storage_resource_name"`
+	Directory       string `json:"directory,omitempty"`
+	PrefixType      string `json:"spark_conf_prefix"`
+	ClientID        string `json:"client_id"`
+	TenantID        string `json:"tenant_id"`
+	SecretScope     string `json:"client_secret_scope"`
+	SecretKey       string `json:"client_secret_key"`
 }
 
 // Source ...
 func (m AzureADLSGen1Mount) Source() string {
 	return fmt.Sprintf("adl://%s.azuredatalakestore.net%s", m.StorageResource, m.Directory)
+}
+
+func (m AzureADLSGen1Mount) Name() string {
+	return m.StorageResource
+}
+
+func (m AzureADLSGen1Mount) ValidateAndApplyDefaults(d *schema.ResourceData, client *common.DatabricksClient) error {
+	return nil
 }
 
 // Config ...

--- a/storage/adls_gen1_mount.go
+++ b/storage/adls_gen1_mount.go
@@ -10,13 +10,13 @@ import (
 
 // AzureADLSGen1Mount describes the object for a azure datalake gen 1 storage mount
 type AzureADLSGen1Mount struct {
-	StorageResource string `json:"storage_resource_name"`
-	Directory       string `json:"directory,omitempty"`
-	PrefixType      string `json:"spark_conf_prefix"`
-	ClientID        string `json:"client_id"`
-	TenantID        string `json:"tenant_id"`
-	SecretScope     string `json:"client_secret_scope"`
-	SecretKey       string `json:"client_secret_key"`
+	StorageResource string `json:"storage_resource_name" tf:"force_new"`
+	Directory       string `json:"directory,omitempty" tf:"force_new"`
+	PrefixType      string `json:"spark_conf_prefix,omitempty" tf:"default:fs.adl,force_new"`
+	ClientID        string `json:"client_id" tf:"force_new"`
+	TenantID        string `json:"tenant_id" tf:"force_new"`
+	SecretScope     string `json:"client_secret_scope" tf:"force_new"`
+	SecretKey       string `json:"client_secret_key" tf:"force_new"`
 }
 
 // Source ...

--- a/storage/adls_gen2_mount.go
+++ b/storage/adls_gen2_mount.go
@@ -32,7 +32,7 @@ func (m AzureADLSGen2Mount) Config(client *common.DatabricksClient) map[string]s
 		"fs.azure.account.auth.type":                          "OAuth",
 		"fs.azure.account.oauth.provider.type":                "org.apache.hadoop.fs.azurebfs.oauth2.ClientCredsTokenProvider",
 		"fs.azure.account.oauth2.client.id":                   m.ClientID,
-		"fs.azure.account.oauth2.client.secret":               fmt.Sprintf("{secrets/%s/%s}", m.SecretScope, m.SecretKey),
+		"fs.azure.account.oauth2.client.secret":               fmt.Sprintf("{{secrets/%s/%s}}", m.SecretScope, m.SecretKey),
 		"fs.azure.account.oauth2.client.endpoint":             fmt.Sprintf("%s/%s/oauth2/token", aadEndpoint, m.TenantID),
 		"fs.azure.createRemoteFileSystemDuringInitialization": fmt.Sprintf("%t", m.InitializeFileSystem),
 	}

--- a/storage/adls_gen2_mount.go
+++ b/storage/adls_gen2_mount.go
@@ -9,14 +9,14 @@ import (
 
 // AzureADLSGen2Mount describes the object for a azure datalake gen 2 storage mount
 type AzureADLSGen2Mount struct {
-	ContainerName        string `json:"container_name"`
-	StorageAccountName   string `json:"storage_account_name"`
-	Directory            string `json:"directory,omitempty"`
-	ClientID             string `json:"client_id"`
-	TenantID             string `json:"tenant_id"`
-	SecretScope          string `json:"client_secret_scope"`
-	SecretKey            string `json:"client_secret_key"`
-	InitializeFileSystem bool   `json:"initialize_file_system"`
+	ContainerName        string `json:"container_name" tf:"force_new"`
+	StorageAccountName   string `json:"storage_account_name" tf:"force_new"`
+	Directory            string `json:"directory,omitempty" tf:"force_new"`
+	ClientID             string `json:"client_id" tf:"force_new"`
+	TenantID             string `json:"tenant_id" tf:"force_new"`
+	SecretScope          string `json:"client_secret_scope" tf:"force_new"`
+	SecretKey            string `json:"client_secret_key" tf:"force_new"`
+	InitializeFileSystem bool   `json:"initialize_file_system" tf:"force_new"`
 }
 
 // Source returns ABFSS URI backing the mount

--- a/storage/adls_gen2_mount.go
+++ b/storage/adls_gen2_mount.go
@@ -26,7 +26,7 @@ func (m AzureADLSGen2Mount) Source() string {
 }
 
 func (m AzureADLSGen2Mount) Name() string {
-	return fmt.Sprintf("%s-%s", m.StorageAccountName, m.ContainerName)
+	return m.ContainerName
 }
 
 func (m AzureADLSGen2Mount) ValidateAndApplyDefaults(d *schema.ResourceData, client *common.DatabricksClient) error {

--- a/storage/adls_gen2_mount.go
+++ b/storage/adls_gen2_mount.go
@@ -9,20 +9,28 @@ import (
 
 // AzureADLSGen2Mount describes the object for a azure datalake gen 2 storage mount
 type AzureADLSGen2Mount struct {
-	ContainerName        string `json:"container_name" tf:"force_new"`
-	StorageAccountName   string `json:"storage_account_name" tf:"force_new"`
-	Directory            string `json:"directory,omitempty" tf:"force_new"`
-	ClientID             string `json:"client_id" tf:"force_new"`
-	TenantID             string `json:"tenant_id" tf:"force_new"`
-	SecretScope          string `json:"client_secret_scope" tf:"force_new"`
-	SecretKey            string `json:"client_secret_key" tf:"force_new"`
-	InitializeFileSystem bool   `json:"initialize_file_system" tf:"force_new"`
+	ContainerName        string `json:"container_name"`
+	StorageAccountName   string `json:"storage_account_name"`
+	Directory            string `json:"directory,omitempty"`
+	ClientID             string `json:"client_id"`
+	TenantID             string `json:"tenant_id"`
+	SecretScope          string `json:"client_secret_scope"`
+	SecretKey            string `json:"client_secret_key"`
+	InitializeFileSystem bool   `json:"initialize_file_system"`
 }
 
 // Source returns ABFSS URI backing the mount
 func (m AzureADLSGen2Mount) Source() string {
 	return fmt.Sprintf("abfss://%s@%s.dfs.core.windows.net%s",
 		m.ContainerName, m.StorageAccountName, m.Directory)
+}
+
+func (m AzureADLSGen2Mount) Name() string {
+	return fmt.Sprintf("%s-%s", m.StorageAccountName, m.ContainerName)
+}
+
+func (m AzureADLSGen2Mount) ValidateAndApplyDefaults(d *schema.ResourceData, client *common.DatabricksClient) error {
+	return nil
 }
 
 // Config returns mount configurations

--- a/storage/aws_s3_mount.go
+++ b/storage/aws_s3_mount.go
@@ -13,13 +13,21 @@ import (
 
 // AWSIamMount describes the object for a aws mount using iam role
 type AWSIamMount struct {
-	S3BucketName    string `json:"s3_bucket_name" tf:"force_new"`
-	InstanceProfile string `json:"instance_profile,omitempty" tf:"force_new"`
+	S3BucketName string `json:"s3_bucket_name"`
 }
 
 // Source ...
 func (m AWSIamMount) Source() string {
 	return fmt.Sprintf("s3a://%s", m.S3BucketName)
+}
+
+// Name ...
+func (m AWSIamMount) Name() string {
+	return m.S3BucketName
+}
+
+func (m AWSIamMount) ValidateAndApplyDefaults(d *schema.ResourceData, client *common.DatabricksClient) error {
+	return nil
 }
 
 // Config ...

--- a/storage/aws_s3_mount.go
+++ b/storage/aws_s3_mount.go
@@ -124,23 +124,10 @@ func GetOrCreateMountingClusterWithInstanceProfile(
 	}
 	instanceProfileParts := strings.Split(arnSections[5], "/")
 	clusterName := fmt.Sprintf("terraform-mount-%s", strings.Join(instanceProfileParts[1:], "-"))
-	// TODO: use SingleNode cluster?
-	return clustersAPI.GetOrCreateRunningCluster(clusterName, compute.Cluster{
-		NumWorkers:  1,
-		ClusterName: clusterName,
-		SparkVersion: clustersAPI.LatestSparkVersionOrDefault(
-			compute.SparkVersionRequest{
-				Latest:          true,
-				LongTermSupport: true,
-			}),
-		NodeTypeID: clustersAPI.GetSmallestNodeType(
-			compute.NodeTypeRequest{
-				LocalDisk: true,
-			}),
-		AutoterminationMinutes: 10,
-		AwsAttributes: &compute.AwsAttributes{
-			InstanceProfileArn: instanceProfile,
-			Availability:       "SPOT",
-		},
-	})
+	cluster := getCommonClusterObject(clustersAPI, clusterName)
+	cluster.AwsAttributes = &compute.AwsAttributes{
+		InstanceProfileArn: instanceProfile,
+		Availability:       "SPOT",
+	}
+	return clustersAPI.GetOrCreateRunningCluster(clusterName, cluster)
 }

--- a/storage/aws_s3_mount.go
+++ b/storage/aws_s3_mount.go
@@ -13,8 +13,8 @@ import (
 
 // AWSIamMount describes the object for a aws mount using iam role
 type AWSIamMount struct {
-	S3BucketName    string `json:"s3_bucket_name"`
-	InstanceProfile string `json:"instance_profile,omitempty"`
+	S3BucketName    string `json:"s3_bucket_name" tf:"force_new"`
+	InstanceProfile string `json:"instance_profile,omitempty" tf:"force_new"`
 }
 
 // Source ...

--- a/storage/aws_s3_mount.go
+++ b/storage/aws_s3_mount.go
@@ -13,7 +13,8 @@ import (
 
 // AWSIamMount describes the object for a aws mount using iam role
 type AWSIamMount struct {
-	S3BucketName string `json:"s3_bucket_name"`
+	S3BucketName    string `json:"s3_bucket_name"`
+	InstanceProfile string `json:"instance_profile,omitempty"`
 }
 
 // Source ...
@@ -123,6 +124,7 @@ func GetOrCreateMountingClusterWithInstanceProfile(
 	}
 	instanceProfileParts := strings.Split(arnSections[5], "/")
 	clusterName := fmt.Sprintf("terraform-mount-%s", strings.Join(instanceProfileParts[1:], "-"))
+	// TODO: use SingleNode cluster?
 	return clustersAPI.GetOrCreateRunningCluster(clusterName, compute.Cluster{
 		NumWorkers:  1,
 		ClusterName: clusterName,

--- a/storage/azure_blob_mount.go
+++ b/storage/azure_blob_mount.go
@@ -10,12 +10,12 @@ import (
 
 // AzureBlobMount describes the object for a azure blob storage mount - a.k.a. NativeAzureFileSystem
 type AzureBlobMount struct {
-	ContainerName      string `json:"container_name"`
-	StorageAccountName string `json:"storage_account_name"`
-	Directory          string `json:"directory"`
-	AuthType           string `json:"auth_type"`
-	SecretScope        string `json:"token_secret_scope"`
-	SecretKey          string `json:"token_secret_key"`
+	ContainerName      string `json:"container_name" tf:"force_new"`
+	StorageAccountName string `json:"storage_account_name" tf:"force_new"`
+	Directory          string `json:"directory,omitempty" tf:"force_new"`
+	AuthType           string `json:"auth_type" tf:"force_new"`
+	SecretScope        string `json:"token_secret_scope" tf:"force_new"`
+	SecretKey          string `json:"token_secret_key" tf:"force_new"`
 }
 
 // Source ...

--- a/storage/azure_blob_mount.go
+++ b/storage/azure_blob_mount.go
@@ -25,7 +25,7 @@ func (m AzureBlobMount) Source() string {
 }
 
 func (m AzureBlobMount) Name() string {
-	return fmt.Sprintf("%s-%s", m.StorageAccountName, m.ContainerName)
+	return m.ContainerName
 }
 
 func (m AzureBlobMount) ValidateAndApplyDefaults(d *schema.ResourceData, client *common.DatabricksClient) error {

--- a/storage/azure_blob_mount.go
+++ b/storage/azure_blob_mount.go
@@ -33,7 +33,7 @@ func (m AzureBlobMount) Config(client *common.DatabricksClient) map[string]strin
 		confKey = fmt.Sprintf("fs.azure.account.key.%s.blob.core.windows.net", m.StorageAccountName)
 	}
 	return map[string]string{
-		confKey: fmt.Sprintf("{secrets/%s/%s}", m.SecretScope, m.SecretKey),
+		confKey: fmt.Sprintf("{{secrets/%s/%s}}", m.SecretScope, m.SecretKey),
 	}
 }
 

--- a/storage/azure_blob_mount.go
+++ b/storage/azure_blob_mount.go
@@ -10,18 +10,26 @@ import (
 
 // AzureBlobMount describes the object for a azure blob storage mount - a.k.a. NativeAzureFileSystem
 type AzureBlobMount struct {
-	ContainerName      string `json:"container_name" tf:"force_new"`
-	StorageAccountName string `json:"storage_account_name" tf:"force_new"`
-	Directory          string `json:"directory,omitempty" tf:"force_new"`
-	AuthType           string `json:"auth_type" tf:"force_new"`
-	SecretScope        string `json:"token_secret_scope" tf:"force_new"`
-	SecretKey          string `json:"token_secret_key" tf:"force_new"`
+	ContainerName      string `json:"container_name"`
+	StorageAccountName string `json:"storage_account_name"`
+	Directory          string `json:"directory"`
+	AuthType           string `json:"auth_type"`
+	SecretScope        string `json:"token_secret_scope"`
+	SecretKey          string `json:"token_secret_key"`
 }
 
 // Source ...
 func (m AzureBlobMount) Source() string {
 	return fmt.Sprintf("wasbs://%[1]s@%[2]s.blob.core.windows.net%[3]s",
 		m.ContainerName, m.StorageAccountName, m.Directory)
+}
+
+func (m AzureBlobMount) Name() string {
+	return fmt.Sprintf("%s-%s", m.StorageAccountName, m.ContainerName)
+}
+
+func (m AzureBlobMount) ValidateAndApplyDefaults(d *schema.ResourceData, client *common.DatabricksClient) error {
+	return nil
 }
 
 // Config ...

--- a/storage/azure_blob_mount_test.go
+++ b/storage/azure_blob_mount_test.go
@@ -22,13 +22,7 @@ func TestResourceAzureBlobMountCreate(t *testing.T) {
 				Response: compute.ClusterInfo{
 					State: compute.ClusterStateRunning,
 				},
-			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/clusters/get?cluster_id=b",
-				Response: compute.ClusterInfo{
-					State: compute.ClusterStateRunning,
-				},
+				ReuseRequest: true,
 			},
 		},
 		Resource: ResourceAzureBlobMount(),

--- a/storage/generic_mounts.go
+++ b/storage/generic_mounts.go
@@ -16,11 +16,11 @@ import (
 type GenericMount struct {
 	URI     string                     `json:"uri,omitempty" tf:"force_new"`
 	Options map[string]string          `json:"extra_configs,omitempty" tf:"force_new"`
-	Abfs    *AzureADLSGen2MountGeneric `json:"abfs,omitempty" tf:"force_new"`
-	S3      *S3IamMount                `json:"s3,omitempty" tf:"force_new"`
-	Adl     *AzureADLSGen1MountGeneric `json:"adl,omitempty" tf:"force_new"`
-	Wasb    *AzureBlobMountGeneric     `json:"wasb,omitempty" tf:"force_new"`
-	Gs      *GSMount                   `json:"gs,omitempty" tf:"force_new"`
+	Abfs    *AzureADLSGen2MountGeneric `json:"abfs,omitempty" tf:"force_new,suppress_diff"`
+	S3      *S3IamMount                `json:"s3,omitempty" tf:"force_new,suppress_diff"`
+	Adl     *AzureADLSGen1MountGeneric `json:"adl,omitempty" tf:"force_new,suppress_diff"`
+	Wasb    *AzureBlobMountGeneric     `json:"wasb,omitempty" tf:"force_new,suppress_diff"`
+	Gs      *GSMount                   `json:"gs,omitempty" tf:"force_new,suppress_diff"`
 
 	ClusterID      string `json:"cluster_id,omitempty" tf:"computed,force_new"`
 	MountName      string `json:"mount_name,omitempty" tf:"computed,force_new"`

--- a/storage/generic_mounts.go
+++ b/storage/generic_mounts.go
@@ -1,0 +1,405 @@
+package storage
+
+import (
+	"context"
+	"crypto/md5"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/databrickslabs/terraform-provider-databricks/common"
+	"github.com/databrickslabs/terraform-provider-databricks/compute"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// TODO: add support for encryption parameters in S3
+type GenericMount struct {
+	URI     string                     `json:"uri,omitempty" tf:"force_new"`
+	Options map[string]string          `json:"extra_configs,omitempty" tf:"force_new"`
+	Abfs    *AzureADLSGen2MountGeneric `json:"abfs,omitempty" tf:"force_new"`
+	S3      *S3IamMount                `json:"s3,omitempty" tf:"force_new"`
+	Adl     *AzureADLSGen1MountGeneric `json:"adl,omitempty" tf:"force_new"`
+	Wasb    *AzureBlobMountGeneric     `json:"wasb,omitempty" tf:"force_new"`
+	Gs      *GSMount                   `json:"gs,omitempty" tf:"force_new"`
+
+	ClusterID      string `json:"cluster_id,omitempty" tf:"computed,force_new"`
+	MountName      string `json:"mount_name,omitempty" tf:"computed,force_new"`
+	ResourceID     string `json:"resource_id,omitempty" tf:"force_new"`
+	EncryptionType string `json:"encryption_type,omitempty" tf:"force_new"`
+}
+
+func (m GenericMount) getBlock() Mount {
+	if m.Abfs != nil {
+		return m.Abfs
+	} else if m.Adl != nil {
+		return m.Adl
+	} else if m.Wasb != nil {
+		return m.Wasb
+	} else if m.S3 != nil {
+		return m.S3
+	} else if m.Gs != nil {
+		return m.Gs
+	}
+	return nil
+}
+
+// Source returns URI backing the mount
+func (m GenericMount) Source() string {
+	if block := m.getBlock(); block != nil {
+		return block.Source()
+	}
+	return m.URI
+}
+
+// Name
+func (m GenericMount) Name() string {
+	if m.MountName != "" {
+		return m.MountName
+	}
+	if block := m.getBlock(); block != nil {
+		return block.Name()
+	}
+	return ""
+}
+
+// Config returns mount configurations
+func (m GenericMount) Config(client *common.DatabricksClient) map[string]string {
+	if block := m.getBlock(); block != nil {
+		return block.Config(client)
+	}
+	return m.Options
+}
+
+// ApplyDefaults tries to apply defaults to a given resource
+func (m GenericMount) ValidateAndApplyDefaults(d *schema.ResourceData, client *common.DatabricksClient) error {
+	if block := m.getBlock(); block != nil {
+		return block.ValidateAndApplyDefaults(d, client)
+	}
+	if _, ok := d.GetOk("mount_name"); !ok {
+		return fmt.Errorf("value of mount_name is not specified or empty")
+	}
+	if _, ok := d.GetOk("uri"); !ok {
+		return fmt.Errorf("value of uri is not specified or empty")
+	}
+	return nil
+}
+
+// --------------- Google Cloud Storage
+
+// GSMount describes the object for a GS mount using google service account
+type GSMount struct {
+	BucketName     string `json:"bucket_name" tf:"force_new"`
+	ServiceAccount string `json:"service_account,omitempty" tf:"force_new"`
+}
+
+// Source ...
+func (m GSMount) Source() string {
+	return fmt.Sprintf("gs://%s", m.BucketName)
+}
+
+func (m GSMount) Name() string {
+	return m.BucketName
+}
+
+func (m GSMount) ValidateAndApplyDefaults(d *schema.ResourceData, client *common.DatabricksClient) error {
+	nm := d.Get("mount_name").(string)
+	if nm != "" {
+		return nil
+	}
+	nm = m.Name()
+	if nm != "" {
+		d.Set("mount_name", nm)
+		return nil
+	}
+	nm = d.Get("resource_id").(string)
+	if nm != "" {
+		d.Set("mount_name", nm)
+		return nil
+	}
+	uri := d.Get("uri").(string)
+	if uri == "" {
+		return fmt.Errorf("mount_name isn't specified, and no other data to infer it (bucket_name, uri or resource_id)")
+	}
+	u, err := url.Parse(uri)
+	if err != nil {
+		return fmt.Errorf("can't parse GCS URI")
+	}
+	if u.Scheme != "gs" {
+		return fmt.Errorf("unsupported schema for GCS URI: %s", u.Scheme)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("no bucket name specified in URI")
+	}
+	d.Set("mount_name", u.Host)
+
+	return nil
+}
+
+// Config ...
+func (m GSMount) Config(client *common.DatabricksClient) map[string]string {
+	return make(map[string]string) // return empty map so nil map does not marshal to null
+}
+
+func preprocessGsMount(ctx context.Context, s map[string]*schema.Schema, d *schema.ResourceData, m interface{}) error {
+	var gm GenericMount
+	if err := common.DataToStructPointer(d, s, &gm); err != nil {
+		return err
+	}
+	// TODO: move into Validate function
+	if !(strings.HasPrefix(gm.URI, "gs://") || gm.Gs != nil) {
+		return nil
+	}
+	clusterID := gm.ClusterID
+	serviceAccount := ""
+	if gm.Gs != nil {
+		serviceAccount = gm.Gs.ServiceAccount
+	}
+	if clusterID == "" && serviceAccount == "" {
+		return fmt.Errorf("either cluster_id or service_account must be specified to mount GCS bucket")
+	}
+	clustersAPI := compute.NewClustersAPI(ctx, m)
+	if clusterID != "" {
+		clusterInfo, err := clustersAPI.Get(clusterID)
+		if err != nil {
+			return err
+		}
+		if clusterInfo.GcpAttributes == nil {
+			return fmt.Errorf("cluster %s must have GCP attributes", clusterID)
+		}
+		if len(clusterInfo.GcpAttributes.GoogleServiceAccount) == 0 {
+			return fmt.Errorf("cluster %s must have GCP service account attached", clusterID)
+		}
+	}
+	if serviceAccount != "" {
+		cluster, err := GetOrCreateMountingClusterWithGcpServiceAccount(clustersAPI, serviceAccount)
+		if err != nil {
+			return err
+		}
+		return d.Set("cluster_id", cluster.ClusterID)
+	}
+	return nil
+}
+
+// GetOrCreateMountingClusterWithGcpServiceAccount ...
+func GetOrCreateMountingClusterWithGcpServiceAccount(
+	clustersAPI compute.ClustersAPI, serviceAccount string) (i compute.ClusterInfo, err error) {
+	clusterName := fmt.Sprintf("terraform-mount-gcs-%x", md5.Sum([]byte(serviceAccount)))
+	cluster := getCommonClusterObject(clustersAPI, clusterName)
+	cluster.GcpAttributes = &compute.GcpAttributes{GoogleServiceAccount: serviceAccount}
+	return clustersAPI.GetOrCreateRunningCluster(clusterName, cluster)
+}
+
+// --------------- Generic AWS S3
+
+// S3IamMount describes the object for a aws mount using iam role
+type S3IamMount struct {
+	BucketName      string `json:"bucket_name" tf:"force_new"`
+	InstanceProfile string `json:"instance_profile,omitempty" tf:"force_new"`
+}
+
+// Source ...
+func (m S3IamMount) Source() string {
+	return fmt.Sprintf("s3a://%s", m.BucketName)
+}
+
+// Name ...
+func (m S3IamMount) Name() string {
+	return m.BucketName
+}
+
+// Config ...
+func (m S3IamMount) Config(client *common.DatabricksClient) map[string]string {
+	return make(map[string]string) // return empty map so nil map does not marshal to null
+}
+
+func (m S3IamMount) ValidateAndApplyDefaults(d *schema.ResourceData, client *common.DatabricksClient) error {
+	nm := d.Get("mount_name").(string)
+	if nm != "" {
+		return nil
+	}
+	nm = m.Name()
+	if nm != "" {
+		d.Set("mount_name", nm)
+		return nil
+	}
+	nm = d.Get("resource_id").(string)
+	if nm != "" {
+		d.Set("mount_name", nm)
+		return nil
+	}
+	uri := d.Get("uri").(string)
+	if uri == "" {
+		return fmt.Errorf("mount_name isn't specified, and no other data to infer it (bucket_name, uri or resource_id)")
+	}
+	u, err := url.Parse(uri)
+	if err != nil {
+		return fmt.Errorf("can't parse S3 URI")
+	}
+	if u.Scheme != "s3" && u.Scheme != "s3a" {
+		return fmt.Errorf("unsupported schema for S3 URI: %s", u.Scheme)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("no bucket name specified in URI")
+	}
+	d.Set("mount_name", u.Host)
+
+	return nil
+}
+
+func preprocessS3MountGeneric(ctx context.Context, s map[string]*schema.Schema, d *schema.ResourceData, m interface{}) error {
+	var gm GenericMount
+	if err := common.DataToStructPointer(d, s, &gm); err != nil {
+		return err
+	}
+	// TODO: move into Validate function
+	if !(strings.HasPrefix(gm.URI, "s3://") || strings.HasPrefix(gm.URI, "s3a://") || gm.S3 != nil) {
+		return nil
+	}
+	clusterID := gm.ClusterID
+	instanceProfile := ""
+	if gm.S3 != nil {
+		instanceProfile = gm.S3.InstanceProfile
+	}
+	if clusterID == "" && instanceProfile == "" {
+		return fmt.Errorf("either cluster_id or instance_profile must be specified to mount S3 bucket")
+	}
+	clustersAPI := compute.NewClustersAPI(ctx, m)
+	if clusterID != "" {
+		clusterInfo, err := clustersAPI.Get(clusterID)
+		if err != nil {
+			return err
+		}
+		if clusterInfo.AwsAttributes == nil {
+			return fmt.Errorf("cluster %s must have AWS attributes", clusterID)
+		}
+		if len(clusterInfo.AwsAttributes.InstanceProfileArn) == 0 {
+			return fmt.Errorf("cluster %s must have EC2 instance profile attached", clusterID)
+		}
+	}
+	if instanceProfile != "" {
+		cluster, err := GetOrCreateMountingClusterWithInstanceProfile(clustersAPI, instanceProfile)
+		if err != nil {
+			return err
+		}
+		return d.Set("cluster_id", cluster.ClusterID)
+	}
+	return nil
+}
+
+// --------------- Generic ADLSgen2
+
+// AzureADLSGen2Mount describes the object for a azure datalake gen 2 storage mount
+type AzureADLSGen2MountGeneric struct {
+	ContainerName        string `json:"container_name,omitempty" tf:"computed,force_new"`
+	StorageAccountName   string `json:"storage_account_name,omitempty" tf:"computed,force_new"`
+	Directory            string `json:"directory,omitempty" tf:"force_new"`
+	ClientID             string `json:"client_id,omitempty" tf:"computed,force_new"`
+	TenantID             string `json:"tenant_id,omitempty" tf:"computed,force_new"`
+	SecretScope          string `json:"client_secret_scope" tf:"force_new"`
+	SecretKey            string `json:"client_secret_key" tf:"force_new"`
+	InitializeFileSystem bool   `json:"initialize_file_system" tf:"force_new"`
+}
+
+// Source returns ABFSS URI backing the mount
+func (m AzureADLSGen2MountGeneric) Source() string {
+	return fmt.Sprintf("abfss://%s@%s.dfs.core.windows.net%s",
+		m.ContainerName, m.StorageAccountName, m.Directory)
+}
+
+func (m AzureADLSGen2MountGeneric) Name() string {
+	return fmt.Sprintf("%s-%s", m.StorageAccountName, m.ContainerName)
+}
+
+func (m AzureADLSGen2MountGeneric) ValidateAndApplyDefaults(d *schema.ResourceData, client *common.DatabricksClient) error {
+	return nil
+}
+
+// Config returns mount configurations
+func (m AzureADLSGen2MountGeneric) Config(client *common.DatabricksClient) map[string]string {
+	aadEndpoint := client.AzureEnvironment.ActiveDirectoryEndpoint
+	return map[string]string{
+		"fs.azure.account.auth.type":                          "OAuth",
+		"fs.azure.account.oauth.provider.type":                "org.apache.hadoop.fs.azurebfs.oauth2.ClientCredsTokenProvider",
+		"fs.azure.account.oauth2.client.id":                   m.ClientID,
+		"fs.azure.account.oauth2.client.secret":               fmt.Sprintf("{{secrets/%s/%s}}", m.SecretScope, m.SecretKey),
+		"fs.azure.account.oauth2.client.endpoint":             fmt.Sprintf("%s/%s/oauth2/token", aadEndpoint, m.TenantID),
+		"fs.azure.createRemoteFileSystemDuringInitialization": fmt.Sprintf("%t", m.InitializeFileSystem),
+	}
+}
+
+// --------------- Generic ADLSgen1
+
+// AzureADLSGen1Mount describes the object for a azure datalake gen 1 storage mount
+type AzureADLSGen1MountGeneric struct {
+	StorageResource string `json:"storage_resource_name,omitempty" tf:"computed,force_new"`
+	Directory       string `json:"directory,omitempty" tf:"force_new"`
+	PrefixType      string `json:"spark_conf_prefix,omitempty" tf:"default:fs.adl,force_new"`
+	ClientID        string `json:"client_id,omitempty" tf:"computed,force_new"`
+	TenantID        string `json:"tenant_id,omitempty" tf:"computed,force_new"`
+	SecretScope     string `json:"client_secret_scope" tf:"force_new"`
+	SecretKey       string `json:"client_secret_key" tf:"force_new"`
+}
+
+// Source ...
+func (m AzureADLSGen1MountGeneric) Source() string {
+	return fmt.Sprintf("adl://%s.azuredatalakestore.net%s", m.StorageResource, m.Directory)
+}
+
+func (m AzureADLSGen1MountGeneric) Name() string {
+	return m.StorageResource
+}
+
+func (m AzureADLSGen1MountGeneric) ValidateAndApplyDefaults(d *schema.ResourceData, client *common.DatabricksClient) error {
+	return nil
+}
+
+// Config ...
+func (m AzureADLSGen1MountGeneric) Config(client *common.DatabricksClient) map[string]string {
+	aadEndpoint := client.AzureEnvironment.ActiveDirectoryEndpoint
+	return map[string]string{
+		m.PrefixType + ".oauth2.access.token.provider.type": "ClientCredential",
+
+		m.PrefixType + ".oauth2.client.id":   m.ClientID,
+		m.PrefixType + ".oauth2.credential":  fmt.Sprintf("{{secrets/%s/%s}}", m.SecretScope, m.SecretKey),
+		m.PrefixType + ".oauth2.refresh.url": fmt.Sprintf("%s/%s/oauth2/token", aadEndpoint, m.TenantID),
+	}
+}
+
+// --------------- Generic Azure Blob Storage
+
+// AzureBlobMount describes the object for a azure blob storage mount - a.k.a. NativeAzureFileSystem
+type AzureBlobMountGeneric struct {
+	ContainerName      string `json:"container_name,omitempty" tf:"computed,force_new"`
+	StorageAccountName string `json:"storage_account_name,omitempty" tf:"computed,force_new"`
+	Directory          string `json:"directory,omitempty" tf:"force_new"`
+	AuthType           string `json:"auth_type" tf:"force_new"`
+	SecretScope        string `json:"token_secret_scope" tf:"force_new"`
+	SecretKey          string `json:"token_secret_key" tf:"force_new"`
+}
+
+// Source ...
+func (m AzureBlobMountGeneric) Source() string {
+	return fmt.Sprintf("wasbs://%[1]s@%[2]s.blob.core.windows.net%[3]s",
+		m.ContainerName, m.StorageAccountName, m.Directory)
+}
+
+func (m AzureBlobMountGeneric) Name() string {
+	return fmt.Sprintf("%s-%s", m.StorageAccountName, m.ContainerName)
+}
+
+func (m AzureBlobMountGeneric) ValidateAndApplyDefaults(d *schema.ResourceData, client *common.DatabricksClient) error {
+	return nil
+}
+
+// Config ...
+func (m AzureBlobMountGeneric) Config(client *common.DatabricksClient) map[string]string {
+	var confKey string
+	if m.AuthType == "SAS" {
+		confKey = fmt.Sprintf("fs.azure.sas.%s.%s.blob.core.windows.net", m.ContainerName, m.StorageAccountName)
+	} else {
+		confKey = fmt.Sprintf("fs.azure.account.key.%s.blob.core.windows.net", m.StorageAccountName)
+	}
+	return map[string]string{
+		confKey: fmt.Sprintf("{{secrets/%s/%s}}", m.SecretScope, m.SecretKey),
+	}
+}

--- a/storage/mounts.go
+++ b/storage/mounts.go
@@ -129,7 +129,7 @@ func getOrCreateMountingCluster(clustersAPI compute.ClustersAPI) (string, error)
 			compute.NodeTypeRequest{
 				LocalDisk: true,
 			}),
-		AutoterminationMinutes: 10,
+		AutoterminationMinutes: 30,
 		SparkConf: map[string]string{
 			"spark.master":                     "local[*]",
 			"spark.databricks.cluster.profile": "singleNode",

--- a/storage/mounts.go
+++ b/storage/mounts.go
@@ -116,10 +116,10 @@ func NewMountPoint(executor common.CommandExecutor, name, clusterID string) Moun
 	}
 }
 
-func getOrCreateMountingCluster(clustersAPI compute.ClustersAPI) (string, error) {
-	cluster, err := clustersAPI.GetOrCreateRunningCluster("terraform-mount", compute.Cluster{
+func getCommonClusterObject(clustersAPI compute.ClustersAPI, clusterName string) compute.Cluster {
+	return compute.Cluster{
 		NumWorkers:  0,
-		ClusterName: "terraform-mount",
+		ClusterName: clusterName,
 		SparkVersion: clustersAPI.LatestSparkVersionOrDefault(
 			compute.SparkVersionRequest{
 				Latest:          true,
@@ -138,7 +138,11 @@ func getOrCreateMountingCluster(clustersAPI compute.ClustersAPI) (string, error)
 		CustomTags: map[string]string{
 			"ResourceClass": "SingleNode",
 		},
-	})
+	}
+}
+
+func getOrCreateMountingCluster(clustersAPI compute.ClustersAPI) (string, error) {
+	cluster, err := clustersAPI.GetOrCreateRunningCluster("terraform-mount", getCommonClusterObject(clustersAPI, "terraform-mount"))
 	if err != nil {
 		return "", err
 	}

--- a/storage/mounts.go
+++ b/storage/mounts.go
@@ -129,7 +129,7 @@ func getOrCreateMountingCluster(clustersAPI compute.ClustersAPI) (string, error)
 			compute.NodeTypeRequest{
 				LocalDisk: true,
 			}),
-		AutoterminationMinutes: 30,
+		AutoterminationMinutes: 10,
 		SparkConf: map[string]string{
 			"spark.master":                     "local[*]",
 			"spark.databricks.cluster.profile": "singleNode",

--- a/storage/mounts.go
+++ b/storage/mounts.go
@@ -68,7 +68,7 @@ func (mp MountPoint) Mount(mo Mount, client *common.DatabricksClient) (source st
 	if err != nil {
 		return
 	}
-	b := regexp.MustCompile(`"\{secrets/([^/]+)/([^\}]+)\}"`)
+	b := regexp.MustCompile(`"\{\{secrets/([^/]+)/([^\}]+)\}\}"`)
 	extraConfigs = b.ReplaceAll(extraConfigs, []byte(`dbutils.secrets.get("$1", "$2")`))
 	command := fmt.Sprintf(`
 		def safe_mount(mount_point, mount_source, configs):

--- a/storage/mounts.go
+++ b/storage/mounts.go
@@ -94,7 +94,7 @@ func (mp MountPoint) Mount(mo Mount, client *common.DatabricksClient) (source st
 				raise e
 		mount_source = safe_mount("/mnt/%s", "%v", %s, "%s")
 		dbutils.notebook.exit(mount_source)
-	`, mp.name, mo.Source(), extraConfigs, mp.encryptionType) // lgtm [go/unsafe-quoting]
+	`, mp.name, mo.Source(), extraConfigs, mp.encryptionType) // lgtm[go/unsafe-quoting]
 	result := mp.exec.Execute(mp.clusterID, "python", command)
 	return result.Text(), result.Err()
 }

--- a/storage/mounts.go
+++ b/storage/mounts.go
@@ -68,8 +68,10 @@ func (mp MountPoint) Mount(mo Mount, client *common.DatabricksClient) (source st
 	if err != nil {
 		return
 	}
-	b := regexp.MustCompile(`"\{\{secrets/([^/]+)/([^\}]+)\}\}"`)
-	extraConfigs = b.ReplaceAll(extraConfigs, []byte(`dbutils.secrets.get("$1", "$2")`))
+	secretsRe := regexp.MustCompile(`"\{\{secrets/([^/]+)/([^\}]+)\}\}"`)
+	extraConfigs = secretsRe.ReplaceAll(extraConfigs, []byte(`dbutils.secrets.get("$1", "$2")`))
+	sparkConfRe := regexp.MustCompile(`"\{\{sparkconf/([^\}]+)\}\}"`)
+	extraConfigs = sparkConfRe.ReplaceAll(extraConfigs, []byte(`spark.conf.get("$1")`))
 	command := fmt.Sprintf(`
 		def safe_mount(mount_point, mount_source, configs):
 			for mount in dbutils.fs.mounts():

--- a/storage/mounts_test.go
+++ b/storage/mounts_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/databrickslabs/terraform-provider-databricks/qa"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/databrickslabs/terraform-provider-databricks/common"
 	"github.com/stretchr/testify/assert"
@@ -148,8 +149,12 @@ func testMountFuncHelper(t *testing.T, mountFunc func(mp MountPoint, mount Mount
 type mockMount struct{}
 
 func (t mockMount) Source() string { return "fake-mount" }
+func (t mockMount) Name() string   { return "fake-mount" }
 func (t mockMount) Config(client *common.DatabricksClient) map[string]string {
 	return map[string]string{"fake-key": "fake-value"}
+}
+func (m mockMount) ValidateAndApplyDefaults(d *schema.ResourceData, client *common.DatabricksClient) error {
+	return nil
 }
 
 func TestMountPoint_Mount(t *testing.T) {
@@ -158,12 +163,12 @@ func TestMountPoint_Mount(t *testing.T) {
 	expectedMountConfig := `{"fake-key":"fake-value"}`
 	mountName := "this_mount"
 	expectedCommand := fmt.Sprintf(`
-		def safe_mount(mount_point, mount_source, configs):
+		def safe_mount(mount_point, mount_source, configs, encryptionType):
 			for mount in dbutils.fs.mounts():
 				if mount.mountPoint == mount_point and mount.source == mount_source:
 					return
 			try:
-				dbutils.fs.mount(mount_source, mount_point, extra_configs=configs)
+				dbutils.fs.mount(mount_source, mount_point, extra_configs=configs, encryptionType=encryption)
 				dbutils.fs.refreshMounts()
 				dbutils.fs.ls(mount_point)
 				return mount_source
@@ -173,7 +178,7 @@ func TestMountPoint_Mount(t *testing.T) {
 				except Exception as e2:
 					print("Failed to unmount", e2)
 				raise e
-		mount_source = safe_mount("/mnt/%s", %q, %s)
+		mount_source = safe_mount("/mnt/%s", %q, %s, "")
 		dbutils.notebook.exit(mount_source)
 	`, mountName, expectedMountSource, expectedMountConfig)
 	testMountFuncHelper(t, func(mp MountPoint, mount Mount) (s string, e error) {

--- a/storage/mounts_test.go
+++ b/storage/mounts_test.go
@@ -316,3 +316,23 @@ func TestDeletedMountClusterRecreates(t *testing.T) {
 		assert.Equal(t, "bcd", clusterID)
 	})
 }
+
+func TestOldMountImplementations(t *testing.T) {
+	n := "test"
+	m1 := AzureADLSGen2Mount{ContainerName: n}
+	assert.Equal(t, m1.Name(), n)
+	assert.Nil(t, m1.ValidateAndApplyDefaults(nil, nil))
+
+	m2 := AzureBlobMount{ContainerName: n}
+	assert.Equal(t, m2.Name(), n)
+	assert.Nil(t, m2.ValidateAndApplyDefaults(nil, nil))
+
+	m3 := AzureADLSGen1Mount{StorageResource: n}
+	assert.Equal(t, m3.Name(), n)
+	assert.Nil(t, m3.ValidateAndApplyDefaults(nil, nil))
+
+	m4 := AWSIamMount{S3BucketName: n}
+	assert.Equal(t, m4.Name(), n)
+	assert.Nil(t, m4.ValidateAndApplyDefaults(nil, nil))
+
+}

--- a/storage/mounts_test.go
+++ b/storage/mounts_test.go
@@ -168,7 +168,7 @@ func TestMountPoint_Mount(t *testing.T) {
 				if mount.mountPoint == mount_point and mount.source == mount_source:
 					return
 			try:
-				dbutils.fs.mount(mount_source, mount_point, extra_configs=configs, encryptionType=encryption)
+				dbutils.fs.mount(mount_source, mount_point, extra_configs=configs, encryption_type=encryptionType)
 				dbutils.fs.refreshMounts()
 				dbutils.fs.ls(mount_point)
 				return mount_source

--- a/storage/resource_mount.go
+++ b/storage/resource_mount.go
@@ -2,180 +2,11 @@ package storage
 
 import (
 	"context"
-	"crypto/md5"
-	"fmt"
-	"strings"
 
 	"github.com/databrickslabs/terraform-provider-databricks/common"
-	"github.com/databrickslabs/terraform-provider-databricks/compute"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
-
-// AWSIamMount describes the object for a aws mount using iam role
-type S3IamMount struct {
-	BucketName      string `json:"bucket_name" tf:"force_new"`
-	InstanceProfile string `json:"instance_profile,omitempty" tf:"force_new"`
-}
-
-// Source ...
-func (m S3IamMount) Source() string {
-	return fmt.Sprintf("s3a://%s", m.BucketName)
-}
-
-// Config ...
-func (m S3IamMount) Config(client *common.DatabricksClient) map[string]string {
-	return make(map[string]string) // return empty map so nil map does not marshal to null
-}
-
-// GSMount describes the object for a GS mount using google service account
-type GSMount struct {
-	BucketName     string `json:"bucket_name" tf:"force_new"`
-	ServiceAccount string `json:"service_account,omitempty" tf:"force_new"`
-}
-
-// Source ...
-func (m GSMount) Source() string {
-	return fmt.Sprintf("gs://%s", m.BucketName)
-}
-
-// Config ...
-func (m GSMount) Config(client *common.DatabricksClient) map[string]string {
-	return make(map[string]string) // return empty map so nil map does not marshal to null
-}
-
-// TODO: add support for encryption parameters in S3
-type GenericMount struct {
-	URI     string              `json:"uri,omitempty" tf:"force_new"`
-	Options map[string]string   `json:"extra_configs,omitempty" tf:"force_new"`
-	Abfs    *AzureADLSGen2Mount `json:"abfs,omitempty" tf:"force_new"`
-	S3      *S3IamMount         `json:"s3,omitempty" tf:"force_new"`
-	Adl     *AzureADLSGen1Mount `json:"adl,omitempty" tf:"force_new"`
-	Wasb    *AzureBlobMount     `json:"wasb,omitempty" tf:"force_new"`
-	Gs      *GSMount            `json:"gs,omitempty" tf:"force_new"`
-
-	ClusterID string `json:"cluster_id,omitempty" tf:"computed,force_new"`
-	MountName string `json:"mount_name" tf:"force_new"`
-}
-
-// Source returns URI backing the mount
-func (m GenericMount) Source() string {
-	if m.Abfs != nil {
-		return m.Abfs.Source()
-	} else if m.Adl != nil {
-		return m.Adl.Source()
-	} else if m.Wasb != nil {
-		return m.Wasb.Source()
-	} else if m.S3 != nil {
-		return m.S3.Source()
-	} else if m.Gs != nil {
-		return m.Gs.Source()
-	}
-	return m.URI
-}
-
-// Config returns mount configurations
-func (m GenericMount) Config(client *common.DatabricksClient) map[string]string {
-	if m.Abfs != nil {
-		return m.Abfs.Config(client)
-	} else if m.Adl != nil {
-		return m.Adl.Config(client)
-	} else if m.Wasb != nil {
-		return m.Wasb.Config(client)
-	} else if m.S3 != nil {
-		return m.S3.Config(client)
-	} else if m.Gs != nil {
-		return m.Gs.Config(client)
-	}
-	return m.Options
-}
-
-func preprocessS3MountGeneric(ctx context.Context, s map[string]*schema.Schema, d *schema.ResourceData, m interface{}) error {
-	var gm GenericMount
-	if err := common.DataToStructPointer(d, s, &gm); err != nil {
-		return err
-	}
-	if !(strings.HasPrefix(gm.URI, "s3://") || strings.HasPrefix(gm.URI, "s3a://") || gm.S3 != nil) {
-		return nil
-	}
-	clusterID := gm.ClusterID
-	instanceProfile := ""
-	if gm.S3 != nil {
-		instanceProfile = gm.S3.InstanceProfile
-	}
-	if clusterID == "" && instanceProfile == "" {
-		return fmt.Errorf("either cluster_id or instance_profile must be specified to mount S3 bucket")
-	}
-	clustersAPI := compute.NewClustersAPI(ctx, m)
-	if clusterID != "" {
-		clusterInfo, err := clustersAPI.Get(clusterID)
-		if err != nil {
-			return err
-		}
-		if clusterInfo.AwsAttributes == nil {
-			return fmt.Errorf("cluster %s must have AWS attributes", clusterID)
-		}
-		if len(clusterInfo.AwsAttributes.InstanceProfileArn) == 0 {
-			return fmt.Errorf("cluster %s must have EC2 instance profile attached", clusterID)
-		}
-	}
-	if instanceProfile != "" {
-		cluster, err := GetOrCreateMountingClusterWithInstanceProfile(clustersAPI, instanceProfile)
-		if err != nil {
-			return err
-		}
-		return d.Set("cluster_id", cluster.ClusterID)
-	}
-	return nil
-}
-
-func preprocessGsMount(ctx context.Context, s map[string]*schema.Schema, d *schema.ResourceData, m interface{}) error {
-	var gm GenericMount
-	if err := common.DataToStructPointer(d, s, &gm); err != nil {
-		return err
-	}
-	if !(strings.HasPrefix(gm.URI, "gs://") || gm.Gs != nil) {
-		return nil
-	}
-	clusterID := gm.ClusterID
-	serviceAccount := ""
-	if gm.Gs != nil {
-		serviceAccount = gm.Gs.ServiceAccount
-	}
-	if clusterID == "" && serviceAccount == "" {
-		return fmt.Errorf("either cluster_id or service_account must be specified to mount GCS bucket")
-	}
-	clustersAPI := compute.NewClustersAPI(ctx, m)
-	if clusterID != "" {
-		clusterInfo, err := clustersAPI.Get(clusterID)
-		if err != nil {
-			return err
-		}
-		if clusterInfo.GcpAttributes == nil {
-			return fmt.Errorf("cluster %s must have GCP attributes", clusterID)
-		}
-		if len(clusterInfo.GcpAttributes.GoogleServiceAccount) == 0 {
-			return fmt.Errorf("cluster %s must have GCP service account attached", clusterID)
-		}
-	}
-	if serviceAccount != "" {
-		cluster, err := GetOrCreateMountingClusterWithGcpServiceAccount(clustersAPI, serviceAccount)
-		if err != nil {
-			return err
-		}
-		return d.Set("cluster_id", cluster.ClusterID)
-	}
-	return nil
-}
-
-// GetOrCreateMountingClusterWithInstanceProfile ...
-func GetOrCreateMountingClusterWithGcpServiceAccount(
-	clustersAPI compute.ClustersAPI, serviceAccount string) (i compute.ClusterInfo, err error) {
-	clusterName := fmt.Sprintf("terraform-mount-gcs-%x", md5.Sum([]byte(serviceAccount)))
-	cluster := getCommonClusterObject(clustersAPI, clusterName)
-	cluster.GcpAttributes = &compute.GcpAttributes{GoogleServiceAccount: serviceAccount}
-	return clustersAPI.GetOrCreateRunningCluster(clusterName, cluster)
-}
 
 // ResourceDatabricksMount mounts using given configuration
 func ResourceDatabricksMount() *schema.Resource {
@@ -205,6 +36,13 @@ func ResourceDatabricksMount() *schema.Resource {
 	r := commonMountResource(tpl, scm)
 	r.CreateContext = func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 		// TODO: convert data into struct here & pass instead of converting in function itself? it would be required for GS & others
+		var gm GenericMount
+		if err := common.DataToStructPointer(d, scm, &gm); err != nil {
+			return diag.FromErr(err)
+		}
+		if err := gm.ValidateAndApplyDefaults(d, m.(*common.DatabricksClient)); err != nil {
+			return diag.FromErr(err)
+		}
 		if err := preprocessS3MountGeneric(ctx, scm, d, m); err != nil {
 			return diag.FromErr(err)
 		}

--- a/storage/resource_mount.go
+++ b/storage/resource_mount.go
@@ -1,0 +1,49 @@
+package storage
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type GenericMount struct {
+	URI     string            `json:"source"`
+	Options map[string]string `json:"extra_configs"`
+}
+
+// Source returns URI backing the mount
+func (m GenericMount) Source() string {
+	return m.URI
+}
+
+// Config returns mount configurations
+func (m GenericMount) Config() map[string]string {
+	return m.Options
+}
+
+// TODO: https://databricks.slack.com/archives/D019B5E3RBJ/p1620837190043900
+// TODO: add a abfss / s3 / other blocks for mount special configs
+
+// ResourceDatabricksMount mounts using given configuration
+func ResourceDatabricksMount() *schema.Resource {
+	return commonMountResource(GenericMount{}, map[string]*schema.Schema{
+		"cluster_id": {
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+		},
+		"mount_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		"source": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		"extra_configs": {
+			Type:     schema.TypeMap,
+			Required: true,
+			ForceNew: true,
+		},
+	})
+}

--- a/storage/resource_mount.go
+++ b/storage/resource_mount.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"crypto/md5"
 	"fmt"
 	"strings"
 
@@ -11,14 +12,47 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+// AWSIamMount describes the object for a aws mount using iam role
+type S3IamMount struct {
+	BucketName      string `json:"bucket_name" tf:"force_new"`
+	InstanceProfile string `json:"instance_profile,omitempty" tf:"force_new"`
+}
+
+// Source ...
+func (m S3IamMount) Source() string {
+	return fmt.Sprintf("s3a://%s", m.BucketName)
+}
+
+// Config ...
+func (m S3IamMount) Config(client *common.DatabricksClient) map[string]string {
+	return make(map[string]string) // return empty map so nil map does not marshal to null
+}
+
+// GCSMount describes the object for a GCS mount using google service account
+type GCSMount struct {
+	BucketName     string `json:"bucket_name" tf:"force_new"`
+	ServiceAccount string `json:"service_account,omitempty" tf:"force_new"`
+}
+
+// Source ...
+func (m GCSMount) Source() string {
+	return fmt.Sprintf("gs://%s", m.BucketName)
+}
+
+// Config ...
+func (m GCSMount) Config(client *common.DatabricksClient) map[string]string {
+	return make(map[string]string) // return empty map so nil map does not marshal to null
+}
+
 // TODO: add support for encryption parameters in S3
 type GenericMount struct {
 	URI     string              `json:"uri,omitempty" tf:"force_new"`
 	Options map[string]string   `json:"extra_configs,omitempty" tf:"force_new"`
 	Abfss   *AzureADLSGen2Mount `json:"abfss,omitempty"`
-	S3      *AWSIamMount        `json:"s3,omitempty"`
+	S3      *S3IamMount         `json:"s3,omitempty"`
 	Adl     *AzureADLSGen1Mount `json:"adl,omitempty"`
 	Wasbs   *AzureBlobMount     `json:"wasbs,omitempty"`
+	Gcs     *GCSMount           `json:"gcs,omitempty"`
 
 	ClusterID string `json:"cluster_id,omitempty" tf:"computed"`
 	MountName string `json:"mount_name" tf:"force_new"`
@@ -34,6 +68,8 @@ func (m GenericMount) Source() string {
 		return m.Wasbs.Source()
 	} else if m.S3 != nil {
 		return m.S3.Source()
+	} else if m.Gcs != nil {
+		return m.Gcs.Source()
 	}
 	return m.URI
 }
@@ -48,6 +84,8 @@ func (m GenericMount) Config(client *common.DatabricksClient) map[string]string 
 		return m.Wasbs.Config(client)
 	} else if m.S3 != nil {
 		return m.S3.Config(client)
+	} else if m.Gcs != nil {
+		return m.Gcs.Config(client)
 	}
 	return m.Options
 }
@@ -61,7 +99,6 @@ func extractFieldNames(elem interface{}) []string {
 	return keys
 }
 
-// TODO: fix it
 func preprocessS3MountGeneric(ctx context.Context, s map[string]*schema.Schema, d *schema.ResourceData, m interface{}) error {
 	var gm GenericMount
 	if err := common.DataToStructPointer(d, s, &gm); err != nil {
@@ -101,6 +138,54 @@ func preprocessS3MountGeneric(ctx context.Context, s map[string]*schema.Schema, 
 	return nil
 }
 
+func preprocessGcsMount(ctx context.Context, s map[string]*schema.Schema, d *schema.ResourceData, m interface{}) error {
+	var gm GenericMount
+	if err := common.DataToStructPointer(d, s, &gm); err != nil {
+		return err
+	}
+	if !(strings.HasPrefix(gm.URI, "gs://") || gm.Gcs != nil) {
+		return nil
+	}
+	clusterID := gm.ClusterID
+	serviceAccount := ""
+	if gm.Gcs != nil {
+		serviceAccount = gm.Gcs.ServiceAccount
+	}
+	if clusterID == "" && serviceAccount == "" {
+		return fmt.Errorf("either cluster_id or service_account must be specified to mount GCS bucket")
+	}
+	clustersAPI := compute.NewClustersAPI(ctx, m)
+	if clusterID != "" {
+		clusterInfo, err := clustersAPI.Get(clusterID)
+		if err != nil {
+			return err
+		}
+		if clusterInfo.GcpAttributes == nil {
+			return fmt.Errorf("cluster %s must have GCP attributes", clusterID)
+		}
+		if len(clusterInfo.GcpAttributes.GoogleServiceAccount) == 0 {
+			return fmt.Errorf("cluster %s must have GCP service account attached", clusterID)
+		}
+	}
+	if serviceAccount != "" {
+		cluster, err := GetOrCreateMountingClusterWithGcpServiceAccount(clustersAPI, serviceAccount)
+		if err != nil {
+			return err
+		}
+		return d.Set("cluster_id", cluster.ClusterID)
+	}
+	return nil
+}
+
+// GetOrCreateMountingClusterWithInstanceProfile ...
+func GetOrCreateMountingClusterWithGcpServiceAccount(
+	clustersAPI compute.ClustersAPI, serviceAccount string) (i compute.ClusterInfo, err error) {
+	clusterName := fmt.Sprintf("terraform-mount-gcs-%x", md5.Sum([]byte(serviceAccount)))
+	cluster := getCommonClusterObject(clustersAPI, clusterName)
+	cluster.GcpAttributes = &compute.GcpAttributes{GoogleServiceAccount: serviceAccount}
+	return clustersAPI.GetOrCreateRunningCluster(clusterName, cluster)
+}
+
 // ResourceDatabricksMount mounts using given configuration
 func ResourceDatabricksMount() *schema.Resource {
 	tpl := GenericMount{}
@@ -110,13 +195,14 @@ func ResourceDatabricksMount() *schema.Resource {
 			Computed: true,
 		}
 
-		s["uri"].ConflictsWith = []string{"abfss", "wasbs", "s3", "adl"}
-		s["extra_configs"].ConflictsWith = []string{"abfss", "wasbs", "s3", "adl"}
-		s["abfss"].ConflictsWith = []string{"uri", "extra_configs", "wasbs", "s3", "adl"}
-		s["wasbs"].ConflictsWith = []string{"uri", "extra_configs", "abfss", "s3", "adl"}
-		s["s3"].ConflictsWith = []string{"uri", "extra_configs", "wasbs", "abfss", "adl"}
-		s["adl"].ConflictsWith = []string{"uri", "extra_configs", "wasbs", "s3", "abfss"}
-		blocks := []string{"abfss", "wasbs", "s3", "adl"}
+		s["uri"].ConflictsWith = []string{"abfss", "wasbs", "s3", "adl", "gcs"}
+		s["extra_configs"].ConflictsWith = []string{"abfss", "wasbs", "s3", "adl", "gcs"}
+		s["abfss"].ConflictsWith = []string{"uri", "extra_configs", "wasbs", "s3", "adl", "gcs"}
+		s["wasbs"].ConflictsWith = []string{"uri", "extra_configs", "abfss", "s3", "adl", "gcs"}
+		s["s3"].ConflictsWith = []string{"uri", "extra_configs", "wasbs", "abfss", "adl", "gcs"}
+		s["adl"].ConflictsWith = []string{"uri", "extra_configs", "wasbs", "s3", "abfss", "gcs"}
+		blocks := []string{"abfss", "wasbs", "s3", "adl", "gcs"}
+		// TODO: remove this when depricating other mount types (will require to add `force_new` annotation to structs as well)
 		for _, nm := range blocks {
 			s[nm].DiffSuppressFunc = common.MakeEmptyBlockSuppressFunc(nm)
 			s[nm].ForceNew = true
@@ -138,16 +224,25 @@ func ResourceDatabricksMount() *schema.Resource {
 		if err := preprocessS3MountGeneric(ctx, scm, d, m); err != nil {
 			return diag.FromErr(err)
 		}
+		if err := preprocessGcsMount(ctx, scm, d, m); err != nil {
+			return diag.FromErr(err)
+		}
 		return mountCreate(tpl, r)(ctx, d, m)
 	}
 	r.ReadContext = func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 		if err := preprocessS3MountGeneric(ctx, scm, d, m); err != nil {
 			return diag.FromErr(err)
 		}
+		if err := preprocessGcsMount(ctx, scm, d, m); err != nil {
+			return diag.FromErr(err)
+		}
 		return mountRead(tpl, r)(ctx, d, m)
 	}
 	r.DeleteContext = func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 		if err := preprocessS3MountGeneric(ctx, scm, d, m); err != nil {
+			return diag.FromErr(err)
+		}
+		if err := preprocessGcsMount(ctx, scm, d, m); err != nil {
 			return diag.FromErr(err)
 		}
 		return mountDelete(tpl, r)(ctx, d, m)

--- a/storage/resource_mount.go
+++ b/storage/resource_mount.go
@@ -24,10 +24,6 @@ func ResourceDatabricksMount() *schema.Resource {
 		s["s3"].ConflictsWith = []string{"uri", "extra_configs", "wasb", "abfs", "adl", "gs"}
 		s["adl"].ConflictsWith = []string{"uri", "extra_configs", "wasb", "s3", "abfs", "gs"}
 		s["gs"].ConflictsWith = []string{"uri", "extra_configs", "wasb", "s3", "abfs", "adl"}
-		blocks := []string{"abfs", "wasb", "s3", "adl", "gs"}
-		for _, nm := range blocks {
-			s[nm].DiffSuppressFunc = common.MakeEmptyBlockSuppressFunc(nm)
-		}
 		// TODO: We need to have a validation function that will check that source isn't empty if other blocks aren't specified
 
 		return s

--- a/storage/resource_mount.go
+++ b/storage/resource_mount.go
@@ -28,8 +28,7 @@ func preprocessResourceData(ctx context.Context, d *schema.ResourceData, scm map
 	return nil
 }
 
-// ResourceDatabricksMount mounts using given configuration
-func ResourceDatabricksMount() *schema.Resource {
+func ResourceDatabricksMountSchema() map[string]*schema.Schema {
 	tpl := GenericMount{}
 	scm := common.StructToSchema(tpl, func(s map[string]*schema.Schema) map[string]*schema.Schema {
 		s["source"] = &schema.Schema{
@@ -48,6 +47,13 @@ func ResourceDatabricksMount() *schema.Resource {
 
 		return s
 	})
+	return scm
+}
+
+// ResourceDatabricksMount mounts using given configuration
+func ResourceDatabricksMount() *schema.Resource {
+	tpl := GenericMount{}
+	scm := ResourceDatabricksMountSchema()
 
 	r := commonMountResource(tpl, scm)
 	r.CreateContext = func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/storage/resource_mount.go
+++ b/storage/resource_mount.go
@@ -1,49 +1,96 @@
 package storage
 
 import (
+	"github.com/databrickslabs/terraform-provider-databricks/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 type GenericMount struct {
-	URI     string            `json:"source"`
-	Options map[string]string `json:"extra_configs"`
+	URI     string              `json:"uri,omitempty"`
+	Options map[string]string   `json:"extra_configs,omitempty"`
+	Abfss   *AzureADLSGen2Mount `json:"abfss,omitempty"`
+	S3      *AWSIamMount        `json:"s3,omitempty"`
+	Adl     *AzureADLSGen1Mount `json:"adl,omitempty"`
+	Wasbs   *AzureBlobMount     `json:"wasbs,omitempty"`
 }
 
 // Source returns URI backing the mount
 func (m GenericMount) Source() string {
+	if m.Abfss != nil {
+		return m.Abfss.Source()
+	} else if m.Adl != nil {
+		m.Adl.Source()
+	} else if m.Wasbs != nil {
+		return m.Wasbs.Source()
+	} else if m.S3 != nil {
+		return m.S3.Source()
+	}
 	return m.URI
 }
 
 // Config returns mount configurations
 func (m GenericMount) Config() map[string]string {
+	if m.Abfss != nil {
+		return m.Abfss.Config()
+	} else if m.Adl != nil {
+		m.Adl.Config()
+	} else if m.Wasbs != nil {
+		return m.Wasbs.Config()
+	} else if m.S3 != nil {
+		return m.S3.Config()
+	}
 	return m.Options
 }
 
-// TODO: https://databricks.slack.com/archives/D019B5E3RBJ/p1620837190043900
-// TODO: add a abfss / s3 / other blocks for mount special configs
+func extractFieldNames(elem interface{}) []string {
+	m := elem.(*schema.Resource)
+	keys := make([]string, 0, len(m.Schema))
+	for k := range m.Schema {
+		keys = append(keys, k)
+	}
+	return keys
+}
 
 // ResourceDatabricksMount mounts using given configuration
 func ResourceDatabricksMount() *schema.Resource {
-	return commonMountResource(GenericMount{}, map[string]*schema.Schema{
-		"cluster_id": {
+	scm := common.StructToSchema(GenericMount{}, func(s map[string]*schema.Schema) map[string]*schema.Schema {
+		s["cluster_id"] = &schema.Schema{
 			Type:     schema.TypeString,
 			Optional: true,
-			ForceNew: true,
-		},
-		"mount_name": {
+			Computed: true,
+		}
+		s["mount_name"] = &schema.Schema{
 			Type:     schema.TypeString,
 			Required: true,
 			ForceNew: true,
-		},
-		"source": {
+		}
+		s["source"] = &schema.Schema{
 			Type:     schema.TypeString,
-			Required: true,
-			ForceNew: true,
-		},
-		"extra_configs": {
-			Type:     schema.TypeMap,
-			Required: true,
-			ForceNew: true,
-		},
+			Computed: true,
+		}
+		s["uri"].ConflictsWith = []string{"abfss", "wasbs", "s3", "adl"}
+		s["extra_configs"].ConflictsWith = []string{"abfss", "wasbs", "s3", "adl"}
+		s["abfss"].ConflictsWith = []string{"uri", "extra_configs", "wasbs", "s3", "adl"}
+		s["wasbs"].ConflictsWith = []string{"uri", "extra_configs", "abfss", "s3", "adl"}
+		s["s3"].ConflictsWith = []string{"uri", "extra_configs", "wasbs", "abfss", "adl"}
+		s["adl"].ConflictsWith = []string{"uri", "extra_configs", "wasbs", "s3", "abfss"}
+		s["uri"].ForceNew = true
+		s["extra_configs"].ForceNew = true
+		blocks := []string{"abfss", "wasbs", "s3", "adl"}
+		for _, nm := range blocks {
+			s[nm].DiffSuppressFunc = common.MakeEmptyBlockSuppressFunc(nm)
+			s[nm].ForceNew = true
+			for _, field := range extractFieldNames(s[nm].Elem) {
+				p, err := common.SchemaPath(s, nm, field)
+				if err == nil {
+					p.ForceNew = true
+				}
+			}
+		}
+		// TODO: We need to have a validation function that will check that source isn't empty if other blocks aren't specified
+
+		return s
 	})
+
+	return commonMountResource(GenericMount{}, scm)
 }

--- a/storage/resource_mount_test.go
+++ b/storage/resource_mount_test.go
@@ -494,7 +494,7 @@ func TestAzureAccADLSv2MountGeneric(t *testing.T) {
 	storageAccountName := qa.GetEnvOrSkipTest(t, "TEST_STORAGE_V2_ACCOUNT")
 	container := qa.GetEnvOrSkipTest(t, "TEST_STORAGE_V2_ABFSS")
 	testWithNewSecretScope(t, func(scope, key string) {
-		testMounting(t, mp, GenericMount{Abfss: &AzureADLSGen2Mount{
+		testMounting(t, mp, GenericMount{Abfs: &AzureADLSGen2Mount{
 			ClientID:             client.AzureClientID,
 			TenantID:             client.AzureTenantID,
 			StorageAccountName:   storageAccountName,
@@ -537,7 +537,7 @@ func TestResourceAdlsGen2MountGeneric_Create(t *testing.T) {
 		State: map[string]interface{}{
 			"cluster_id": "this_cluster",
 			"mount_name": "this_mount",
-			"abfss": []interface{}{map[string]interface{}{
+			"abfs": []interface{}{map[string]interface{}{
 				"storage_account_name":   "test-adls-gen2",
 				"container_name":         "e",
 				"tenant_id":              "a",
@@ -591,7 +591,7 @@ func TestResourceAzureBlobMountCreateGeneric(t *testing.T) {
 		State: map[string]interface{}{
 			"cluster_id": "b",
 			"mount_name": "e",
-			"wasbs": []interface{}{map[string]interface{}{
+			"wasb": []interface{}{map[string]interface{}{
 				"auth_type":            "ACCESS_KEY",
 				"storage_account_name": "f",
 				"token_secret_key":     "g",
@@ -628,7 +628,7 @@ func TestResourceAzureBlobMountCreateGeneric_Error(t *testing.T) {
 		State: map[string]interface{}{
 			"cluster_id": "b",
 			"mount_name": "e",
-			"wasbs": []interface{}{map[string]interface{}{
+			"wasb": []interface{}{map[string]interface{}{
 				"container_name":       "c",
 				"auth_type":            "ACCESS_KEY",
 				"directory":            "/d",
@@ -668,7 +668,7 @@ func TestResourceAzureBlobMountGeneric_Read(t *testing.T) {
 		State: map[string]interface{}{
 			"cluster_id": "b",
 			"mount_name": "e",
-			"wasbs": []interface{}{map[string]interface{}{
+			"wasb": []interface{}{map[string]interface{}{
 				"auth_type":            "ACCESS_KEY",
 				"container_name":       "c",
 				"directory":            "/d",
@@ -708,7 +708,7 @@ func TestResourceAzureBlobMountGenericRead_NotFound(t *testing.T) {
 		State: map[string]interface{}{
 			"cluster_id": "b",
 			"mount_name": "e",
-			"wasbs": []interface{}{map[string]interface{}{
+			"wasb": []interface{}{map[string]interface{}{
 				"auth_type":            "ACCESS_KEY",
 				"container_name":       "c",
 				"directory":            "/d",
@@ -746,7 +746,7 @@ func TestResourceAzureBlobMountGenericRead_Error(t *testing.T) {
 		State: map[string]interface{}{
 			"cluster_id": "b",
 			"mount_name": "e",
-			"wasbs": []interface{}{map[string]interface{}{
+			"wasb": []interface{}{map[string]interface{}{
 				"auth_type":            "ACCESS_KEY",
 				"container_name":       "c",
 				"directory":            "/d",
@@ -787,7 +787,7 @@ func TestResourceAzureBlobMountGenericDelete(t *testing.T) {
 		State: map[string]interface{}{
 			"cluster_id": "b",
 			"mount_name": "e",
-			"wasbs": []interface{}{map[string]interface{}{
+			"wasb": []interface{}{map[string]interface{}{
 				"auth_type":            "ACCESS_KEY",
 				"container_name":       "c",
 				"directory":            "/d",
@@ -810,7 +810,7 @@ func TestAzureAccBlobMountGeneric(t *testing.T) {
 	accountKey := qa.GetEnvOrSkipTest(t, "TEST_STORAGE_V2_KEY")
 	container := qa.GetEnvOrSkipTest(t, "TEST_STORAGE_V2_WASBS")
 	testWithNewSecretScope(t, func(scope, key string) {
-		testMounting(t, mp, GenericMount{Wasbs: &AzureBlobMount{
+		testMounting(t, mp, GenericMount{Wasb: &AzureBlobMount{
 			StorageAccountName: storageAccountName,
 			ContainerName:      container,
 			SecretScope:        scope,
@@ -857,7 +857,7 @@ func TestResourceGcsMountGenericCreate_WithCluster(t *testing.T) {
 		State: map[string]interface{}{
 			"cluster_id": "this_cluster",
 			"mount_name": "this_mount",
-			"gcs": []interface{}{map[string]interface{}{
+			"gs": []interface{}{map[string]interface{}{
 				"bucket_name": testS3BucketName,
 			}},
 		},
@@ -960,7 +960,7 @@ func TestResourceGcsMountGenericCreate_WithServiceAccount(t *testing.T) {
 		},
 		State: map[string]interface{}{
 			"mount_name": "this_mount",
-			"gcs": []interface{}{map[string]interface{}{
+			"gs": []interface{}{map[string]interface{}{
 				"bucket_name":     testS3BucketName,
 				"service_account": google_account,
 			}},
@@ -978,7 +978,7 @@ func TestResourceGcsMountGenericCreate_nothing_specified(t *testing.T) {
 		Resource: ResourceDatabricksMount(),
 		State: map[string]interface{}{
 			"mount_name": "this_mount",
-			"gcs": []interface{}{map[string]interface{}{
+			"gs": []interface{}{map[string]interface{}{
 				"bucket_name": testS3BucketName,
 			}},
 		},
@@ -994,7 +994,7 @@ func TestResourceGcsMountGenericCreate_nothing_specified(t *testing.T) {
 // 	accountKey := qa.GetEnvOrSkipTest(t, "TEST_STORAGE_V2_KEY")
 // 	container := qa.GetEnvOrSkipTest(t, "TEST_STORAGE_V2_WASBS")
 // 	testWithNewSecretScope(t, func(scope, key string) {
-// 		testMounting(t, mp, GenericMount{Wasbs: &AzureBlobMount{
+// 		testMounting(t, mp, GenericMount{Wasb: &AzureBlobMount{
 // 			StorageAccountName: storageAccountName,
 // 			ContainerName:      container,
 // 			SecretScope:        scope,

--- a/storage/resource_mount_test.go
+++ b/storage/resource_mount_test.go
@@ -124,11 +124,12 @@ func TestResourceAwsS3MountGenericCreate_WithInstanceProfile(t *testing.T) {
 								Availability:       "SPOT",
 							},
 							AutoterminationMinutes: 10,
-							SparkConf:              map[string]string{"spark.databricks.cluster.profile": "singleNode", "spark.master": "local[*]"},
-							CustomTags:             map[string]string{"ResourceClass": "SingleNode"},
-							ClusterName:            clusterName,
-							SparkVersion:           "7.3.x-scala2.12",
-							NumWorkers:             0,
+							SparkConf: map[string]string{"spark.databricks.cluster.profile": "singleNode",
+								"spark.master": "local[*]", "spark.scheduler.mode": "FIFO"},
+							CustomTags:   map[string]string{"ResourceClass": "SingleNode"},
+							ClusterName:  clusterName,
+							SparkVersion: "7.3.x-scala2.12",
+							NumWorkers:   0,
 						},
 					},
 				},
@@ -156,11 +157,12 @@ func TestResourceAwsS3MountGenericCreate_WithInstanceProfile(t *testing.T) {
 						Availability:       "SPOT",
 					},
 					AutoterminationMinutes: 10,
-					SparkConf:              map[string]string{"spark.databricks.cluster.profile": "singleNode", "spark.master": "local[*]"},
-					CustomTags:             map[string]string{"ResourceClass": "SingleNode"},
-					ClusterName:            clusterName,
-					SparkVersion:           "7.3.x-scala2.12",
-					NumWorkers:             0,
+					SparkConf: map[string]string{"spark.databricks.cluster.profile": "singleNode",
+						"spark.master": "local[*]", "spark.scheduler.mode": "FIFO"},
+					CustomTags:   map[string]string{"ResourceClass": "SingleNode"},
+					ClusterName:  clusterName,
+					SparkVersion: "7.3.x-scala2.12",
+					NumWorkers:   0,
 				},
 				Response: compute.ClusterID{
 					ClusterID: "abcd",
@@ -427,7 +429,7 @@ func TestAzureAccADLSv1MountGeneric(t *testing.T) {
 	storageResource := qa.GetEnvOrSkipTest(t, "TEST_DATA_LAKE_STORE_NAME")
 	testWithNewSecretScope(t, func(scope, key string) {
 		testMounting(t, mp,
-			GenericMount{Adl: &AzureADLSGen1Mount{
+			GenericMount{Adl: &AzureADLSGen1MountGeneric{
 				ClientID:        client.AzureClientID,
 				TenantID:        client.AzureTenantID,
 				PrefixType:      "dfs.adls",
@@ -494,7 +496,7 @@ func TestAzureAccADLSv2MountGeneric(t *testing.T) {
 	storageAccountName := qa.GetEnvOrSkipTest(t, "TEST_STORAGE_V2_ACCOUNT")
 	container := qa.GetEnvOrSkipTest(t, "TEST_STORAGE_V2_ABFSS")
 	testWithNewSecretScope(t, func(scope, key string) {
-		testMounting(t, mp, GenericMount{Abfs: &AzureADLSGen2Mount{
+		testMounting(t, mp, GenericMount{Abfs: &AzureADLSGen2MountGeneric{
 			ClientID:             client.AzureClientID,
 			TenantID:             client.AzureTenantID,
 			StorageAccountName:   storageAccountName,
@@ -810,7 +812,7 @@ func TestAzureAccBlobMountGeneric(t *testing.T) {
 	accountKey := qa.GetEnvOrSkipTest(t, "TEST_STORAGE_V2_KEY")
 	container := qa.GetEnvOrSkipTest(t, "TEST_STORAGE_V2_WASBS")
 	testWithNewSecretScope(t, func(scope, key string) {
-		testMounting(t, mp, GenericMount{Wasb: &AzureBlobMount{
+		testMounting(t, mp, GenericMount{Wasb: &AzureBlobMountGeneric{
 			StorageAccountName: storageAccountName,
 			ContainerName:      container,
 			SecretScope:        scope,
@@ -902,11 +904,12 @@ func TestResourceGcsMountGenericCreate_WithServiceAccount(t *testing.T) {
 								GoogleServiceAccount: google_account,
 							},
 							AutoterminationMinutes: 10,
-							SparkConf:              map[string]string{"spark.databricks.cluster.profile": "singleNode", "spark.master": "local[*]"},
-							CustomTags:             map[string]string{"ResourceClass": "SingleNode"},
-							ClusterName:            clusterName,
-							SparkVersion:           "7.3.x-scala2.12",
-							NumWorkers:             0,
+							SparkConf: map[string]string{"spark.databricks.cluster.profile": "singleNode",
+								"spark.master": "local[*]", "spark.scheduler.mode": "FIFO"},
+							CustomTags:   map[string]string{"ResourceClass": "SingleNode"},
+							ClusterName:  clusterName,
+							SparkVersion: "7.3.x-scala2.12",
+							NumWorkers:   0,
 						},
 					},
 				},
@@ -933,11 +936,12 @@ func TestResourceGcsMountGenericCreate_WithServiceAccount(t *testing.T) {
 						GoogleServiceAccount: "acc@acc-dbx.iam.gserviceaccount.com",
 					},
 					AutoterminationMinutes: 10,
-					SparkConf:              map[string]string{"spark.databricks.cluster.profile": "singleNode", "spark.master": "local[*]"},
-					CustomTags:             map[string]string{"ResourceClass": "SingleNode"},
-					ClusterName:            clusterName,
-					SparkVersion:           "7.3.x-scala2.12",
-					NumWorkers:             0,
+					SparkConf: map[string]string{"spark.databricks.cluster.profile": "singleNode",
+						"spark.master": "local[*]", "spark.scheduler.mode": "FIFO"},
+					CustomTags:   map[string]string{"ResourceClass": "SingleNode"},
+					ClusterName:  clusterName,
+					SparkVersion: "7.3.x-scala2.12",
+					NumWorkers:   0,
 				},
 				Response: compute.ClusterID{
 					ClusterID: "abcd",

--- a/storage/resource_mount_test.go
+++ b/storage/resource_mount_test.go
@@ -224,7 +224,7 @@ func TestResourceAwsS3MountGenericCreate_invalid_arn(t *testing.T) {
 		},
 		Create: true,
 	}.Apply(t)
-	require.EqualError(t, err, "arn: invalid prefix")
+	require.EqualError(t, err, "invalid arn: this_mount")
 }
 
 func TestResourceAwsS3MountGenericRead(t *testing.T) {

--- a/storage/resource_mount_test.go
+++ b/storage/resource_mount_test.go
@@ -1,0 +1,1049 @@
+package storage
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/databrickslabs/terraform-provider-databricks/common"
+	"github.com/databrickslabs/terraform-provider-databricks/compute"
+	"github.com/databrickslabs/terraform-provider-databricks/identity"
+	"github.com/databrickslabs/terraform-provider-databricks/internal"
+
+	"github.com/databrickslabs/terraform-provider-databricks/qa"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ============================== AWS S3 Tests ==============================
+
+// Test interface compliance via compile time error
+var _ Mount = (*S3IamMount)(nil)
+
+var sparkVersionsResponse = compute.SparkVersionsList{
+	SparkVersions: []compute.SparkVersion{
+		{
+			Version:     "7.3.x-scala2.12",
+			Description: "7.3 LTS (includes Apache Spark 3.0.1, Scala 2.12)",
+		},
+	},
+}
+
+var nodeListResponse = compute.NodeTypeList{
+	NodeTypes: []compute.NodeType{
+		{
+			NodeTypeID:     "Standard_F4s",
+			InstanceTypeID: "Standard_F4s",
+			MemoryMB:       8192,
+			NumCores:       4,
+			NodeInstanceType: &compute.NodeInstanceType{
+				LocalDisks:      1,
+				LocalDiskSizeGB: 16,
+				LocalNVMeDisks:  0,
+			},
+		},
+	},
+}
+
+func TestResourceAwsS3MountGenericCreate(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				ReuseRequest: true,
+				Resource:     "/api/2.0/clusters/get?cluster_id=this_cluster",
+				Response: compute.ClusterInfo{
+					State: compute.ClusterStateRunning,
+					AwsAttributes: &compute.AwsAttributes{
+						InstanceProfileArn: "abc",
+					},
+				},
+			},
+		},
+		Resource: ResourceDatabricksMount(),
+		CommandMock: func(commandStr string) common.CommandResults {
+			trunc := internal.TrimLeadingWhitespace(commandStr)
+			t.Logf("Received command:\n%s", trunc)
+			if strings.HasPrefix(trunc, "def safe_mount") {
+				assert.Contains(t, trunc, testS3BucketPath) // bucketname
+				assert.Contains(t, trunc, `{}`)             // empty brackets for empty config
+			}
+			assert.Contains(t, trunc, "/mnt/this_mount")
+			return common.CommandResults{
+				ResultType: "text",
+				Data:       testS3BucketPath,
+			}
+		},
+		State: map[string]interface{}{
+			"cluster_id": "this_cluster",
+			"mount_name": "this_mount",
+			"s3": []interface{}{map[string]interface{}{
+				"bucket_name": testS3BucketName,
+			}},
+		},
+		Create: true,
+	}.Apply(t)
+	require.NoError(t, err, err)
+	assert.Equal(t, "this_mount", d.Id())
+	assert.Equal(t, testS3BucketPath, d.Get("source"))
+}
+
+func TestResourceAwsS3MountGenericCreate_WithInstanceProfile(t *testing.T) {
+	instance_profile := "arn:aws:iam::1234567:instance-profile/s3-access"
+	clusterName := "terraform-mount-s3-access"
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				ReuseRequest: true,
+				Resource:     "/api/2.0/clusters/get?cluster_id=abcd",
+				Response: compute.ClusterInfo{
+					ClusterID: "abcd",
+					State:     compute.ClusterStateRunning,
+					AwsAttributes: &compute.AwsAttributes{
+						InstanceProfileArn: instance_profile,
+						Availability:       "SPOT",
+					},
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/clusters/list",
+				Response: map[string]interface{}{},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/clusters/list",
+				Response: compute.ClusterList{
+					Clusters: []compute.ClusterInfo{
+						{
+							ClusterID: "abcd",
+							State:     compute.ClusterStateRunning,
+							AwsAttributes: &compute.AwsAttributes{
+								InstanceProfileArn: instance_profile,
+								Availability:       "SPOT",
+							},
+							AutoterminationMinutes: 10,
+							SparkConf:              map[string]string{"spark.databricks.cluster.profile": "singleNode", "spark.master": "local[*]"},
+							CustomTags:             map[string]string{"ResourceClass": "SingleNode"},
+							ClusterName:            clusterName,
+							SparkVersion:           "7.3.x-scala2.12",
+							NumWorkers:             0,
+						},
+					},
+				},
+			},
+			{
+				Method:       "GET",
+				Resource:     "/api/2.0/clusters/spark-versions",
+				Response:     sparkVersionsResponse,
+				ReuseRequest: true,
+			},
+			{
+				Method:       "GET",
+				Resource:     "/api/2.0/clusters/list-node-types",
+				ReuseRequest: true,
+				Response:     nodeListResponse,
+			},
+			{
+				Method:       "POST",
+				Resource:     "/api/2.0/clusters/create",
+				ReuseRequest: true,
+				ExpectedRequest: compute.Cluster{
+					NodeTypeID: "Standard_F4s",
+					AwsAttributes: &compute.AwsAttributes{
+						InstanceProfileArn: instance_profile,
+						Availability:       "SPOT",
+					},
+					AutoterminationMinutes: 10,
+					SparkConf:              map[string]string{"spark.databricks.cluster.profile": "singleNode", "spark.master": "local[*]"},
+					CustomTags:             map[string]string{"ResourceClass": "SingleNode"},
+					ClusterName:            clusterName,
+					SparkVersion:           "7.3.x-scala2.12",
+					NumWorkers:             0,
+				},
+				Response: compute.ClusterID{
+					ClusterID: "abcd",
+				},
+			},
+		},
+		Resource: ResourceDatabricksMount(),
+		CommandMock: func(commandStr string) common.CommandResults {
+			trunc := internal.TrimLeadingWhitespace(commandStr)
+			t.Logf("Received command:\n%s", trunc)
+			if strings.HasPrefix(trunc, "def safe_mount") {
+				assert.Contains(t, trunc, testS3BucketPath) // bucketname
+				assert.Contains(t, trunc, `{}`)             // empty brackets for empty config
+			}
+			assert.Contains(t, trunc, "/mnt/this_mount")
+			return common.CommandResults{
+				ResultType: "text",
+				Data:       testS3BucketPath,
+			}
+		},
+		State: map[string]interface{}{
+			"mount_name": "this_mount",
+			"s3": []interface{}{map[string]interface{}{
+				"bucket_name":      testS3BucketName,
+				"instance_profile": instance_profile,
+			}},
+		},
+		Create: true,
+	}.Apply(t)
+	require.NoError(t, err, err)
+	assert.Equal(t, "this_mount", d.Id())
+	assert.Equal(t, "abcd", d.Get("cluster_id"))
+	assert.Equal(t, testS3BucketPath, d.Get("source"))
+}
+
+func TestResourceAwsS3MountGenericCreate_nothing_specified(t *testing.T) {
+	_, err := qa.ResourceFixture{
+		Resource: ResourceDatabricksMount(),
+		State: map[string]interface{}{
+			"mount_name": "this_mount",
+			"s3": []interface{}{map[string]interface{}{
+				"bucket_name": testS3BucketName,
+			}},
+		},
+		Create: true,
+	}.Apply(t)
+	require.EqualError(t, err, "either cluster_id or instance_profile must be specified to mount S3 bucket")
+}
+
+func TestResourceAwsS3MountGenericCreate_invalid_arn(t *testing.T) {
+	_, err := qa.ResourceFixture{
+		Resource: ResourceDatabricksMount(),
+		State: map[string]interface{}{
+			"mount_name": "this_mount",
+			"s3": []interface{}{map[string]interface{}{
+				"bucket_name":      testS3BucketName,
+				"instance_profile": "this_mount",
+			}},
+		},
+		Create: true,
+	}.Apply(t)
+	require.EqualError(t, err, "arn: invalid prefix")
+}
+
+func TestResourceAwsS3MountGenericRead(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				ReuseRequest: true,
+				Resource:     "/api/2.0/clusters/get?cluster_id=this_cluster",
+				Response: compute.ClusterInfo{
+					State: compute.ClusterStateRunning,
+					AwsAttributes: &compute.AwsAttributes{
+						InstanceProfileArn: "abc",
+					},
+				},
+			},
+		},
+		Resource: ResourceDatabricksMount(),
+		CommandMock: func(commandStr string) common.CommandResults {
+			trunc := internal.TrimLeadingWhitespace(commandStr)
+			t.Logf("Received command:\n%s", trunc)
+			assert.Contains(t, trunc, "dbutils.fs.mounts()")
+			assert.Contains(t, trunc, `mount.mountPoint == "/mnt/this_mount"`)
+			return common.CommandResults{
+				ResultType: "text",
+				Data:       testS3BucketPath,
+			}
+		},
+		State: map[string]interface{}{
+			"cluster_id": "this_cluster",
+			"mount_name": "this_mount",
+			"s3": []interface{}{map[string]interface{}{
+				"bucket_name": testS3BucketName,
+			}},
+		},
+		ID:   "this_mount",
+		Read: true,
+	}.Apply(t)
+	require.NoError(t, err)
+	assert.Equal(t, "this_mount", d.Id())
+	assert.Equal(t, testS3BucketPath, d.Get("source"))
+}
+
+func TestResourceAwsS3MountGenericRead_NotFound(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				ReuseRequest: true,
+				Resource:     "/api/2.0/clusters/get?cluster_id=this_cluster",
+				Response: compute.ClusterInfo{
+					State: compute.ClusterStateRunning,
+					AwsAttributes: &compute.AwsAttributes{
+						InstanceProfileArn: "abc",
+					},
+				},
+			},
+		},
+		Resource: ResourceDatabricksMount(),
+		CommandMock: func(commandStr string) common.CommandResults {
+			trunc := internal.TrimLeadingWhitespace(commandStr)
+			t.Logf("Received command:\n%s", trunc)
+			return common.CommandResults{
+				ResultType: "error",
+				Summary:    "Mount not found",
+			}
+		},
+		State: map[string]interface{}{
+			"cluster_id": "this_cluster",
+			"mount_name": "this_mount",
+			"s3": []interface{}{map[string]interface{}{
+				"bucket_name": testS3BucketName,
+			}},
+		},
+		ID:      "this_mount",
+		Read:    true,
+		Removed: true,
+	}.ApplyNoError(t)
+}
+
+func TestResourceAwsS3MountGenericRead_Error(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				ReuseRequest: true,
+				Resource:     "/api/2.0/clusters/get?cluster_id=this_cluster",
+				Response: compute.ClusterInfo{
+					State: compute.ClusterStateRunning,
+					AwsAttributes: &compute.AwsAttributes{
+						InstanceProfileArn: "abc",
+					},
+				},
+			},
+		},
+		Resource: ResourceDatabricksMount(),
+		CommandMock: func(commandStr string) common.CommandResults {
+			trunc := internal.TrimLeadingWhitespace(commandStr)
+			t.Logf("Received command:\n%s", trunc)
+			return common.CommandResults{
+				ResultType: "error",
+				Summary:    "Some error",
+			}
+		},
+		State: map[string]interface{}{
+			"cluster_id": "this_cluster",
+			"mount_name": "this_mount",
+			"s3": []interface{}{map[string]interface{}{
+				"bucket_name": testS3BucketName,
+			}},
+		},
+		ID:   "this_mount",
+		Read: true,
+	}.Apply(t)
+	require.EqualError(t, err, "Some error")
+	assert.Equal(t, "this_mount", d.Id())
+	assert.Equal(t, "", d.Get("source"))
+}
+
+func TestResourceAwsS3MountDeleteGeneric(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				ReuseRequest: true,
+				Resource:     "/api/2.0/clusters/get?cluster_id=this_cluster",
+				Response: compute.ClusterInfo{
+					State: compute.ClusterStateRunning,
+					AwsAttributes: &compute.AwsAttributes{
+						InstanceProfileArn: "abc",
+					},
+				},
+			},
+		},
+		Resource: ResourceDatabricksMount(),
+		CommandMock: func(commandStr string) common.CommandResults {
+			trunc := internal.TrimLeadingWhitespace(commandStr)
+			t.Logf("Received command:\n%s", trunc)
+			assert.Contains(t, trunc, "/mnt/this_mount")
+			assert.Contains(t, trunc, "dbutils.fs.unmount(mount_point)")
+			return common.CommandResults{
+				ResultType: "text",
+				Data:       "",
+			}
+		},
+		State: map[string]interface{}{
+			"cluster_id": "this_cluster",
+			"mount_name": "this_mount",
+			"s3": []interface{}{map[string]interface{}{
+				"bucket_name": testS3BucketName,
+			}},
+		},
+		ID:     "this_mount",
+		Delete: true,
+	}.Apply(t)
+	require.NoError(t, err)
+	assert.Equal(t, "this_mount", d.Id())
+	assert.Equal(t, "", d.Get("source"))
+}
+
+func TestAwsAccS3MountGeneric(t *testing.T) {
+	client := common.NewClientFromEnvironment()
+	instanceProfile := qa.GetEnvOrSkipTest(t, "TEST_EC2_INSTANCE_PROFILE")
+	ctx := context.WithValue(context.Background(), common.Current, t.Name())
+	instanceProfilesAPI := identity.NewInstanceProfilesAPI(ctx, client)
+	instanceProfilesAPI.Synchronized(instanceProfile, func() bool {
+		if err := instanceProfilesAPI.Create(identity.InstanceProfileInfo{
+			InstanceProfileArn: instanceProfile,
+		}); err != nil {
+			return false
+		}
+		bucket := qa.GetEnvOrSkipTest(t, "TEST_S3_BUCKET")
+		client := compute.CommonEnvironmentClientWithRealCommandExecutor()
+		clustersAPI := compute.NewClustersAPI(ctx, client)
+		clusterInfo, err := GetOrCreateMountingClusterWithInstanceProfile(
+			clustersAPI, instanceProfile)
+		require.NoError(t, err)
+		defer func() {
+			err = clustersAPI.PermanentDelete(clusterInfo.ClusterID)
+			assert.NoError(t, err)
+			err = instanceProfilesAPI.Delete(instanceProfile)
+			assert.NoError(t, err)
+		}()
+		testMounting(t, MountPoint{
+			exec:      client.CommandExecutor(ctx),
+			clusterID: clusterInfo.ClusterID,
+			name:      qa.RandomName("t"),
+		}, GenericMount{
+			S3: &S3IamMount{BucketName: bucket},
+		})
+		return true
+	})
+}
+
+// ============================== ADLS Gen1 Tests ==============================
+
+func TestAzureAccADLSv1MountGeneric(t *testing.T) {
+	client, mp := mountPointThroughReusedCluster(t)
+	if !client.IsAzureClientSecretSet() {
+		t.Skip("Test is meant only for client-secret conf Azure")
+	}
+	storageResource := qa.GetEnvOrSkipTest(t, "TEST_DATA_LAKE_STORE_NAME")
+	testWithNewSecretScope(t, func(scope, key string) {
+		testMounting(t, mp,
+			GenericMount{Adl: &AzureADLSGen1Mount{
+				ClientID:        client.AzureClientID,
+				TenantID:        client.AzureTenantID,
+				PrefixType:      "dfs.adls",
+				StorageResource: storageResource,
+				Directory:       "/",
+				SecretScope:     scope,
+				SecretKey:       key,
+			}})
+	}, client, mp.name, client.AzureClientSecret)
+}
+
+func TestResourceAdlsGen1MountGeneric_Create(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				ReuseRequest: true,
+				Resource:     "/api/2.0/clusters/get?cluster_id=this_cluster",
+				Response: compute.ClusterInfo{
+					State: compute.ClusterStateRunning,
+				},
+			},
+		},
+		Resource: ResourceDatabricksMount(),
+		CommandMock: func(commandStr string) common.CommandResults {
+			trunc := internal.TrimLeadingWhitespace(commandStr)
+			t.Logf("Received command:\n%s", trunc)
+			if strings.HasPrefix(trunc, "def safe_mount") {
+				assert.Contains(t, trunc, "adl://test-adls.azuredatalakestore.net")
+				assert.Contains(t, trunc, `"fs.adl.oauth2.credential":dbutils.secrets.get("c", "d")`)
+			}
+			assert.Contains(t, trunc, "/mnt/this_mount")
+			return common.CommandResults{
+				ResultType: "text",
+				Data:       testS3BucketPath,
+			}
+		},
+		State: map[string]interface{}{
+			"cluster_id": "this_cluster",
+			"mount_name": "this_mount",
+			"adl": []interface{}{map[string]interface{}{
+				"storage_resource_name": "test-adls",
+				"tenant_id":             "a",
+				"client_id":             "b",
+				"client_secret_scope":   "c",
+				"client_secret_key":     "d",
+				"spark_conf_prefix":     "fs.adl",
+			}},
+		},
+		Create: true,
+	}.Apply(t)
+	require.NoError(t, err, err)
+	assert.Equal(t, "this_mount", d.Id())
+	assert.Equal(t, testS3BucketPath, d.Get("source"))
+}
+
+// ============================== ADLS Gen2 Tests ==============================
+
+func TestAzureAccADLSv2MountGeneric(t *testing.T) {
+	client, mp := mountPointThroughReusedCluster(t)
+	if !client.IsAzureClientSecretSet() {
+		t.Skip("Test is meant only for client-secret conf Azure")
+	}
+	storageAccountName := qa.GetEnvOrSkipTest(t, "TEST_STORAGE_V2_ACCOUNT")
+	container := qa.GetEnvOrSkipTest(t, "TEST_STORAGE_V2_ABFSS")
+	testWithNewSecretScope(t, func(scope, key string) {
+		testMounting(t, mp, GenericMount{Abfss: &AzureADLSGen2Mount{
+			ClientID:             client.AzureClientID,
+			TenantID:             client.AzureTenantID,
+			StorageAccountName:   storageAccountName,
+			ContainerName:        container,
+			SecretScope:          scope,
+			SecretKey:            key,
+			InitializeFileSystem: true,
+			Directory:            "/",
+		},
+		})
+	}, client, mp.name, client.AzureClientSecret)
+}
+
+func TestResourceAdlsGen2MountGeneric_Create(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				ReuseRequest: true,
+				Resource:     "/api/2.0/clusters/get?cluster_id=this_cluster",
+				Response: compute.ClusterInfo{
+					State: compute.ClusterStateRunning,
+				},
+			},
+		},
+		Resource: ResourceDatabricksMount(),
+		CommandMock: func(commandStr string) common.CommandResults {
+			trunc := internal.TrimLeadingWhitespace(commandStr)
+			t.Logf("Received command:\n%s", trunc)
+			if strings.HasPrefix(trunc, "def safe_mount") {
+				assert.Contains(t, trunc, "abfss://e@test-adls-gen2.dfs.core.windows.net")
+				assert.Contains(t, trunc, `"fs.azure.account.oauth2.client.secret":dbutils.secrets.get("c", "d")`)
+			}
+			assert.Contains(t, trunc, "/mnt/this_mount")
+			return common.CommandResults{
+				ResultType: "text",
+				Data:       "abfss://e@test-adls-gen2.dfs.core.windows.net",
+			}
+		},
+		State: map[string]interface{}{
+			"cluster_id": "this_cluster",
+			"mount_name": "this_mount",
+			"abfss": []interface{}{map[string]interface{}{
+				"storage_account_name":   "test-adls-gen2",
+				"container_name":         "e",
+				"tenant_id":              "a",
+				"client_id":              "b",
+				"client_secret_scope":    "c",
+				"client_secret_key":      "d",
+				"initialize_file_system": true,
+			}}},
+		Create: true,
+	}.Apply(t)
+	require.NoError(t, err, err)
+	assert.Equal(t, "this_mount", d.Id())
+	assert.Equal(t, "abfss://e@test-adls-gen2.dfs.core.windows.net", d.Get("source"))
+}
+
+// ============================== Azure Blob Storage Tests ==============================
+
+func TestResourceAzureBlobMountCreateGeneric(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/clusters/get?cluster_id=b",
+				Response: compute.ClusterInfo{
+					State: compute.ClusterStateRunning,
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/clusters/get?cluster_id=b",
+				Response: compute.ClusterInfo{
+					State: compute.ClusterStateRunning,
+				},
+			},
+		},
+		Resource: ResourceDatabricksMount(),
+		CommandMock: func(commandStr string) common.CommandResults {
+			trunc := internal.TrimLeadingWhitespace(commandStr)
+			t.Logf("Received command:\n%s", trunc)
+
+			if strings.HasPrefix(trunc, "def safe_mount") {
+				assert.Contains(t, trunc, "wasbs://c@f.blob.core.windows.net/d")
+				assert.Contains(t, trunc, `"fs.azure.account.key.f.blob.core.windows.net":dbutils.secrets.get("h", "g")`)
+			}
+			assert.Contains(t, trunc, "/mnt/e")
+			return common.CommandResults{
+				ResultType: "text",
+				Data:       "wasbs://c@f.blob.core.windows.net/d",
+			}
+		},
+		State: map[string]interface{}{
+			"cluster_id": "b",
+			"mount_name": "e",
+			"wasbs": []interface{}{map[string]interface{}{
+				"auth_type":            "ACCESS_KEY",
+				"storage_account_name": "f",
+				"token_secret_key":     "g",
+				"token_secret_scope":   "h",
+				"container_name":       "c",
+				"directory":            "/d",
+			},
+			}},
+		Create: true,
+	}.Apply(t)
+	require.NoError(t, err, err) // TODO: global search-replace for NoError
+	assert.Equal(t, "e", d.Id())
+	assert.Equal(t, "wasbs://c@f.blob.core.windows.net/d", d.Get("source"))
+}
+
+func TestResourceAzureBlobMountCreateGeneric_Error(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/clusters/get?cluster_id=b",
+				Response: compute.ClusterInfo{
+					State: compute.ClusterStateRunning,
+				},
+			},
+		},
+		Resource: ResourceDatabricksMount(),
+		CommandMock: func(commandStr string) common.CommandResults {
+			return common.CommandResults{
+				ResultType: "error",
+				Summary:    "Some error",
+			}
+		},
+		State: map[string]interface{}{
+			"cluster_id": "b",
+			"mount_name": "e",
+			"wasbs": []interface{}{map[string]interface{}{
+				"container_name":       "c",
+				"auth_type":            "ACCESS_KEY",
+				"directory":            "/d",
+				"storage_account_name": "f",
+				"token_secret_key":     "g",
+				"token_secret_scope":   "h",
+			}}},
+		Create: true,
+	}.Apply(t)
+	require.EqualError(t, err, "Some error")
+	assert.Equal(t, "e", d.Id())
+	assert.Equal(t, "", d.Get("source"))
+}
+
+func TestResourceAzureBlobMountGeneric_Read(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/clusters/get?cluster_id=b",
+				Response: compute.ClusterInfo{
+					State: compute.ClusterStateRunning,
+				},
+			},
+		},
+		Resource: ResourceDatabricksMount(),
+		CommandMock: func(commandStr string) common.CommandResults {
+			trunc := internal.TrimLeadingWhitespace(commandStr)
+			t.Logf("Received command:\n%s", trunc)
+			assert.Contains(t, trunc, "dbutils.fs.mounts()")
+			assert.Contains(t, trunc, `mount.mountPoint == "/mnt/e"`)
+			return common.CommandResults{
+				ResultType: "text",
+				Data:       "wasbs://c@f.blob.core.windows.net/d",
+			}
+		},
+		State: map[string]interface{}{
+			"cluster_id": "b",
+			"mount_name": "e",
+			"wasbs": []interface{}{map[string]interface{}{
+				"auth_type":            "ACCESS_KEY",
+				"container_name":       "c",
+				"directory":            "/d",
+				"storage_account_name": "f",
+				"token_secret_key":     "g",
+				"token_secret_scope":   "h",
+			}},
+		},
+		ID:   "e",
+		Read: true,
+	}.Apply(t)
+	require.NoError(t, err)
+	assert.Equal(t, "e", d.Id())
+	assert.Equal(t, "wasbs://c@f.blob.core.windows.net/d", d.Get("source"))
+}
+
+func TestResourceAzureBlobMountGenericRead_NotFound(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/clusters/get?cluster_id=b",
+				Response: compute.ClusterInfo{
+					State: compute.ClusterStateRunning,
+				},
+			},
+		},
+		Resource: ResourceDatabricksMount(),
+		CommandMock: func(commandStr string) common.CommandResults {
+			trunc := internal.TrimLeadingWhitespace(commandStr)
+			t.Logf("Received command:\n%s", trunc)
+			return common.CommandResults{
+				ResultType: "error",
+				Summary:    "Mount not found",
+			}
+		},
+		State: map[string]interface{}{
+			"cluster_id": "b",
+			"mount_name": "e",
+			"wasbs": []interface{}{map[string]interface{}{
+				"auth_type":            "ACCESS_KEY",
+				"container_name":       "c",
+				"directory":            "/d",
+				"storage_account_name": "f",
+				"token_secret_key":     "g",
+				"token_secret_scope":   "h",
+			}},
+		},
+		ID:      "e",
+		Read:    true,
+		Removed: true,
+	}.ApplyNoError(t)
+}
+
+func TestResourceAzureBlobMountGenericRead_Error(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/clusters/get?cluster_id=b",
+				Response: compute.ClusterInfo{
+					State: compute.ClusterStateRunning,
+				},
+			},
+		},
+		Resource: ResourceDatabricksMount(),
+		CommandMock: func(commandStr string) common.CommandResults {
+			trunc := internal.TrimLeadingWhitespace(commandStr)
+			t.Logf("Received command:\n%s", trunc)
+			return common.CommandResults{
+				ResultType: "error",
+				Summary:    "Some error",
+			}
+		},
+		State: map[string]interface{}{
+			"cluster_id": "b",
+			"mount_name": "e",
+			"wasbs": []interface{}{map[string]interface{}{
+				"auth_type":            "ACCESS_KEY",
+				"container_name":       "c",
+				"directory":            "/d",
+				"storage_account_name": "f",
+				"token_secret_key":     "g",
+				"token_secret_scope":   "h",
+			}},
+		},
+		ID:   "e",
+		Read: true,
+	}.Apply(t)
+	require.EqualError(t, err, "Some error")
+	assert.Equal(t, "e", d.Id())
+	assert.Equal(t, "", d.Get("source"))
+}
+
+func TestResourceAzureBlobMountGenericDelete(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/clusters/get?cluster_id=b",
+				Response: compute.ClusterInfo{
+					State: compute.ClusterStateRunning,
+				},
+			},
+		},
+		Resource: ResourceDatabricksMount(),
+		CommandMock: func(commandStr string) common.CommandResults {
+			trunc := internal.TrimLeadingWhitespace(commandStr)
+			t.Logf("Received command:\n%s", trunc)
+			assert.Contains(t, trunc, "dbutils.fs.unmount(mount_point)")
+			return common.CommandResults{
+				ResultType: "Text",
+				Data:       "",
+			}
+		},
+		State: map[string]interface{}{
+			"cluster_id": "b",
+			"mount_name": "e",
+			"wasbs": []interface{}{map[string]interface{}{
+				"auth_type":            "ACCESS_KEY",
+				"container_name":       "c",
+				"directory":            "/d",
+				"storage_account_name": "f",
+				"token_secret_key":     "g",
+				"token_secret_scope":   "h",
+			}},
+		},
+		ID:     "e",
+		Delete: true,
+	}.Apply(t)
+	require.NoError(t, err)
+	assert.Equal(t, "e", d.Id())
+	assert.Equal(t, "", d.Get("source"))
+}
+
+func TestAzureAccBlobMountGeneric(t *testing.T) {
+	client, mp := mountPointThroughReusedCluster(t)
+	storageAccountName := qa.GetEnvOrSkipTest(t, "TEST_STORAGE_V2_ACCOUNT")
+	accountKey := qa.GetEnvOrSkipTest(t, "TEST_STORAGE_V2_KEY")
+	container := qa.GetEnvOrSkipTest(t, "TEST_STORAGE_V2_WASBS")
+	testWithNewSecretScope(t, func(scope, key string) {
+		testMounting(t, mp, GenericMount{Wasbs: &AzureBlobMount{
+			StorageAccountName: storageAccountName,
+			ContainerName:      container,
+			SecretScope:        scope,
+			SecretKey:          key,
+			Directory:          "/",
+		}})
+	}, client, mp.name, accountKey)
+}
+
+// ============================== Google Cloud Storage Tests ==============================
+
+const testGcsBucketPath = "gs://" + testS3BucketName
+
+func TestResourceGcsMountGenericCreate_WithCluster(t *testing.T) {
+	google_account := "acc@acc-dbx.iam.gserviceaccount.com"
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				ReuseRequest: true,
+				Resource:     "/api/2.0/clusters/get?cluster_id=this_cluster",
+				Response: compute.ClusterInfo{
+					State: compute.ClusterStateRunning,
+					GcpAttributes: &compute.GcpAttributes{
+						GoogleServiceAccount: google_account,
+					},
+				},
+			},
+		},
+		Resource: ResourceDatabricksMount(),
+		CommandMock: func(commandStr string) common.CommandResults {
+			trunc := internal.TrimLeadingWhitespace(commandStr)
+			t.Logf("Received command:\n%s", trunc)
+			if strings.HasPrefix(trunc, "def safe_mount") {
+				assert.Contains(t, trunc, testGcsBucketPath) // bucketname
+				assert.Contains(t, trunc, `{}`)              // empty brackets for empty config
+			}
+			assert.Contains(t, trunc, "/mnt/this_mount")
+			return common.CommandResults{
+				ResultType: "text",
+				Data:       testGcsBucketPath,
+			}
+		},
+		State: map[string]interface{}{
+			"cluster_id": "this_cluster",
+			"mount_name": "this_mount",
+			"gcs": []interface{}{map[string]interface{}{
+				"bucket_name": testS3BucketName,
+			}},
+		},
+		Create: true,
+	}.Apply(t)
+	require.NoError(t, err, err)
+	assert.Equal(t, "this_mount", d.Id())
+	assert.Equal(t, testGcsBucketPath, d.Get("source"))
+}
+
+func TestResourceGcsMountGenericCreate_WithServiceAccount(t *testing.T) {
+	google_account := "acc@acc-dbx.iam.gserviceaccount.com"
+	clusterName := "terraform-mount-gcs-bcb24f32098efa4172f435adbed2dae2"
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				ReuseRequest: true,
+				Resource:     "/api/2.0/clusters/get?cluster_id=abcd",
+				Response: compute.ClusterInfo{
+					ClusterID: "abcd",
+					State:     compute.ClusterStateRunning,
+					GcpAttributes: &compute.GcpAttributes{
+						GoogleServiceAccount: google_account,
+					},
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/clusters/list",
+				Response: map[string]interface{}{},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/clusters/list",
+				Response: compute.ClusterList{
+					Clusters: []compute.ClusterInfo{
+						{
+							ClusterID: "abcd",
+							State:     compute.ClusterStateRunning,
+							GcpAttributes: &compute.GcpAttributes{
+								GoogleServiceAccount: google_account,
+							},
+							AutoterminationMinutes: 10,
+							SparkConf:              map[string]string{"spark.databricks.cluster.profile": "singleNode", "spark.master": "local[*]"},
+							CustomTags:             map[string]string{"ResourceClass": "SingleNode"},
+							ClusterName:            clusterName,
+							SparkVersion:           "7.3.x-scala2.12",
+							NumWorkers:             0,
+						},
+					},
+				},
+			},
+			{
+				Method:       "GET",
+				Resource:     "/api/2.0/clusters/spark-versions",
+				Response:     sparkVersionsResponse,
+				ReuseRequest: true,
+			},
+			{
+				Method:       "GET",
+				Resource:     "/api/2.0/clusters/list-node-types",
+				ReuseRequest: true,
+				Response:     nodeListResponse,
+			},
+			{
+				Method:       "POST",
+				Resource:     "/api/2.0/clusters/create",
+				ReuseRequest: true,
+				ExpectedRequest: compute.Cluster{
+					NodeTypeID: "Standard_F4s",
+					GcpAttributes: &compute.GcpAttributes{
+						GoogleServiceAccount: "acc@acc-dbx.iam.gserviceaccount.com",
+					},
+					AutoterminationMinutes: 10,
+					SparkConf:              map[string]string{"spark.databricks.cluster.profile": "singleNode", "spark.master": "local[*]"},
+					CustomTags:             map[string]string{"ResourceClass": "SingleNode"},
+					ClusterName:            clusterName,
+					SparkVersion:           "7.3.x-scala2.12",
+					NumWorkers:             0,
+				},
+				Response: compute.ClusterID{
+					ClusterID: "abcd",
+				},
+			},
+		},
+		Resource: ResourceDatabricksMount(),
+		CommandMock: func(commandStr string) common.CommandResults {
+			trunc := internal.TrimLeadingWhitespace(commandStr)
+			t.Logf("Received command:\n%s", trunc)
+			if strings.HasPrefix(trunc, "def safe_mount") {
+				assert.Contains(t, trunc, testGcsBucketPath) // bucketname
+				assert.Contains(t, trunc, `{}`)              // empty brackets for empty config
+			}
+			assert.Contains(t, trunc, "/mnt/this_mount")
+			return common.CommandResults{
+				ResultType: "text",
+				Data:       testGcsBucketPath,
+			}
+		},
+		State: map[string]interface{}{
+			"mount_name": "this_mount",
+			"gcs": []interface{}{map[string]interface{}{
+				"bucket_name":     testS3BucketName,
+				"service_account": google_account,
+			}},
+		},
+		Create: true,
+	}.Apply(t)
+	require.NoError(t, err, err)
+	assert.Equal(t, "this_mount", d.Id())
+	assert.Equal(t, "abcd", d.Get("cluster_id"))
+	assert.Equal(t, testGcsBucketPath, d.Get("source"))
+}
+
+func TestResourceGcsMountGenericCreate_nothing_specified(t *testing.T) {
+	_, err := qa.ResourceFixture{
+		Resource: ResourceDatabricksMount(),
+		State: map[string]interface{}{
+			"mount_name": "this_mount",
+			"gcs": []interface{}{map[string]interface{}{
+				"bucket_name": testS3BucketName,
+			}},
+		},
+		Create: true,
+	}.Apply(t)
+	require.EqualError(t, err, "either cluster_id or service_account must be specified to mount GCS bucket")
+}
+
+// TODO: implement it
+// func TestGcpAccGcsMount(t *testing.T) {
+// 	client, mp := mountPointThroughReusedCluster(t)
+// 	storageAccountName := qa.GetEnvOrSkipTest(t, "TEST_STORAGE_V2_ACCOUNT")
+// 	accountKey := qa.GetEnvOrSkipTest(t, "TEST_STORAGE_V2_KEY")
+// 	container := qa.GetEnvOrSkipTest(t, "TEST_STORAGE_V2_WASBS")
+// 	testWithNewSecretScope(t, func(scope, key string) {
+// 		testMounting(t, mp, GenericMount{Wasbs: &AzureBlobMount{
+// 			StorageAccountName: storageAccountName,
+// 			ContainerName:      container,
+// 			SecretScope:        scope,
+// 			SecretKey:          key,
+// 			Directory:          "/",
+// 		}})
+// 	}, client, mp.name, accountKey)
+// }
+
+// ============================== Tests for Generic Configuration options ==============================
+
+func TestResourceMountGenericCreate_WithUriAndOpts(t *testing.T) {
+	abfssPath := "abfss://test@$test.dfs.core.windows.net"
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				ReuseRequest: true,
+				Resource:     "/api/2.0/clusters/get?cluster_id=this_cluster",
+				Response: compute.ClusterInfo{
+					State: compute.ClusterStateRunning,
+				},
+			},
+		},
+		Resource: ResourceDatabricksMount(),
+		CommandMock: func(commandStr string) common.CommandResults {
+			trunc := internal.TrimLeadingWhitespace(commandStr)
+			t.Logf("Received command:\n%s", trunc)
+			if strings.HasPrefix(trunc, "def safe_mount") {
+				assert.Contains(t, trunc, abfssPath) // URI
+				assert.Contains(t, trunc, `{"fs.azure.account.auth.type":"CustomAccessToken"}`)
+			}
+			assert.Contains(t, trunc, "/mnt/this_mount")
+			return common.CommandResults{
+				ResultType: "text",
+				Data:       abfssPath,
+			}
+		},
+		State: map[string]interface{}{
+			"cluster_id": "this_cluster",
+			"mount_name": "this_mount",
+			"uri":        abfssPath,
+			"extra_configs": map[string]interface{}{
+				"fs.azure.account.auth.type": "CustomAccessToken",
+			},
+		},
+		Create: true,
+	}.Apply(t)
+	require.NoError(t, err, err)
+	assert.Equal(t, "this_mount", d.Id())
+	assert.Equal(t, abfssPath, d.Get("source"))
+}


### PR DESCRIPTION
This PR solves the problem with customization of the mount options that isn't possible right now, for example, to create Azure credentials passthrough mounts, etc.

Resource implements two approaches:
* You specify two main options `uri` - URL to mount (service dependent), and `extra_configs` - map of Spark configurations that is necessary to mount the resource.  This is most flexible way to perform mounts - see example for Azure passthrough mounts in documentation. For example:

```hcl
resource "databricks_mount" "this" {
  mount_name = "tf-test"
  
  uri = "abfss://${local.container}@${local.storage_acc}.dfs.core.windows.net"
  extra_configs = {
    "fs.azure.account.auth.type":                          "OAuth",
    "fs.azure.account.oauth.provider.type":                "org.apache.hadoop.fs.azurebfs.oauth2.ClientCredsTokenProvider",
    "fs.azure.account.oauth2.client.id":                   local.client_id,
    "fs.azure.account.oauth2.client.secret":               "{{secrets/${local.secret_scope}/${local.secret_key}}}",
    "fs.azure.account.oauth2.client.endpoint":             "https://login.microsoftonline.com/${local.tenant_id}/oauth2/token",
    "fs.azure.createRemoteFileSystemDuringInitialization": "false",
  }
}
```

* You specify block that is specific to cloud storage with almost same content as existing mount resources.  Currently we support `abfss`, `adl`, `wasbs` and `s3` blocks.  Using these blocks it will be easier to migrate existing resources, and also simplify configuration, as users won't need to care for configuration options with fixed values, etc.  For example (same effect as previous example):

```hcl
resource "databricks_mount" "this2" {
  mount_name = "tf-test"

  abfss {
    container_name         = local.container
    storage_account_name   = local.storage_acc
    tenant_id              = local.tenant_id
    client_id              = local.client_id
    client_secret_scope    = local.secret_scope
    client_secret_key      = local.secret_key
    initialize_file_system = false
  }
}
```

This should fix #497