### PR TITLE
Add support for extra_configs in aws_s3_mount

### DIFF
--- a/storage/aws_s3_mount.go
+++ b/storage/aws_s3_mount.go
@@ -15,6 +15,7 @@ import (
 // AWSIamMount describes the object for a aws mount using iam role
 type AWSIamMount struct {
 	S3BucketName string `json:"s3_bucket_name"`
+    ExtraConfigs map[string]string `json:"extra_configs"`
 }
 
 // Source ...
@@ -24,7 +25,10 @@ func (m AWSIamMount) Source() string {
 
 // Config ...
 func (m AWSIamMount) Config(client *common.DatabricksClient) map[string]string {
-	return make(map[string]string) // return empty map so nil map does not marshal to null
+     if m.ExtraConfigs == nil {
+            return make(map[string]string)
+    }
+    return m.ExtraConfigs
 }
 
 // ResourceAWSS3Mount ...
@@ -58,6 +62,13 @@ func ResourceAWSS3Mount() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+           "extra_configs": {
+                Type:     schema.TypeMap,
+                Optional: true,
+                ForceNew: true,
+                Default:  make(map[string]interface{}),
+           },
+
 		},
 		SchemaVersion: 2,
 		Importer: &schema.ResourceImporter{

--- a/storage/aws_s3_mount_test.go
+++ b/storage/aws_s3_mount_test.go
@@ -42,8 +42,8 @@ func TestResourceAwsS3MountCreate(t *testing.T) {
 			t.Logf("Received command:\n%s", trunc)
 			if strings.HasPrefix(trunc, "def safe_mount") {
 				assert.Contains(t, trunc, testS3BucketPath) // bucketname
-				assert.Contains(t, trunc, `{}`)             // empty brackets for empty config
-			}
+			    assert.Contains(t, trunc, `{"fs.s3a.acl.default":"BucketOwnerFullControl"}`)             // empty brackets for empty config
+            }
 			assert.Contains(t, trunc, "/mnt/this_mount")
 			return common.CommandResults{
 				ResultType: "text",
@@ -54,6 +54,7 @@ func TestResourceAwsS3MountCreate(t *testing.T) {
 			"cluster_id":     "this_cluster",
 			"mount_name":     "this_mount",
 			"s3_bucket_name": testS3BucketName,
+            "extra_configs": map[string]interface{}{"fs.s3a.acl.default":"BucketOwnerFullControl"},
 		},
 		Create: true,
 	}.Apply(t)


### PR DESCRIPTION
Add support for extra_configs in aws_s3_mount.
Notebook usage:
```
dbutils.fs.mount("s3a://bucket-name", "/mnt/mount_path", extraConfigs=Map( 
"fs.s3a.acl.default" -> "BucketOwnerFullControl"
))
```

Terraform template usage:
```
resource "databricks_aws_s3_mount" "this" {
  provider = databricks.provider
  instance_profile = instance_profile.ds.id
  s3_bucket_name = var.bucket_name
  mount_name = var.bucket_mount_point
  extra_configs = {"fs.s3a.acl.default":"BucketOwnerFullControl"}
}
```

Test:
1. Unit test
2.  Create workspace with new extra_configs works well.