### PR TITLE
Suppress instance profile skip_validation diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.3.10
 
 * Added `private_access_level` and `allowed_vpc_endpoint_ids` to `databricks_mws_private_access_settings` resource, which is also now updatable ([#867](https://github.com/databrickslabs/terraform-provider-databricks/issues/867)).
+* Whenever `databricks_instance_profile` is created with `skip_validation = true`, create any changes to the field after resource is created won't have any effect ([#860](https://github.com/databrickslabs/terraform-provider-databricks/issues/860)).
 
 ## 0.3.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.3.10
 
 * Added `private_access_level` and `allowed_vpc_endpoint_ids` to `databricks_mws_private_access_settings` resource, which is also now updatable ([#867](https://github.com/databrickslabs/terraform-provider-databricks/issues/867)).
-* Whenever `databricks_instance_profile` is created with `skip_validation = true`, create any changes to the field after resource is created won't have any effect ([#860](https://github.com/databrickslabs/terraform-provider-databricks/issues/860)).
+* Fixed missing diff skip for `skip_validation` in `databricks_instance_profile` ([#860](https://github.com/databrickslabs/terraform-provider-databricks/issues/860)).
 
 ## 0.3.9
 

--- a/identity/resource_instance_profile.go
+++ b/identity/resource_instance_profile.go
@@ -138,6 +138,12 @@ func ResourceInstanceProfile() *schema.Resource {
 	instanceProfileSchema := common.StructToSchema(InstanceProfileInfo{},
 		func(m map[string]*schema.Schema) map[string]*schema.Schema {
 			m["instance_profile_arn"].ValidateDiagFunc = ValidInstanceProfile
+			m["skip_validation"].DiffSuppressFunc = func(k, old, new string, d *schema.ResourceData) bool {
+				if old == "false" && new == "true" {
+					return true
+				}
+				return false
+			}
 			return m
 		})
 	return common.Resource{


### PR DESCRIPTION
* Whenever `databricks_instance_profile` is created with `skip_validation = true`, create any changes to the field after resource is created won't have any effect.

Fixes #860