### PR TITLE
Initial support for Azure MSI authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.3.8
 
 * Added `databricks_repo` resource to manage [Databricks Repos](https://docs.databricks.com/repos.html) ([#771](https://github.com/databrickslabs/terraform-provider-databricks/pull/771))
+* Added support for Azure MSI authentication ([#743](https://github.com/databrickslabs/terraform-provider-databricks/pull/743))
 * Already deleted `databricks_token` don't fail the apply ([#808](https://github.com/databrickslabs/terraform-provider-databricks/pull/808))
 * Multiple documentation improvements
 

--- a/access/resource_secret_scope.go
+++ b/access/resource_secret_scope.go
@@ -59,7 +59,7 @@ func (a SecretScopesAPI) Create(s SecretScope) error {
 		BackendType:            "DATABRICKS",
 	}
 	if s.KeyvaultMetadata != nil {
-		if err := a.client.Authenticate(); err != nil {
+		if err := a.client.Authenticate(a.context); err != nil {
 			return err
 		}
 		if !a.client.IsAzure() {

--- a/common/azure_auth.go
+++ b/common/azure_auth.go
@@ -120,6 +120,11 @@ func (aa *DatabricksClient) configureWithManagedIdentity(ctx context.Context) (f
 	if !adal.MSIAvailable(ctx, aa.httpClient.HTTPClient) {
 		return nil, nil
 	}
+	azureEnvironment, err := aa.getAzureEnvironment()
+	if err != nil {
+		return nil, fmt.Errorf("cannot get azure environment: %w", err)
+	}
+	aa.AzureEnvironment = &azureEnvironment
 	log.Printf("[INFO] Using Azure Managed Identity authentication")
 	return aa.simpleAADRequestVisitor(ctx, func(resource string) (autorest.Authorizer, error) {
 		return auth.MSIConfig{

--- a/common/azure_auth.go
+++ b/common/azure_auth.go
@@ -84,7 +84,7 @@ func (aa *DatabricksClient) IsAzureClientSecretSet() bool {
 	return aa.AzureClientID != "" && aa.AzureClientSecret != "" && aa.AzureTenantID != ""
 }
 
-func (aa *DatabricksClient) configureWithClientSecret() (func(r *http.Request) error, error) {
+func (aa *DatabricksClient) configureWithClientSecret(ctx context.Context) (func(*http.Request) error, error) {
 	if !aa.IsAzure() {
 		return nil, nil
 	}
@@ -110,11 +110,13 @@ func (aa *DatabricksClient) configureWithClientSecret() (func(r *http.Request) e
 	}
 
 	log.Printf("[INFO] Generating AAD token for Azure Service Principal")
-	return aa.simpleAADRequestVisitor(aa.InitContext, aa.getClientSecretAuthorizer, aa.addSpManagementTokenVisitor)
+	return aa.simpleAADRequestVisitor(ctx, aa.getClientSecretAuthorizer, aa.addSpManagementTokenVisitor)
 }
 
-func (aa *DatabricksClient) configureWithManagedIdentity() (func(r *http.Request) error, error) {
-	ctx := context.TODO()
+func (aa *DatabricksClient) configureWithManagedIdentity(ctx context.Context) (func(*http.Request) error, error) {
+	if !aa.IsAzure() {
+		return nil, nil
+	}
 	if !adal.MSIAvailable(ctx, aa.httpClient.HTTPClient) {
 		return nil, nil
 	}

--- a/common/azure_auth.go
+++ b/common/azure_auth.go
@@ -84,7 +84,7 @@ func (aa *DatabricksClient) IsAzureClientSecretSet() bool {
 	return aa.AzureClientID != "" && aa.AzureClientSecret != "" && aa.AzureTenantID != ""
 }
 
-func (aa *DatabricksClient) configureWithClientSecret(ctx context.Context) (func(*http.Request) error, error) {
+func (aa *DatabricksClient) configureWithAzureClientSecret(ctx context.Context) (func(*http.Request) error, error) {
 	if !aa.IsAzure() {
 		return nil, nil
 	}
@@ -113,7 +113,7 @@ func (aa *DatabricksClient) configureWithClientSecret(ctx context.Context) (func
 	return aa.simpleAADRequestVisitor(ctx, aa.getClientSecretAuthorizer, aa.addSpManagementTokenVisitor)
 }
 
-func (aa *DatabricksClient) configureWithManagedIdentity(ctx context.Context) (func(*http.Request) error, error) {
+func (aa *DatabricksClient) configureWithAzureManagedIdentity(ctx context.Context) (func(*http.Request) error, error) {
 	if !aa.IsAzure() {
 		return nil, nil
 	}

--- a/common/azure_auth.go
+++ b/common/azure_auth.go
@@ -112,8 +112,11 @@ func (aa *DatabricksClient) configureWithAzureManagedIdentity(ctx context.Contex
 	if !aa.IsAzure() {
 		return nil, nil
 	}
-	if !adal.MSIAvailable(ctx, aa.httpClient.HTTPClient) {
+	if !aa.AzureUseMSI {
 		return nil, nil
+	}
+	if !adal.MSIAvailable(ctx, aa.httpClient.HTTPClient) {
+		return nil, fmt.Errorf("managed identity is not available")
 	}
 	log.Printf("[INFO] Using Azure Managed Identity authentication")
 	return aa.simpleAADRequestVisitor(ctx, func(resource string) (autorest.Authorizer, error) {

--- a/common/azure_auth_test.go
+++ b/common/azure_auth_test.go
@@ -182,12 +182,13 @@ func TestDatabricksClient_ensureWorkspaceURL(t *testing.T) {
 
 func TestDatabricksClient_configureWithClientSecretPAT(t *testing.T) {
 	client := DatabricksClient{InsecureSkipVerify: true}
-	auth, err := client.configureWithClientSecret()
+	ctx := context.Background()
+	auth, err := client.configureWithClientSecret(ctx)
 	assert.Nil(t, auth)
 	assert.NoError(t, err)
 
 	client.AzureDatabricksResourceID = "/subscriptions/a/resourceGroups/b/providers/Microsoft.Databricks/workspaces/c"
-	auth, err = client.configureWithClientSecret()
+	auth, err = client.configureWithClientSecret(ctx)
 	assert.Nil(t, auth)
 	assert.NoError(t, err)
 
@@ -245,7 +246,7 @@ func TestDatabricksClient_configureWithClientSecretPAT(t *testing.T) {
 	client.AzureEnvironment = &azure.Environment{
 		ResourceManagerEndpoint: fmt.Sprintf("%s/", server.URL),
 	}
-	auth, err = client.configureWithClientSecret()
+	auth, err = client.configureWithClientSecret(ctx)
 	assert.NotNil(t, auth)
 	assert.NoError(t, err)
 
@@ -307,7 +308,8 @@ func TestDatabricksClient_configureWithClientSecretAAD(t *testing.T) {
 		ResourceManagerEndpoint: fmt.Sprintf("%s/", server.URL),
 	}
 	client.configureHTTPCLient()
-	auth, err := client.configureWithClientSecret()
+	ctx := context.Background()
+	auth, err := client.configureWithClientSecret(ctx)
 	assert.NoError(t, err)
 
 	client.authVisitor = auth

--- a/common/azure_auth_test.go
+++ b/common/azure_auth_test.go
@@ -183,12 +183,12 @@ func TestDatabricksClient_ensureWorkspaceURL(t *testing.T) {
 func TestDatabricksClient_configureWithClientSecretPAT(t *testing.T) {
 	client := DatabricksClient{InsecureSkipVerify: true}
 	ctx := context.Background()
-	auth, err := client.configureWithClientSecret(ctx)
+	auth, err := client.configureWithAzureClientSecret(ctx)
 	assert.Nil(t, auth)
 	assert.NoError(t, err)
 
 	client.AzureDatabricksResourceID = "/subscriptions/a/resourceGroups/b/providers/Microsoft.Databricks/workspaces/c"
-	auth, err = client.configureWithClientSecret(ctx)
+	auth, err = client.configureWithAzureClientSecret(ctx)
 	assert.Nil(t, auth)
 	assert.NoError(t, err)
 
@@ -246,7 +246,7 @@ func TestDatabricksClient_configureWithClientSecretPAT(t *testing.T) {
 	client.AzureEnvironment = &azure.Environment{
 		ResourceManagerEndpoint: fmt.Sprintf("%s/", server.URL),
 	}
-	auth, err = client.configureWithClientSecret(ctx)
+	auth, err = client.configureWithAzureClientSecret(ctx)
 	assert.NotNil(t, auth)
 	assert.NoError(t, err)
 
@@ -309,7 +309,7 @@ func TestDatabricksClient_configureWithClientSecretAAD(t *testing.T) {
 	}
 	client.configureHTTPCLient()
 	ctx := context.Background()
-	auth, err := client.configureWithClientSecret(ctx)
+	auth, err := client.configureWithAzureClientSecret(ctx)
 	assert.NoError(t, err)
 
 	client.authVisitor = auth

--- a/common/azure_cli_auth.go
+++ b/common/azure_cli_auth.go
@@ -93,7 +93,7 @@ func (aa *DatabricksClient) cliAuthorizer(resource string) (autorest.Authorizer,
 	return autorest.NewBearerAuthorizer(&rct), nil
 }
 
-func (aa *DatabricksClient) configureWithAzureCLI() (func(r *http.Request) error, error) {
+func (aa *DatabricksClient) configureWithAzureCLI(ctx context.Context) (func(*http.Request) error, error) {
 	if !aa.IsAzure() {
 		return nil, nil
 	}
@@ -126,5 +126,5 @@ func (aa *DatabricksClient) configureWithAzureCLI() (func(r *http.Request) error
 		}, nil
 	}
 	log.Printf("[INFO] Using Azure CLI authentication with AAD tokens")
-	return aa.simpleAADRequestVisitor(context.TODO(), aa.cliAuthorizer)
+	return aa.simpleAADRequestVisitor(ctx, aa.cliAuthorizer)
 }

--- a/common/azure_cli_auth.go
+++ b/common/azure_cli_auth.go
@@ -100,13 +100,8 @@ func (aa *DatabricksClient) configureWithAzureCLI(ctx context.Context) (func(*ht
 	if aa.IsAzureClientSecretSet() {
 		return nil, nil
 	}
-	azureEnvironment, err := aa.getAzureEnvironment()
-	if err != nil {
-		return nil, fmt.Errorf("cannot get environment: %w", err)
-	}
-	aa.AzureEnvironment = &azureEnvironment
 	// verify that Azure CLI is authenticated
-	_, err = cli.GetTokenFromCLI(AzureDatabricksResourceID)
+	_, err := cli.GetTokenFromCLI(AzureDatabricksResourceID)
 	if err != nil {
 		if err.Error() == "Invoking Azure CLI failed with the following error: " {
 			return nil, fmt.Errorf("most likely Azure CLI is not installed. " +

--- a/common/azure_cli_auth_test.go
+++ b/common/azure_cli_auth_test.go
@@ -175,7 +175,8 @@ func TestConfigureWithAzureCLI_SP(t *testing.T) {
 		AzureTenantID:             "c",
 		AzureDatabricksResourceID: "/subscriptions/a/resourceGroups/b/providers/Microsoft.Databricks/workspaces/c",
 	}
-	auth, err := aa.configureWithAzureCLI()
+	ctx := context.Background()
+	auth, err := aa.configureWithAzureCLI(ctx)
 	assert.NoError(t, err)
 	assert.Nil(t, auth)
 }
@@ -193,7 +194,7 @@ func TestConfigureWithAzureCLI(t *testing.T) {
 	client.AzureDatabricksResourceID = "/subscriptions/a/resourceGroups/b/providers/Microsoft.Databricks/workspaces/c"
 	client.AzureUsePATForCLI = true
 
-	auth, err := client.configureWithAzureCLI()
+	auth, err := client.configureWithAzureCLI(context.Background())
 	assert.NoError(t, err)
 
 	err = auth(httptest.NewRequest("GET", "/clusters/list", http.NoBody))
@@ -213,7 +214,7 @@ func TestConfigureWithAzureCLI_Error(t *testing.T) {
 	client.AzureDatabricksResourceID = "/subscriptions/a/resourceGroups/b/providers/Microsoft.Databricks/workspaces/c"
 	client.AzureUsePATForCLI = true
 
-	auth, err := client.configureWithAzureCLI()
+	auth, err := client.configureWithAzureCLI(context.Background())
 	assert.NoError(t, err)
 
 	err = auth(httptest.NewRequest("GET", "/clusters/list", http.NoBody))
@@ -235,7 +236,7 @@ func TestConfigureWithAzureCLI_NotInstalled(t *testing.T) {
 	client.AzureDatabricksResourceID = "/subscriptions/a/resourceGroups/b/providers/Microsoft.Databricks/workspaces/c"
 	client.AzureUsePATForCLI = true
 
-	_, err := client.configureWithAzureCLI()
+	_, err := client.configureWithAzureCLI(context.Background())
 	require.Error(t, err)
 	assert.True(t, strings.HasPrefix(err.Error(), "most likely Azure CLI is not installed"),
 		"Actual message: %s", err.Error())

--- a/common/client.go
+++ b/common/client.go
@@ -209,6 +209,7 @@ func (c *DatabricksClient) Configure(attrsUsed ...string) error {
 
 // Authenticate lazily authenticates across authorizers or returns error
 func (c *DatabricksClient) Authenticate() error {
+	// TODO: add context
 	if c.authVisitor != nil {
 		return nil
 	}
@@ -220,6 +221,7 @@ func (c *DatabricksClient) Authenticate() error {
 	authorizers := []func() (func(r *http.Request) error, error){
 		c.configureAuthWithDirectParams,
 		c.configureWithClientSecret,
+		c.configureWithManagedIdentity,
 		c.configureWithAzureCLI,
 		c.configureWithGoogleForAccountsAPI,
 		c.configureWithGoogleForWorkspace,

--- a/common/client.go
+++ b/common/client.go
@@ -214,14 +214,15 @@ func (c *DatabricksClient) Authenticate(ctx context.Context) error {
 		return nil
 	}
 	authorizers := []func(context.Context) (func(*http.Request) error, error){
-		c.configureAuthWithDirectParams,
-		c.configureWithClientSecret,
-		c.configureWithManagedIdentity,
+		c.configureWithDirectParams,
+		c.configureWithAzureClientSecret,
 		c.configureWithAzureCLI,
+		c.configureWithAzureManagedIdentity,
 		c.configureWithGoogleForAccountsAPI,
 		c.configureWithGoogleForWorkspace,
-		c.configureFromDatabricksCfg,
+		c.configureWithDatabricksCfg,
 	}
+	// try configuring authentication with different methods
 	for _, authProvider := range authorizers {
 		authorizer, err := authProvider(ctx)
 		if err != nil {
@@ -258,7 +259,7 @@ func (c *DatabricksClient) fixHost() {
 	}
 }
 
-func (c *DatabricksClient) configureAuthWithDirectParams(ctx context.Context) (func(*http.Request) error, error) {
+func (c *DatabricksClient) configureWithDirectParams(ctx context.Context) (func(*http.Request) error, error) {
 	authType := "Bearer"
 	var needsHostBecause string
 	if c.Username != "" && c.Password != "" {
@@ -280,7 +281,7 @@ func (c *DatabricksClient) configureAuthWithDirectParams(ctx context.Context) (f
 	return c.authorizer(authType, c.Token), nil
 }
 
-func (c *DatabricksClient) configureFromDatabricksCfg(ctx context.Context) (func(r *http.Request) error, error) {
+func (c *DatabricksClient) configureWithDatabricksCfg(ctx context.Context) (func(r *http.Request) error, error) {
 	configFile := c.ConfigFile
 	if configFile == "" {
 		configFile = "~/.databrickscfg"

--- a/common/client_test.go
+++ b/common/client_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
@@ -17,7 +18,7 @@ func configureAndAuthenticate(dc *DatabricksClient) (*DatabricksClient, error) {
 	if err != nil {
 		return dc, err
 	}
-	return dc, dc.Authenticate()
+	return dc, dc.Authenticate(context.Background())
 }
 
 func TestDatabricksClientConfigure_Nothing(t *testing.T) {

--- a/common/client_test.go
+++ b/common/client_test.go
@@ -160,7 +160,7 @@ func TestDatabricksClient_FormatURL(t *testing.T) {
 
 func TestClientAttributes(t *testing.T) {
 	ca := ClientAttributes()
-	assert.Len(t, ca, 24)
+	assert.Len(t, ca, 25)
 }
 
 func TestEnvVarsUsed(t *testing.T) {

--- a/common/gcp_test.go
+++ b/common/gcp_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"context"
 	"net/http/httptest"
 	"testing"
 
@@ -21,7 +22,7 @@ func TestGoogleOIDC(t *testing.T) {
 	}
 	client.configureHTTPCLient()
 
-	_, err := client.getGoogleOIDCSource()
+	_, err := client.getGoogleOIDCSource(context.Background())
 	require.NoError(t, err)
 }
 
@@ -33,11 +34,11 @@ func TestConfigureWithGoogleForAccountsAPI(t *testing.T) {
 	}
 	client.configureHTTPCLient()
 
-	_, err := client.configureWithGoogleForAccountsAPI()
+	_, err := client.configureWithGoogleForAccountsAPI(context.Background())
 	assert.Error(t, err)
 
 	client.googleAuthOptions = []option.ClientOption{option.WithoutAuthentication()}
-	a, err := client.configureWithGoogleForAccountsAPI()
+	a, err := client.configureWithGoogleForAccountsAPI(context.Background())
 	require.NoError(t, err)
 	assert.NotNil(t, a)
 }
@@ -50,11 +51,11 @@ func TestConfigureWithGoogleForWorkspace(t *testing.T) {
 	}
 	client.configureHTTPCLient()
 
-	_, err := client.configureWithGoogleForWorkspace()
+	_, err := client.configureWithGoogleForWorkspace(context.Background())
 	assert.Error(t, err)
 
 	client.googleAuthOptions = []option.ClientOption{option.WithoutAuthentication()}
-	a, err := client.configureWithGoogleForWorkspace()
+	a, err := client.configureWithGoogleForWorkspace(context.Background())
 	require.NoError(t, err)
 	assert.NotNil(t, a)
 }

--- a/common/http.go
+++ b/common/http.go
@@ -355,7 +355,7 @@ func (c *DatabricksClient) OldAPI(ctx context.Context, method, path string, requ
 
 func (c *DatabricksClient) authenticatedQuery(ctx context.Context, method, requestURL string,
 	data interface{}, visitors ...func(*http.Request) error) (body []byte, err error) {
-	err = c.Authenticate()
+	err = c.Authenticate(ctx)
 	if err != nil {
 		return
 	}

--- a/common/http_test.go
+++ b/common/http_test.go
@@ -228,6 +228,7 @@ func singleRequestServer(t *testing.T, method, url, response string) (*Databrick
 func TestGet_Error(t *testing.T) {
 	defer CleanupEnvironment()()
 	ws := DatabricksClient{}
+	ws.configureHTTPCLient()
 	err := ws.Get(context.Background(), "/imaginary/endpoint", nil, nil)
 	require.Error(t, err)
 	assert.True(t, strings.HasPrefix(err.Error(), "authentication is not configured"),

--- a/identity/resource_service_principal.go
+++ b/identity/resource_service_principal.go
@@ -90,6 +90,7 @@ func ResourceServicePrincipal() *schema.Resource {
 			}
 			client := c.(*common.DatabricksClient)
 			if client.IsAzure() && sp.ApplicationID == "" {
+				// TODO: verify cases for non-existing resources
 				return fmt.Errorf("application_id is required for service principals in Azure Databricks")
 			}
 			if client.IsAws() && sp.DisplayName == "" {

--- a/mws/resource_workspace_test.go
+++ b/mws/resource_workspace_test.go
@@ -30,7 +30,7 @@ func TestMwsAccWorkspace(t *testing.T) {
 func TestGcpAccWorkspace(t *testing.T) {
 	acctID := qa.GetEnvOrSkipTest(t, "DATABRICKS_ACCOUNT_ID")
 	client := common.CommonEnvironmentClient()
-	workspacesAPI := NewWorkspacesAPI(client.InitContext, client)
+	workspacesAPI := NewWorkspacesAPI(context.Background(), client)
 
 	workspaceList, err := workspacesAPI.List(acctID)
 	require.NoError(t, err, err)

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -124,7 +124,8 @@ func providerSchema() map[string]*schema.Schema {
 	ps["azure_client_secret"].Sensitive = true
 
 	azCoordinatesDeprecation := "`%s` is deprecated and would be removed in v0.4.0. Please rewrite provider configuration " +
-		"with `host = data.azurerm_databricks_workspace.example.workspace_url` to achieve the same effect. Please check " +
+		"with `host = data.azurerm_databricks_workspace.example.workspace_url` to achieve the same effect. " + 
+		"ARM_* environment variables would continue to be used as they're used by `azurerm` provider. See " +
 		"https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/databricks_workspace#workspace_url for details"
 	ps["azure_workspace_name"].Deprecated = fmt.Sprintf(azCoordinatesDeprecation, "azure_workspace_name")
 	ps["azure_resource_group"].Deprecated = fmt.Sprintf(azCoordinatesDeprecation, "azure_resource_group")

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -417,7 +417,8 @@ func configureProviderAndReturnClient(t *testing.T, tt providerFixture) (*common
 		os.Setenv(k, v)
 	}
 	p := DatabricksProvider()
-	diags := p.Configure(context.Background(), terraform.NewResourceConfigRaw(tt.rawConfig()))
+	ctx := context.Background()
+	diags := p.Configure(ctx, terraform.NewResourceConfigRaw(tt.rawConfig()))
 	if len(diags) > 0 {
 		issues := []string{}
 		for _, d := range diags {
@@ -427,7 +428,7 @@ func configureProviderAndReturnClient(t *testing.T, tt providerFixture) (*common
 	}
 	client := p.Meta().(*common.DatabricksClient)
 	client.AzureUsePATForSPN = tt.usePATForSPN
-	err := client.Authenticate()
+	err := client.Authenticate(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Authenticating with Azure MSI

Since v0.3.8, it's possible to leverage [Azure Managed Service Identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/managed_service_identity) authentication, which is using the same environment variables as `azurerm` provider. Both `SystemAssigned` and `UserAssigned` identities work, as long as they have `Contributor` role on subscription level and created the workspace resource, or directly added to workspace through [databricks_service_principal](resources/service_principal.md).

```hcl
provider "databricks" {
  host = data.azurerm_databricks_workspace.this.workspace_url
  
  # ARM_USE_MSI environment variable is recommended
  azure_use_msi = true 
}
```