### PR TITLE
Don't error if widget or visualization doesn't exist

### DIFF
--- a/sqlanalytics/resource_visualization.go
+++ b/sqlanalytics/resource_visualization.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
 	"strconv"
 	"strings"
 
@@ -94,10 +95,11 @@ func (a VisualizationAPI) Read(queryID, visualizationID string) (*api.Visualizat
 		}
 	}
 
-	// Cannot find visualization with `visualizationID` attached to query `queryID`.
-	// Terraform can deal with this situation by recreating it so don't return an error.
-	log.Printf("[WARN] Cannot find visualization %s attached to query %s", visualizationID, queryID)
-	return nil, nil
+	return nil, common.APIError{
+		ErrorCode:  "NOT_FOUND",
+		StatusCode: http.StatusNotFound,
+		Message:    fmt.Sprintf("Cannot find visualization %s attached to query %s", visualizationID, queryID),
+	}
 }
 
 // Update ...
@@ -188,12 +190,6 @@ func ResourceVisualization() *schema.Resource {
 			av, err := NewVisualizationAPI(ctx, c).Read(queryID, visualizationID)
 			if err != nil {
 				return err
-			}
-
-			// Handle if visualization was not found.
-			if av == nil {
-				data.SetId("")
-				return nil
 			}
 
 			var v VisualizationEntity

--- a/sqlanalytics/resource_visualization.go
+++ b/sqlanalytics/resource_visualization.go
@@ -94,7 +94,10 @@ func (a VisualizationAPI) Read(queryID, visualizationID string) (*api.Visualizat
 		}
 	}
 
-	return nil, fmt.Errorf("cannot find visualization %s attached to query %s", visualizationID, queryID)
+	// Cannot find visualization with `visualizationID` attached to query `queryID`.
+	// Terraform can deal with this situation by recreating it so don't return an error.
+	log.Printf("[WARN] Cannot find visualization %s attached to query %s", visualizationID, queryID)
+	return nil, nil
 }
 
 // Update ...
@@ -185,6 +188,12 @@ func ResourceVisualization() *schema.Resource {
 			av, err := NewVisualizationAPI(ctx, c).Read(queryID, visualizationID)
 			if err != nil {
 				return err
+			}
+
+			// Handle if visualization was not found.
+			if av == nil {
+				data.SetId("")
+				return nil
 			}
 
 			var v VisualizationEntity

--- a/sqlanalytics/resource_visualization_test.go
+++ b/sqlanalytics/resource_visualization_test.go
@@ -137,6 +137,43 @@ func TestVisualizationRead(t *testing.T) {
 	assert.Less(t, 0, len(d.Get("options").(string)))
 }
 
+func TestVisualizationReadNotFound(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/preview/sql/queries/foo",
+				Response: api.Query{
+					ID: "foo",
+					Visualizations: []json.RawMessage{
+						json.RawMessage(`
+							{
+								"id": 12345,
+								"type": "CHART"
+							}
+						`),
+					},
+				},
+			},
+		},
+		Resource:    ResourceVisualization(),
+		Read:        true,
+		Removed:     true,
+		RequiresNew: true,
+		ID:          "foo/1234",
+		State: map[string]interface{}{
+			"query_id":    "foo",
+			"type":        "chart",
+			"name":        "My Chart",
+			"description": "Some Description",
+			"options":     "{}",
+		},
+	}.Apply(t)
+
+	assert.NoError(t, err, err)
+	assert.Equal(t, "", d.Id(), "Resource ID should be empty")
+}
+
 func TestVisualizationUpdate(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{

--- a/sqlanalytics/resource_widget.go
+++ b/sqlanalytics/resource_widget.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"net/http"
 	"sort"
 	"strconv"
 	"strings"
@@ -236,10 +236,11 @@ func (a WidgetAPI) Read(dashboardID, widgetID string) (*api.Widget, error) {
 		}
 	}
 
-	// Cannot find widget with `widgetID` attached to dashboard `dashboardID`.
-	// Terraform can deal with this situation by recreating it so don't return an error.
-	log.Printf("[WARN] Cannot find widget %s attached to dashboard %s", widgetID, dashboardID)
-	return nil, nil
+	return nil, common.APIError{
+		ErrorCode:  "NOT_FOUND",
+		StatusCode: http.StatusNotFound,
+		Message:    fmt.Sprintf("Cannot find widget %s attached to dashboard %s", widgetID, dashboardID),
+	}
 }
 
 // Update ...
@@ -308,12 +309,6 @@ func ResourceWidget() *schema.Resource {
 			aw, err := NewWidgetAPI(ctx, c).Read(dashboardID, widgetID)
 			if err != nil {
 				return err
-			}
-
-			// Handle if widget was not found.
-			if aw == nil {
-				data.SetId("")
-				return nil
 			}
 
 			var w WidgetEntity

--- a/sqlanalytics/resource_widget_test.go
+++ b/sqlanalytics/resource_widget_test.go
@@ -500,6 +500,40 @@ func TestWidgetCreateWithPositionAndAutoheight(t *testing.T) {
 	assert.Equal(t, true, d.Get("position.0.auto_height"))
 }
 
+func TestWidgetReadNotFound(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/preview/sql/dashboards/some-uuid",
+				Response: api.Dashboard{
+					ID: "some-uuid",
+					Widgets: []json.RawMessage{
+						json.RawMessage(`
+							{
+								"id": "12345",
+								"text": "text"
+							}
+						`),
+					},
+				},
+			},
+		},
+		Resource:    ResourceWidget(),
+		Read:        true,
+		Removed:     true,
+		RequiresNew: true,
+		ID:          "some-uuid/12344",
+		InstanceState: map[string]string{
+			"dashboard_id":     "some-uuid",
+			"visualization_id": "678",
+		},
+	}.Apply(t)
+
+	assert.NoError(t, err, err)
+	assert.Equal(t, "", d.Id(), "Resource ID should be empty")
+}
+
 func TestWidgetUpdate(t *testing.T) {
 	sText := "text"
 


### PR DESCRIPTION
It's fine if the remote resource was deleted. Terraform will attempt to recreate.