### PR TITLE
Added support to create `databricks_user` on the account level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added `databricks_repo` resource to manage [Databricks Repos](https://docs.databricks.com/repos.html) ([#771](https://github.com/databrickslabs/terraform-provider-databricks/pull/771))
 * Added support for Azure MSI authentication ([#743](https://github.com/databrickslabs/terraform-provider-databricks/pull/743))
+* Added support to create `databricks_user` on the account level ([#818](https://github.com/databrickslabs/terraform-provider-databricks/issues/818))
 * Already deleted `databricks_token` don't fail the apply ([#808](https://github.com/databrickslabs/terraform-provider-databricks/pull/808))
 * Default `terraform-mount` clusters created for mounting for `databricks_aws_s3_mount`, `databricks_azure_adls_gen1_mount`, `databricks_azure_adls_gen2_mount`, and `databricks_azure_blob_mount` have now `spark.scheduler.mode` as `FIFO` ([#828](https://github.com/databrickslabs/terraform-provider-databricks/pull/828))
 * Fixed crash when using non-Azure authentication to mount Azure resources ([#831](https://github.com/databrickslabs/terraform-provider-databricks/issues/831))

--- a/common/http.go
+++ b/common/http.go
@@ -336,6 +336,10 @@ func (c *DatabricksClient) api12(r *http.Request) error {
 func (c *DatabricksClient) Scim(ctx context.Context, method, path string, request interface{}, response interface{}) error {
 	body, err := c.authenticatedQuery(ctx, method, path, request, c.api2, func(r *http.Request) error {
 		r.Header.Set("Content-Type", "application/scim+json")
+		if c.isAccountsClient() && c.AccountID != "" {
+			// until `/preview` is there for workspace scim
+			r.URL.Path = strings.ReplaceAll(path, "/preview", fmt.Sprintf("/api/2.0/accounts/%s", c.AccountID))
+		}
 		return nil
 	})
 	if err != nil {

--- a/docs/index.md
+++ b/docs/index.md
@@ -174,6 +174,7 @@ Alternatively, you can provide this value as an environment variable `DATABRICKS
 * `config_file` - (optional) Location of the Databricks CLI credentials file created by `databricks configure --token` command (~/.databrickscfg by default). Check [Databricks CLI documentation](https://docs.databricks.com/dev-tools/cli/index.html#set-up-authentication) for more details. The provider uses configuration file credentials when you don't specify host/token/username/password/azure attributes. Alternatively, you can provide this value as an environment variable `DATABRICKS_CONFIG_FILE`. This field defaults to `~/.databrickscfg`. 
 * `profile` - (optional) Connection profile specified within ~/.databrickscfg. Please check [connection profiles section](https://docs.databricks.com/dev-tools/cli/index.html#connection-profiles) for more details. This field defaults to 
 `DEFAULT`.
+* `account_id` - (optional) Account Id that could be found in the bottom left corner of [Accounts Console](https://accounts.cloud.databricks.com/). Alternatively, you can provide this value as an environment variable `DATABRICKS_ACCOUNT_ID`. Only has effect when `host = "https://accounts.cloud.databricks.com/"` and currently used to provision account admins via [databricks_user](resources/user.md). In the future releases of the provider this property will also be used specify account for `databricks_mws_*` resources as well.
 
 ## Special configurations for Azure
 
@@ -283,6 +284,7 @@ The following configuration attributes can be passed via environment variables:
 |                       `token` | `DATABRICKS_TOKEN`                |
 |                    `username` | `DATABRICKS_USERNAME`             |
 |                    `password` | `DATABRICKS_PASSWORD`             |
+|                  `account_id` | `DATABRICKS_ACCOUNT_ID`           |
 |                 `config_file` | `DATABRICKS_CONFIG_FILE`          |
 |                     `profile` | `DATABRICKS_CONFIG_PROFILE`       |
 |         `azure_client_secret` | `ARM_CLIENT_SECRET`               |


### PR DESCRIPTION
This PR fixes #818 

```hcl
provider "databricks" {
  host = "https://accounts.cloud.databricks.com/"
  account_id = "aaaaaa-bbbb-cccc-dddd"
}

resource "databricks_user" "me_admin" {
  user_name = "me@example.com"
}
```