### PR TITLE
Reset custom workspace configuration using value

### DIFF
--- a/workspace/resource_workspace_conf_test.go
+++ b/workspace/resource_workspace_conf_test.go
@@ -73,15 +73,25 @@ func TestWorkspaceConfUpdate(t *testing.T) {
 				Resource: "/api/2.0/workspace-conf",
 				ExpectedRequest: map[string]string{
 					"enableIpAccessLists": "true",
+					"enforceSomething":    "1",
 					"enableSomething":     "false",
 					"someProperty":        "",
 				},
 			},
 			{
 				Method:   http.MethodGet,
-				Resource: "/api/2.0/workspace-conf?keys=enableIpAccessLists",
+				Resource: "/api/2.0/workspace-conf?keys=enableIpAccessLists%2CenforceSomething",
 				Response: map[string]string{
 					"enableIpAccessLists": "true",
+					"enforceSomething":    "true",
+				},
+			},
+			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.0/workspace-conf?keys=enforceSomething%2CenableIpAccessLists",
+				Response: map[string]string{
+					"enableIpAccessLists": "true",
+					"enforceSomething":    "true",
 				},
 			},
 		},
@@ -92,6 +102,7 @@ func TestWorkspaceConfUpdate(t *testing.T) {
 		},
 		HCL: `custom_config {
 			enableIpAccessLists = "true"
+			enforceSomething = true
 		}`,
 		Update: true,
 		ID:     "_",
@@ -179,7 +190,7 @@ func TestWorkspaceConfDelete(t *testing.T) {
 			},
 		},
 		HCL: `custom_config {
-			enableSomething = "true"
+			enableSomething = true
 			enforceSomethingElse = "true"
 			enableFancyThing = "false"
 			someProperty = "thing"


### PR DESCRIPTION
Created this PR to address issue #823.

The issue shows that a key is added which doesn't comply to the expected naming conventions. As a consequence, the user is unable to remove the key, because it defaults to an invalid type according to the Databricks API.

This change replaces the key-based default value lookup with a value-based lookup. The lookup first checks the value type, and second tries to parse boolean strings.

Like the old implementation, this defaults to the `"false"`-string for boolean values, and default to the empty `""` string for all other values.