### PR TITLE
Create new group instead of updating the name

### DIFF
--- a/identity/resource_group.go
+++ b/identity/resource_group.go
@@ -13,6 +13,7 @@ func ResourceGroup() *schema.Resource {
 		"display_name": {
 			Type:     schema.TypeString,
 			Required: true,
+			ForceNew: true,
 		},
 		"url": {
 			Type:     schema.TypeString,

--- a/identity/resource_group_test.go
+++ b/identity/resource_group_test.go
@@ -278,6 +278,7 @@ func TestResourceGroupUpdate(t *testing.T) {
 		allow_cluster_create = true
 		allow_sql_analytics_access = true
 		`,
+		RequiresNew: true,
 		Update: true,
 		ID:     "abc",
 	}.Apply(t)
@@ -308,6 +309,7 @@ func TestResourceGroupUpdate_Error(t *testing.T) {
 			"allow_instance_pool_create": true,
 		},
 		Update: true,
+		RequiresNew: true,
 		ID:     "abc",
 	}.ExpectError(t, "Internal error happened")
 }


### PR DESCRIPTION
The SCIM API in use does not support updating group names.  This avoids:
```
2021-11-02T11:27:08.561Z [DEBUG] provider.terraform-provider-databricks_v0.3.9: 404 Not Found {
"detail": "Group not found.",
"schemas": [
],
"status": "404"
}: timestamp=2021-11-02T11:27:08.561Z
```
when trying to update group names

See: https://docs.databricks.com/dev-tools/api/latest/scim/scim-groups.html#update-group