### PR TITLE
Fix available permissions to DBSQL resources

### DIFF
--- a/access/resource_permissions.go
+++ b/access/resource_permissions.go
@@ -241,9 +241,9 @@ func permissionsResourceIDFields(ctx context.Context) []permissionsIDFieldMappin
 		{"authorization", "tokens", "authorization", []string{"CAN_USE"}, SIMPLE},
 		{"authorization", "passwords", "authorization", []string{"CAN_USE"}, SIMPLE},
 		{"sql_endpoint_id", "endpoints", "sql/endpoints", []string{"CAN_USE", "CAN_MANAGE"}, SIMPLE},
-		{"sql_dashboard_id", "dashboard", "sql/dashboards", []string{"CAN_USE", "CAN_MANAGE"}, SIMPLE},
-		{"sql_alert_id", "alert", "sql/alerts", []string{"CAN_USE", "CAN_MANAGE"}, SIMPLE},
-		{"sql_query_id", "query", "sql/queries", []string{"CAN_USE", "CAN_MANAGE"}, SIMPLE},
+		{"sql_dashboard_id", "dashboard", "sql/dashboards", []string{"CAN_EDIT", "CAN_RUN", "CAN_MANAGE"}, SIMPLE},
+		{"sql_alert_id", "alert", "sql/alerts", []string{"CAN_EDIT", "CAN_RUN", "CAN_MANAGE"}, SIMPLE},
+		{"sql_query_id", "query", "sql/queries", []string{"CAN_EDIT", "CAN_RUN", "CAN_MANAGE"}, SIMPLE},
 	}
 }
 

--- a/access/resource_permissions_test.go
+++ b/access/resource_permissions_test.go
@@ -433,7 +433,7 @@ func TestResourcePermissionsCreate_SQLA_Asset(t *testing.T) {
 					AccessControlList: []AccessControlChange{
 						{
 							UserName:        TestingUser,
-							PermissionLevel: "CAN_USE",
+							PermissionLevel: "CAN_RUN",
 						},
 						{
 							UserName:        TestingAdminUser,
@@ -451,7 +451,7 @@ func TestResourcePermissionsCreate_SQLA_Asset(t *testing.T) {
 					AccessControlList: []AccessControl{
 						{
 							UserName:        TestingUser,
-							PermissionLevel: "CAN_USE",
+							PermissionLevel: "CAN_RUN",
 						},
 						{
 							UserName:        TestingAdminUser,
@@ -467,7 +467,7 @@ func TestResourcePermissionsCreate_SQLA_Asset(t *testing.T) {
 			"access_control": []interface{}{
 				map[string]interface{}{
 					"user_name":        TestingUser,
-					"permission_level": "CAN_USE",
+					"permission_level": "CAN_RUN",
 				},
 			},
 		},
@@ -478,7 +478,7 @@ func TestResourcePermissionsCreate_SQLA_Asset(t *testing.T) {
 	require.Equal(t, 1, len(ac.List()))
 	firstElem := ac.List()[0].(map[string]interface{})
 	assert.Equal(t, TestingUser, firstElem["user_name"])
-	assert.Equal(t, "CAN_USE", firstElem["permission_level"])
+	assert.Equal(t, "CAN_RUN", firstElem["permission_level"])
 }
 
 func TestResourcePermissionsCreate_SQLA_Endpoint(t *testing.T) {


### PR DESCRIPTION
Validation of the set of permissions available to each resources was added in #706.

The set for DBSQL resources was incorrect and broke permission handling. This PR corrects those.