### PR TITLE
Prepare release v0.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 * Added `private_access_level` and `allowed_vpc_endpoint_ids` to `databricks_mws_private_access_settings` resource, which is also now updatable ([#867](https://github.com/databrickslabs/terraform-provider-databricks/issues/867)).
 * Fixed missing diff skip for `skip_validation` in `databricks_instance_profile` ([#860](https://github.com/databrickslabs/terraform-provider-databricks/issues/860)).
+* Added support for `pipeline_task` ([871](https://github.com/databrickslabs/terraform-provider-databricks/pull/871)) and `python_wheel_task` ([#872](https://github.com/databrickslabs/terraform-provider-databricks/pull/872)) to `databricks_job`.
+* Improved enterprise HTTPS proxy support for creating workspaces in PrivateLink environments ([#882](https://github.com/databrickslabs/terraform-provider-databricks/pull/882)).
+* Added `hostname` attribute to `odbc_params` in `databricks_sql_endpoint` ([#868](https://github.com/databrickslabs/terraform-provider-databricks/issues/868)).
+* Improved documentation ([#858](https://github.com/databrickslabs/terraform-provider-databricks/pull/858), [#870](https://github.com/databrickslabs/terraform-provider-databricks/pull/870)).
+
+Updated dependency versions:
+
+* Bumped google.golang.org/api from 0.58.0 to 0.59.0
 
 ## 0.3.9
 

--- a/compute/acceptance/job_test.go
+++ b/compute/acceptance/job_test.go
@@ -88,7 +88,7 @@ func TestAwsAccJobsCreate(t *testing.T) {
 	assert.True(t, job.Settings.NewCluster.SparkVersion == newSparkVersion, "Something is wrong with spark version")
 }
 
-func TestAccJobTasks(t *testing.T) {
+func TestPreviewAccJobTasks(t *testing.T) {
 	acceptance.Test(t, []acceptance.Step{
 		{
 			Template: `

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -137,6 +137,13 @@ You can invoke Spark submit tasks only on new clusters. **In the `new_cluster` s
 
 * `pipeline_id` - (Required) The pipeline's unique ID.
 
+### python_wheel_task Configuration Block
+
+* `entry_point` - (Optional) Python function as entry point for the task
+* `package_name` - (Optional) Name of Python package
+* `parameters` - (Optional) Parameters for the task
+* `named_parameters` - (Optional) Named parameters for the task
+
 ### email_notifications Configuration Block
 
 * `on_failure` - (Optional) (List) list of emails to notify on failure


### PR DESCRIPTION
## 0.3.10 changelog

* Added `private_access_level` and `allowed_vpc_endpoint_ids` to `databricks_mws_private_access_settings` resource, which is also now updatable ([#867](https://github.com/databrickslabs/terraform-provider-databricks/issues/867)).
* Fixed missing diff skip for `skip_validation` in `databricks_instance_profile` ([#860](https://github.com/databrickslabs/terraform-provider-databricks/issues/860)).
* Added support for `pipeline_task` ([871](https://github.com/databrickslabs/terraform-provider-databricks/pull/871)) and `python_wheel_task` ([#872](https://github.com/databrickslabs/terraform-provider-databricks/pull/872)) to `databricks_job`.
* Improved enterprise HTTPS proxy support for creating workspaces in PrivateLink environments ([#882](https://github.com/databrickslabs/terraform-provider-databricks/pull/882)).
* Added `hostname` attribute to `odbc_params` in `databricks_sql_endpoint` ([#868](https://github.com/databrickslabs/terraform-provider-databricks/issues/868)).
* Improved documentation ([#858](https://github.com/databrickslabs/terraform-provider-databricks/pull/858), [#870](https://github.com/databrickslabs/terraform-provider-databricks/pull/870)).

Updated dependency versions:

* Bumped google.golang.org/api from 0.58.0 to 0.59.0

mws
---

 * [x] mws.TestMwsAccCreds (3.18s)
 * [x] mws.TestMwsAccCustomerManagedKeys (4.55s)
 * [x] mws.TestMwsAccLogDelivery (8.85s)
 * [x] mws.TestMwsAccMissingResources (3.51s)
 * [x] mws.TestMwsAccMissingResources/Credential (0.81s)
 * [x] mws.TestMwsAccMissingResources/Customer_Managed_Key (0.65s)
 * [x] mws.TestMwsAccMissingResources/Network (0.63s)
 * [x] mws.TestMwsAccMissingResources/Storage (0.65s)
 * [x] mws.TestMwsAccMissingResources/Workspace (0.77s)
 * [x] mws.TestMwsAccPAS (3.62s)
 * [x] mws.TestMwsAccStorageConfigurations (2.51s)
 * [x] mws.TestMwsAccVPCEndpointIntegration (108.27s)
 * [x] mws.TestMwsAccWorkspace (0.65s)
 * [x] mws/acceptance.TestMwsAccCredentials (6.06s)
 * [x] mws/acceptance.TestMwsAccCustomerManagedKeys (8.30s)
 * [x] mws/acceptance.TestMwsAccLogDelivery (13.59s)
 * [x] mws/acceptance.TestMwsAccNetworks (5.53s)
 * [x] mws/acceptance.TestMwsAccPrivateAccessSettings (6.73s)
 * [x] mws/acceptance.TestMwsAccStorageConfigurations (6.45s)
 * [x] mws/acceptance.TestMwsAccVpcEndpoint (95.97s)
 * [x] mws/acceptance.TestMwsAccWorkspaces (124.08s)

gcp-accounts
---

 * [x] mws.TestGcpaAccWorkspace (74.89s)

azcli
---

 * [x] access.TestAccIPACL (9.38s)
 * [x] access.TestAccPermissionsClusterPolicy (8.06s)
 * [x] access.TestAccPermissionsClusters (200.64s)
 * [x] access.TestAccPermissionsInstancePool (8.82s)
 * [x] access.TestAccPermissionsJobs (9.65s)
 * [x] access.TestAccPermissionsNotebooks (18.27s)
 * [x] access.TestAccPermissionsTokens (6.70s)
 * [x] access/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (36.93s)
 * [x] access/acceptance.TestAccInitialManagePrincipals (1.50s)
 * [x] access/acceptance.TestAccInitialManagePrincipalsGroup (1.39s)
 * [x] access/acceptance.TestAccSecretAclResource (11.29s)
 * [x] access/acceptance.TestAccSecretAclResourceDefaultPrincipal (10.37s)
 * [x] access/acceptance.TestAccSecretResource (17.06s)
 * [x] access/acceptance.TestAccSecretScopeResource (18.28s)
 * [x] access/acceptance.TestAccTableACL (409.16s)
 * [x] access/acceptance.TestAzureAccKeyVaultSimple (3.26s)
 * [x] compute.TestAccContext (34.10s)
 * [x] compute.TestAccInstancePools (8.19s)
 * [x] compute.TestAccLibraryCreate (45.11s)
 * [x] compute.TestAccListClustersIntegration (192.53s)
 * [x] compute.TestAzureAccNodeTypes (0.42s)
 * [x] compute/acceptance.TestAccClusterPolicyResourceFullLifecycle (24.66s)
 * [x] compute/acceptance.TestAccJobResource (10.21s)
 * [x] identity.TestAccCreateToken (2.94s)
 * [x] identity.TestAccCreateToken_NoExpiration (2.71s)
 * [x] identity.TestAccCreateUser (5.66s)
 * [x] identity.TestAccFilterGroup (2.64s)
 * [x] identity.TestAccGroup (15.17s)
 * [x] identity.TestAccReadUser (2.62s)
 * [x] identity.TestAzureAccSP (5.26s)
 * [x] identity/acceptance.TestAccGroupMemberResource (16.76s)
 * [x] identity/acceptance.TestAccGroupResource (23.47s)
 * [x] identity/acceptance.TestAccGroupResource_verify_entitlements (15.66s)
 * [x] identity/acceptance.TestAccTokenResource (11.89s)
 * [x] identity/acceptance.TestAccUserResource (16.16s)
 * [x] identity/acceptance.TestAzureAccServicePrincipalResource (9.59s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace (2.93s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies (0.13s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies_Delete (0.28s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Clusters (0.19s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/DBFS_Files (0.33s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Groups (0.17s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Instance_Pools (0.13s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Jobs (0.15s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Notebooks (0.40s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_ACLs (0.13s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_Scopes (0.17s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secrets (0.17s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Tokens (0.67s)
 * [x] internal/sanity.TestAccMutiworkspaceUsedFromNormalMode (10.05s)
 * [x] storage.TestAccCreateFile (3.96s)
 * [x] storage.TestAccInvalidSecretScopeFails (5.27s)
 * [x] storage.TestAccSourceOnInvalidMountFails (26.53s)
 * [x] storage.TestAzureAccBlobMount (177.78s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (18.98s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (9.32s)
 * [x] storage/acceptance.TestAzureAccBlobMount_correctly_mounts (624.20s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (15.09s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (20.45s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (9.02s)

preview
---
 * Fail: TestPreviewAccDashboard (1202.60s)
 * Fail: TestPreviewAccSQLEndpoints (1200.65s)
 * [x] compute/acceptance.TestPreviewAccJobTasks (8.88s)
 * [x] compute/acceptance.TestPreviewAccPipelineResource_CreatePipeline (6.48s)

gcp
---
 * [x] TestAccInstancePools (1.99s)
 * [x] TestAccJobTasks (6.14s)
 * [x] TestAccListClustersIntegration (849.55s)
 * [x] access.TestAccIPACL (2.83s)
 * [x] access.TestAccPermissionsClusterPolicy (4.73s)
 * [x] access.TestAccPermissionsClusters (842.02s)
 * [x] access.TestAccPermissionsInstancePool (5.12s)
 * [x] access.TestAccPermissionsJobs (5.59s)
 * [x] access.TestAccPermissionsNotebooks (6.26s)
 * [x] access.TestAccPermissionsTokens (5.55s)
 * [x] access/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (32.44s)
 * [x] access/acceptance.TestAccInitialManagePrincipals (0.93s)
 * [x] access/acceptance.TestAccInitialManagePrincipalsGroup (0.69s)
 * [x] access/acceptance.TestAccSecretAclResource (9.71s)
 * [x] access/acceptance.TestAccSecretAclResourceDefaultPrincipal (6.19s)
 * [x] access/acceptance.TestAccSecretResource (12.16s)
 * [x] access/acceptance.TestAccSecretScopeResource (7.69s)
 * [x] compute.TestAccContext (51.81s)
 * [x] compute.TestAccLibraryCreate (95.28s)
 * [x] compute/acceptance.TestAccClusterPolicyResourceFullLifecycle (14.01s)
 * [x] compute/acceptance.TestAccJobResource (12.63s)
 * [x] identity.TestAccCreateToken (1.29s)
 * [x] identity.TestAccCreateToken_NoExpiration (1.22s)
 * [x] identity.TestAccCreateUser (2.93s)
 * [x] identity.TestAccFilterGroup (0.87s)
 * [x] identity.TestAccGroup (7.76s)
 * [x] identity.TestAccReadUser (0.94s)
 * [x] identity/acceptance.TestAccGroupMemberResource (11.12s)
 * [x] identity/acceptance.TestAccGroupResource (12.77s)
 * [x] identity/acceptance.TestAccGroupResource_verify_entitlements (14.99s)
 * [x] identity/acceptance.TestAccTokenResource (6.14s)
 * [x] identity/acceptance.TestAccUserResource (8.73s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace (6.26s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies (1.52s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies_Delete (0.51s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Clusters (0.45s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/DBFS_Files (0.75s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Groups (0.50s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Instance_Pools (0.48s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Jobs (0.43s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Notebooks (0.44s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_ACLs (0.43s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_Scopes (0.14s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secrets (0.15s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Tokens (0.47s)
 * [x] internal/sanity.TestAccMutiworkspaceUsedFromNormalMode (2.02s)
 * [x] storage.TestAccCreateFile (6.36s)
 * [x] storage.TestAccInvalidSecretScopeFails (4.39s)
 * [x] storage.TestAccSourceOnInvalidMountFails (893.65s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (13.70s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (11.42s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (8.72s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (14.88s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (4.41s)
