### PR TITLE
Prepare v0.3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@
 * Added `databricks_sql_global_config` resource to provide global configuration for SQL Endpoints ([#855](https://github.com/databrickslabs/terraform-provider-databricks/issues/855))
 * Added `databricks_mount` resource to mount arbitrary cloud storage ([#497](https://github.com/databrickslabs/terraform-provider-databricks/issues/497))
 * Improved implementation of `databricks_repo` by creating the parent folder structure ([#895](https://github.com/databrickslabs/terraform-provider-databricks/pull/895))
+* Fixed `databricks_job` error related [to randomized job IDs](https://docs.databricks.com/release-notes/product/2021/august.html#jobs-service-stability-and-scalability-improvements) ([#901](https://github.com/databrickslabs/terraform-provider-databricks/issues/901))
+* Replace `databricks_group` on name change ([#890](https://github.com/databrickslabs/terraform-provider-databricks/pull/890))
+* Names of scopes in `databricks_secret_scope` can have `/` characters in them ([#892](https://github.com/databrickslabs/terraform-provider-databricks/pull/892))
+
+**Deprecations**
+* `databricks_aws_s3_mount`, `databricks_azure_adls_gen1_mount`, `databricks_azure_adls_gen2_mount`, and `databricks_azure_blob_mount` are deprecated in favor of `databricks_mount`.
+
+Updated dependency versions:
+
+* Bump google.golang.org/api from 0.59.0 to 0.60.0
 
 ## 0.3.10
 

--- a/docs/resources/mount.md
+++ b/docs/resources/mount.md
@@ -3,8 +3,6 @@ subcategory: "Storage"
 ---
 # databricks_mount Resource
 
--> **Note** This resource has an evolving API, which may change in future versions of the provider.
-
 This resource will mount your cloud storage account on `dbfs:/mnt/yourname`. Right now it supports mounting AWS S3, Azure (Blob Storage, ADLS Gen1 & Gen2), Google Cloud Storage.  It is important to understand that this will start up the [cluster](cluster.md) if the cluster is terminated. The read and refresh terraform command will require a cluster and may take some time to validate the mount. If `cluster_id` is not specified, it will create the smallest possible cluster with name equal to or starting with `terraform-mount` for the shortest possible amount of time.
 
 This resource provides two ways of mounting a storage account:
@@ -21,9 +19,9 @@ This resource provides two ways of mounting a storage account:
 
 * `cluster_id` - (Optional, String) Cluster to use for mounting. If no cluster is specified, a new cluster will be created and will mount the bucket for all of the clusters in this workspace. If the cluster is not running - it's going to be started, so be aware to set auto-termination rules on it.
 * `name` - (Optional, String) Name, under which mount will be accessible in `dbfs:/mnt/<MOUNT_NAME>`. If not specified, provider will try to infer it from depending on the resource type:
-  * bucket name for AWS S3 and Google Cloud Storage
-  * container name for ADLS Gen2 and Azure Blob Storage
-  * storage resource name for ADLS Gen1
+  * `bucket_name` for AWS S3 and Google Cloud Storage
+  * `container_name` for ADLS Gen2 and Azure Blob Storage
+  * `storage_resource_name` for ADLS Gen1
 * `uri` - (Optional, String) the URI for accessing specific storage (`s3a://....`, `abfss://....`, `gs://....`, etc.)
 * `extra_configs` - (Optional, String map) configuration parameters that are necessary for mounting of specific storage
 * `resource_id` - (Optional, String) resource ID for given storage account. Could be used to fill defaults, such as storage account & container names on Azure.
@@ -33,8 +31,8 @@ This resource provides two ways of mounting a storage account:
 
 ```hcl
 locals {
-  tenant_id = "8f35a392-f2ae-4280-9796-f1864a10eeec"
-  client_id = "d1b2a25b-86c4-451a-a0eb-0808be121957"
+  tenant_id = "00000000-1111-2222-3333-444444444444"
+  client_id = "55555555-6666-7777-8888-999999999999"
   secret_scope = "some-kv"
   secret_key = "some-sp-secret"
   container = "test"
@@ -82,9 +80,8 @@ data "azurerm_databricks_workspace" "this" {
 
 # it works only with AAD token!
 provider "databricks" {
-  azure_workspace_resource_id = data.azurerm_databricks_workspace.this.id
+  host = data.azurerm_databricks_workspace.this.workspace_url
 }
-
 
 data "databricks_node_type" "smallest" {
   local_disk = true

--- a/docs/resources/sql_global_config.md
+++ b/docs/resources/sql_global_config.md
@@ -5,7 +5,7 @@ subcategory: "Databricks SQL"
 
 -> **Public Preview** This feature is in [Public Preview](https://docs.databricks.com/release-notes/release-types.html).
 
-This resource configures the security policy, instance profile (AWS only), and data access properties for all SQL endpoints of workspace. *Please note that changing parameters of this resources will restart all running SQL endpoints.*  To use this resource you need to be an administrator.
+This resource configures the security policy, [databricks_instance_profile](instance_profile.md), and data access properties for all [databricks_sql_endpoint](sql_endpoint.md) of workspace. *Please note that changing parameters of this resources will restart all running [databricks_sql_endpoint](sql_endpoint.md).*  To use this resource you need to be an administrator.
 
 ## Example usage
 
@@ -24,8 +24,8 @@ resource "databricks_sql_global_config" "this" {
 The following arguments are supported (see [documentation](https://docs.databricks.com/sql/api/sql-endpoints.html#global-edit) for more details):
 
 * `security_policy` (Optional, String) - The policy for controlling access to datasets. Default value: `DATA_ACCESS_CONTROL`, consult documentation for list of possible values
-* `data_access_config` (Optional, Map) - data access configuration for SQL Endpoints, such as configuration for an external Hive metastore, Hadoop Filesystem configuration, etc.  Please note that the list of supported configuration properties is limited, so refer to the [documentation](https://docs.databricks.com/sql/admin/data-access-configuration.html#supported-properties) for a full list.  Apply will fail if you're specifying not permitted configuration.
-* `instance_profile_arn` (Optional, String) - Instance profile used to access storage from SQL endpoints. Please note that this parameter is only for AWS, and will generate an error if used on other clouds.
+* `data_access_config` (Optional, Map) - data access configuration for [databricks_sql_endpoint](sql_endpoint.md), such as configuration for an external Hive metastore, Hadoop Filesystem configuration, etc.  Please note that the list of supported configuration properties is limited, so refer to the [documentation](https://docs.databricks.com/sql/admin/data-access-configuration.html#supported-properties) for a full list.  Apply will fail if you're specifying not permitted configuration.
+* `instance_profile_arn` (Optional, String) - [databricks_instance_profile](instance_profile.md) used to access storage from [databricks_sql_endpoint](sql_endpoint.md). Please note that this parameter is only for AWS, and will generate an error if used on other clouds.
 
 ## Import
 

--- a/storage/adls_gen1_mount.go
+++ b/storage/adls_gen1_mount.go
@@ -46,7 +46,7 @@ func (m AzureADLSGen1Mount) Config(client *common.DatabricksClient) map[string]s
 
 // ResourceAzureAdlsGen1Mount creates the resource
 func ResourceAzureAdlsGen1Mount() *schema.Resource {
-	return commonMountResource(AzureADLSGen1Mount{}, map[string]*schema.Schema{
+	return deprecatedMountTesource(commonMountResource(AzureADLSGen1Mount{}, map[string]*schema.Schema{
 		"cluster_id": {
 			Type:     schema.TypeString,
 			Optional: true,
@@ -106,5 +106,5 @@ func ResourceAzureAdlsGen1Mount() *schema.Resource {
 			Required: true,
 			ForceNew: true,
 		},
-	})
+	}))
 }

--- a/storage/adls_gen2_mount.go
+++ b/storage/adls_gen2_mount.go
@@ -48,7 +48,7 @@ func (m AzureADLSGen2Mount) Config(client *common.DatabricksClient) map[string]s
 
 // ResourceAzureAdlsGen2Mount creates the resource
 func ResourceAzureAdlsGen2Mount() *schema.Resource {
-	return commonMountResource(AzureADLSGen2Mount{}, map[string]*schema.Schema{
+	return deprecatedMountTesource(commonMountResource(AzureADLSGen2Mount{}, map[string]*schema.Schema{
 		"cluster_id": {
 			Type:     schema.TypeString,
 			Optional: true,
@@ -106,5 +106,5 @@ func ResourceAzureAdlsGen2Mount() *schema.Resource {
 			Required: true,
 			ForceNew: true,
 		},
-	})
+	}))
 }

--- a/storage/aws_s3_mount.go
+++ b/storage/aws_s3_mount.go
@@ -39,6 +39,10 @@ func (m AWSIamMount) Config(client *common.DatabricksClient) map[string]string {
 func ResourceAWSS3Mount() *schema.Resource {
 	tpl := AWSIamMount{}
 	r := &schema.Resource{
+		DeprecationMessage: "Resource is deprecated and will be removed in further versions. " +
+			"Please rewrite configuration using `databricks_mount` resource. More info at " +
+			"https://registry.terraform.io/providers/databrickslabs/databricks/latest/docs/" +
+			"resources/mount#migration-from-other-mount-resources",
 		Schema: map[string]*schema.Schema{
 			"cluster_id": {
 				Type:     schema.TypeString,

--- a/storage/azure_blob_mount.go
+++ b/storage/azure_blob_mount.go
@@ -47,7 +47,7 @@ func (m AzureBlobMount) Config(client *common.DatabricksClient) map[string]strin
 
 // ResourceAzureBlobMount creates the resource
 func ResourceAzureBlobMount() *schema.Resource {
-	return commonMountResource(AzureBlobMount{}, map[string]*schema.Schema{
+	return deprecatedMountTesource(commonMountResource(AzureBlobMount{}, map[string]*schema.Schema{
 		"cluster_id": {
 			Type:     schema.TypeString,
 			Optional: true,
@@ -97,5 +97,5 @@ func ResourceAzureBlobMount() *schema.Resource {
 			Sensitive: true,
 			ForceNew:  true,
 		},
-	})
+	}))
 }

--- a/storage/mounts.go
+++ b/storage/mounts.go
@@ -100,7 +100,14 @@ func (mp MountPoint) Mount(mo Mount, client *common.DatabricksClient) (source st
 }
 
 func commonMountResource(tpl Mount, s map[string]*schema.Schema) *schema.Resource {
-	resource := &schema.Resource{Schema: s, SchemaVersion: 2}
+	resource := &schema.Resource{
+		DeprecationMessage: "Resource is deprecated and will be removed in further versions. " +
+			"Please rewrite configuration using `databricks_mount` resource. More info at " +
+			"https://registry.terraform.io/providers/databrickslabs/databricks/latest/docs/" +
+			"resources/mount#migration-from-other-mount-resources",
+		SchemaVersion: 2,
+		Schema:        s,
+	}
 	// nolint should be a bigger context-aware refactor
 	resource.CreateContext = mountCreate(tpl, resource)
 	resource.ReadContext = mountRead(tpl, resource)

--- a/storage/mounts.go
+++ b/storage/mounts.go
@@ -101,10 +101,6 @@ func (mp MountPoint) Mount(mo Mount, client *common.DatabricksClient) (source st
 
 func commonMountResource(tpl Mount, s map[string]*schema.Schema) *schema.Resource {
 	resource := &schema.Resource{
-		DeprecationMessage: "Resource is deprecated and will be removed in further versions. " +
-			"Please rewrite configuration using `databricks_mount` resource. More info at " +
-			"https://registry.terraform.io/providers/databrickslabs/databricks/latest/docs/" +
-			"resources/mount#migration-from-other-mount-resources",
 		SchemaVersion: 2,
 		Schema:        s,
 	}
@@ -116,6 +112,14 @@ func commonMountResource(tpl Mount, s map[string]*schema.Schema) *schema.Resourc
 		StateContext: schema.ImportStatePassthroughContext,
 	}
 	return resource
+}
+
+func deprecatedMountTesource(r *schema.Resource) *schema.Resource {
+	r.DeprecationMessage = "Resource is deprecated and will be removed in further versions. " +
+		"Please rewrite configuration using `databricks_mount` resource. More info at " +
+		"https://registry.terraform.io/providers/databrickslabs/databricks/latest/docs/" +
+		"resources/mount#migration-from-other-mount-resources"
+	return r
 }
 
 // NewMountPoint returns new mount point config


### PR DESCRIPTION
* Added `databricks_sql_global_config` resource to provide global configuration for SQL Endpoints ([#855](https://github.com/databrickslabs/terraform-provider-databricks/issues/855))
* Added `databricks_mount` resource to mount arbitrary cloud storage ([#497](https://github.com/databrickslabs/terraform-provider-databricks/issues/497))
* Improved implementation of `databricks_repo` by creating the parent folder structure ([#895](https://github.com/databrickslabs/terraform-provider-databricks/pull/895))
* Fixed `databricks_job` error related [to randomized job IDs](https://docs.databricks.com/release-notes/product/2021/august.html#jobs-service-stability-and-scalability-improvements) ([#901](https://github.com/databrickslabs/terraform-provider-databricks/issues/901))
* Replace `databricks_group` on name change ([#890](https://github.com/databrickslabs/terraform-provider-databricks/pull/890))
* Names of scopes in `databricks_secret_scope` can have `/` characters in them ([#892](https://github.com/databrickslabs/terraform-provider-databricks/pull/892))

**Deprecations**
* `databricks_aws_s3_mount`, `databricks_azure_adls_gen1_mount`, `databricks_azure_adls_gen2_mount`, and `databricks_azure_blob_mount` are deprecated in favor of `databricks_mount`.

Updated dependency versions:

* Bump google.golang.org/api from 0.59.0 to 0.60.0

awsmt
---
 * [x] TestAccClusterResource_CreateClusterWithLibraries (343.92s)
 * [x] TestAwsAccS3Mount (1830.00s)
 * [x] access.TestAccIPACL (1.80s)
 * [x] access.TestAccPermissionsClusterPolicy (18.68s)
 * [x] access.TestAccPermissionsClusters (398.28s)
 * [x] access.TestAccPermissionsInstancePool (15.33s)
 * [x] access.TestAccPermissionsJobs (16.80s)
 * [x] access.TestAccPermissionsNotebooks (18.05s)
 * [x] access.TestAccPermissionsTokens (16.37s)
 * [x] access/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (59.54s)
 * [x] access/acceptance.TestAccInitialManagePrincipals (2.09s)
 * [x] access/acceptance.TestAccInitialManagePrincipalsGroup (0.79s)
 * [x] access/acceptance.TestAccSecretAclResource (14.91s)
 * [x] access/acceptance.TestAccSecretAclResourceDefaultPrincipal (6.86s)
 * [x] access/acceptance.TestAccSecretResource (8.75s)
 * [x] access/acceptance.TestAccSecretScopeResource (7.00s)
 * [x] access/acceptance.TestAccTableACL (683.06s)
 * [x] compute.TestAccContext (142.18s)
 * [x] compute.TestAccInstancePools (1.53s)
 * [x] compute.TestAccLibraryCreate (140.65s)
 * [x] compute.TestAccListClustersIntegration (318.52s)
 * [x] compute.TestAwsAccSmallestNodeType (0.20s)
 * [x] compute/acceptance.TestAccClusterPolicyResourceFullLifecycle (17.57s)
 * [x] compute/acceptance.TestAccClusterResource_CreateSingleNodeCluster (95.18s)
 * [x] compute/acceptance.TestAccJobResource (3.36s)
 * [x] compute/acceptance.TestAwsAccJobResource_NoInstancePool (2.80s)
 * [x] compute/acceptance.TestAwsAccJobsCreate (2.06s)
 * [x] identity.TestAccCreateToken (0.75s)
 * [x] identity.TestAccCreateToken_NoExpiration (0.34s)
 * [x] identity.TestAccCreateUser (8.86s)
 * [x] identity.TestAccFilterGroup (1.88s)
 * [x] identity.TestAccGroup (30.00s)
 * [x] identity.TestAccReadUser (2.18s)
 * [x] identity.TestAwsAccInstanceProfiles (1586.21s)
 * [x] identity.TestAwsAccInstanceProfilesSkippingValidation (1.87s)
 * [x] identity.TestAwsAccOboFlow (12.40s)
 * [x] identity/acceptance.TestAccGroupMemberResource (30.82s)
 * [x] identity/acceptance.TestAccGroupResource (21.52s)
 * [x] identity/acceptance.TestAccGroupResource_verify_entitlements (15.15s)
 * [x] identity/acceptance.TestAccTokenResource (3.75s)
 * [x] identity/acceptance.TestAccUserResource (12.26s)
 * [x] identity/acceptance.TestAwsAccGroupInstanceProfileResource (1611.19s)
 * [x] identity/acceptance.TestAwsAccOboTokenResource (29.95s)
 * [x] identity/acceptance.TestAwsAccServicePrincipalResource (8.58s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace (6.86s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies (0.12s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies_Delete (0.44s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Clusters (0.26s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/DBFS_Files (0.91s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Groups (0.98s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Instance_Pools (0.28s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Instance_Profiles (1.02s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Jobs (0.66s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Notebooks (0.12s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_ACLs (0.26s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_Scopes (0.55s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secrets (0.56s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Tokens (0.69s)
 * [x] internal/sanity.TestAccMutiworkspaceUsedFromNormalMode (2.44s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (8.98s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (6.13s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (3.00s)

mws
---

 * [x] mws.TestMwsAccCreds (3.19s)
 * [x] mws.TestMwsAccCustomerManagedKeys (4.27s)
 * [x] mws.TestMwsAccLogDelivery (8.55s)
 * [x] mws.TestMwsAccMissingResources (3.07s)
 * [x] mws.TestMwsAccMissingResources/Credential (0.71s)
 * [x] mws.TestMwsAccMissingResources/Customer_Managed_Key (0.55s)
 * [x] mws.TestMwsAccMissingResources/Network (0.57s)
 * [x] mws.TestMwsAccMissingResources/Storage (0.58s)
 * [x] mws.TestMwsAccMissingResources/Workspace (0.66s)
 * [x] mws.TestMwsAccPAS (3.44s)
 * [x] mws.TestMwsAccStorageConfigurations (2.53s)
 * [x] mws.TestMwsAccVPCEndpointIntegration (118.24s)
 * [x] mws.TestMwsAccWorkspace (1.06s)
 * [x] mws/acceptance.TestMwsAccCredentials (5.73s)
 * [x] mws/acceptance.TestMwsAccCustomerManagedKeys (9.80s)
 * [x] mws/acceptance.TestMwsAccLogDelivery (15.54s)
 * [x] mws/acceptance.TestMwsAccNetworks (5.26s)
 * [x] mws/acceptance.TestMwsAccPrivateAccessSettings (6.11s)
 * [x] mws/acceptance.TestMwsAccStorageConfigurations (6.51s)
 * [x] mws/acceptance.TestMwsAccVpcEndpoint (95.30s)
 * [x] mws/acceptance.TestMwsAccWorkspaces (119.82s)

azcli
---

 * [x] access.TestAccIPACL (11.42s)
 * [x] access.TestAccPermissionsClusterPolicy (6.79s)
 * [x] access.TestAccPermissionsClusters (227.39s)
 * [x] access.TestAccPermissionsInstancePool (7.24s)
 * [x] access.TestAccPermissionsJobs (16.65s)
 * [x] access.TestAccPermissionsNotebooks (17.08s)
 * [x] access.TestAccPermissionsTokens (12.00s)
 * [x] access/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (35.03s)
 * [x] access/acceptance.TestAccInitialManagePrincipals (1.79s)
 * [x] access/acceptance.TestAccInitialManagePrincipalsGroup (1.11s)
 * [x] access/acceptance.TestAccSecretAclResource (11.51s)
 * [x] access/acceptance.TestAccSecretAclResourceDefaultPrincipal (10.03s)
 * [x] access/acceptance.TestAccSecretResource (16.27s)
 * [x] access/acceptance.TestAccSecretScopeResource (17.11s)
 * [x] access/acceptance.TestAccTableACL (430.52s)
 * [x] access/acceptance.TestAzureAccKeyVaultSimple (6.07s)
 * [x] compute.TestAccContext (54.00s)
 * [x] compute.TestAccInstancePools (3.17s)
 * [x] compute.TestAccLibraryCreate (40.94s)
 * [x] compute.TestAccListClustersIntegration (249.18s)
 * [x] compute.TestAzureAccNodeTypes (1.41s)
 * [x] compute/acceptance.TestAccClusterPolicyResourceFullLifecycle (26.18s)
 * [x] compute/acceptance.TestAccJobResource (9.88s)
 * [x] identity.TestAccCreateToken (2.72s)
 * [x] identity.TestAccCreateToken_NoExpiration (2.60s)
 * [x] identity.TestAccCreateUser (4.64s)
 * [x] identity.TestAccFilterGroup (2.61s)
 * [x] identity.TestAccGroup (17.80s)
 * [x] identity.TestAccReadUser (2.92s)
 * [x] identity.TestAzureAccSP (4.45s)
 * [x] identity/acceptance.TestAccGroupMemberResource (15.43s)
 * [x] identity/acceptance.TestAccGroupResource (24.14s)
 * [x] identity/acceptance.TestAccGroupResource_verify_entitlements (15.95s)
 * [x] identity/acceptance.TestAccTokenResource (11.60s)
 * [x] identity/acceptance.TestAccUserResource (14.90s)
 * [x] identity/acceptance.TestAzureAccServicePrincipalResource (8.70s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace (2.05s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies (0.11s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies_Delete (0.28s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Clusters (0.09s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/DBFS_Files (0.34s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Groups (0.11s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Instance_Pools (0.11s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Jobs (0.11s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Notebooks (0.23s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_ACLs (0.09s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_Scopes (0.15s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secrets (0.15s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Tokens (0.30s)
 * [x] internal/sanity.TestAccMutiworkspaceUsedFromNormalMode (12.39s)
 * [x] storage.TestAccCreateFile (3.62s)
 * [x] storage.TestAccInvalidSecretScopeFails (5.77s)
 * [x] storage.TestAccSourceOnInvalidMountFails (38.38s)
 * [x] storage.TestAzureAccBlobMount (169.92s)
 * [x] storage.TestAzureAccBlobMountGeneric (158.09s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (19.36s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (7.59s)
 * [x] storage/acceptance.TestAzureAccBlobMount_correctly_mounts (672.90s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (13.91s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (17.99s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (8.78s)

gcp
---
 * [x] TestAccInstancePools (2.01s)
 * [x] TestAccListClustersIntegration (928.90s)
 * [x] access.TestAccIPACL (1.69s)
 * [x] access.TestAccPermissionsClusterPolicy (4.63s)
 * [x] access.TestAccPermissionsClusters (943.08s)
 * [x] access.TestAccPermissionsInstancePool (5.04s)
 * [x] access.TestAccPermissionsJobs (5.31s)
 * [x] access.TestAccPermissionsNotebooks (5.77s)
 * [x] access.TestAccPermissionsTokens (4.85s)
 * [x] access/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (23.20s)
 * [x] access/acceptance.TestAccInitialManagePrincipals (0.94s)
 * [x] access/acceptance.TestAccInitialManagePrincipalsGroup (0.67s)
 * [x] access/acceptance.TestAccSecretAclResource (6.69s)
 * [x] access/acceptance.TestAccSecretAclResourceDefaultPrincipal (4.81s)
 * [x] access/acceptance.TestAccSecretResource (8.26s)
 * [x] access/acceptance.TestAccSecretScopeResource (7.81s)
 * [x] compute.TestAccContext (21.07s)
 * [x] compute.TestAccLibraryCreate (84.91s)
 * [x] compute/acceptance.TestAccClusterPolicyResourceFullLifecycle (11.94s)
 * [x] compute/acceptance.TestAccJobResource (4.26s)
 * [x] identity.TestAccCreateToken (1.12s)
 * [x] identity.TestAccCreateToken_NoExpiration (1.06s)
 * [x] identity.TestAccCreateUser (2.75s)
 * [x] identity.TestAccFilterGroup (0.81s)
 * [x] identity.TestAccGroup (6.54s)
 * [x] identity.TestAccReadUser (0.91s)
 * [x] identity/acceptance.TestAccGroupMemberResource (10.30s)
 * [x] identity/acceptance.TestAccGroupResource (10.58s)
 * [x] identity/acceptance.TestAccGroupResource_verify_entitlements (6.84s)
 * [x] identity/acceptance.TestAccTokenResource (6.12s)
 * [x] identity/acceptance.TestAccUserResource (7.43s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace (5.05s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies (0.43s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Cluster_Policies_Delete (0.52s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Clusters (0.42s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/DBFS_Files (0.49s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Groups (0.50s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Instance_Pools (0.50s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Jobs (0.43s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Notebooks (0.44s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_ACLs (0.53s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secret_Scopes (0.15s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Secrets (0.19s)
 * [x] internal/sanity.TestAccMissingResourcesInWorkspace/Tokens (0.46s)
 * [x] internal/sanity.TestAccMutiworkspaceUsedFromNormalMode (2.08s)
 * [x] storage.TestAccCreateFile (6.01s)
 * [x] storage.TestAccInvalidSecretScopeFails (4.42s)
 * [x] storage.TestAccSourceOnInvalidMountFails (946.77s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (9.34s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (4.68s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (8.60s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (7.66s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (3.85s)
