### PR TITLE
feat: max_concurrent_run defaults to 1

### DIFF
--- a/compute/resource_job.go
+++ b/compute/resource_job.go
@@ -222,6 +222,7 @@ var jobSchema = common.StructToSchema(JobSettings{},
 		}
 		s["email_notifications"].DiffSuppressFunc = common.MakeEmptyBlockSuppressFunc("email_notifications.#")
 		s["max_concurrent_runs"].ValidateDiagFunc = validation.ToDiagFunc(validation.IntAtLeast(1))
+		s["max_concurrent_runs"].Default = 1
 		s["url"] = &schema.Schema{
 			Type:     schema.TypeString,
 			Computed: true,

--- a/compute/resource_job_test.go
+++ b/compute/resource_job_test.go
@@ -117,8 +117,9 @@ func TestResourceJobCreate_AlwaysRunning(t *testing.T) {
 					SparkJarTask: &SparkJarTask{
 						MainClassName: "com.labs.BarMain",
 					},
-					Name:       "Featurizer",
-					MaxRetries: 3,
+					Name:              "Featurizer",
+					MaxRetries:        3,
+					MaxConcurrentRuns: 1,
 				},
 				Response: Job{
 					JobID: 789,
@@ -584,7 +585,8 @@ func TestResourceJobUpdate_Restart(t *testing.T) {
 				ExpectedRequest: UpdateJobRequest{
 					JobID: 789,
 					NewSettings: &JobSettings{
-						Name: "Featurizer New",
+						Name:              "Featurizer New",
+						MaxConcurrentRuns: 1,
 					},
 				},
 			},

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -60,7 +60,7 @@ The following arguments are required:
 * `max_retries` - (Optional) (Integer) An optional maximum number of times to retry an unsuccessful run. A run is considered to be unsuccessful if it completes with a FAILED result_state or INTERNAL_ERROR life_cycle_state. The value -1 means to retry indefinitely and the value 0 means to never retry. The default behavior is to never retry.
 * `timeout_seconds` - (Optional) (Integer) An optional timeout applied to each run of this job. The default behavior is to have no timeout.
 * `min_retry_interval_millis` - (Optional) (Integer) An optional minimal interval in milliseconds between the start of the failed run and the subsequent retry run. The default behavior is that unsuccessful runs are immediately retried.
-* `max_concurrent_runs` - (Optional) (Integer) An optional maximum allowed number of concurrent runs of the job.
+* `max_concurrent_runs` - (Optional) (Integer) An optional maximum allowed number of concurrent runs of the job. Defaults to *1*.
 * `email_notifications` - (Optional) (List) An optional set of email addresses notified when runs of this job begin and complete and when this job is deleted. The default behavior is to not send any emails. This field is a block and is documented below.
 * `schedule` - (Optional) (List) An optional periodic schedule for this job. The default behavior is that the job runs when triggered by clicking Run Now in the Jobs UI or sending an API request to runNow. This field is a block and is documented below.
 


### PR DESCRIPTION
Fixes #739

This PR makes `max_concurrent_runs` on the `job` resource an optional attribute which defaults to `1`.

**Testing**. I ran the unit tests with `make test` but I didn't run the integration tests via `make test-azcli` or `make test-awsmt`. I don't mind running this, but would ask for some help here on how to run this without using my company's wrokspace as a test environment.

