### PR TITLE
Ignore autoaz changes

### DIFF
--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -3,6 +3,7 @@ package clusters
 import (
 	"context"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -47,9 +48,19 @@ func SparkConfDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool 
 	return false
 }
 
+func AwsAttribsDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
+	if strings.HasPrefix(k, "aws_attributes.") &&
+		strings.HasSuffix(k, ".zone_id") && new == "auto" {
+		log.Printf("[DEBUG] Suppressing diff for k=%#v old=%#v new=%#v", k, old, new)
+		return true
+	}
+	return false
+}
+
 func resourceClusterSchema() map[string]*schema.Schema {
 	return common.StructToSchema(Cluster{}, func(s map[string]*schema.Schema) map[string]*schema.Schema {
 		s["spark_conf"].DiffSuppressFunc = SparkConfDiffSuppressFunc
+		s["aws_attributes"].DiffSuppressFunc = AwsAttribsDiffSuppressFunc
 		// adds `library` configuration block
 		s["library"] = common.StructToSchema(libraries.ClusterLibraryList{},
 			func(ss map[string]*schema.Schema) map[string]*schema.Schema {

--- a/clusters/resource_cluster.go
+++ b/clusters/resource_cluster.go
@@ -3,7 +3,6 @@ package clusters
 import (
 	"context"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -49,8 +48,7 @@ func SparkConfDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool 
 }
 
 func AwsAttribsDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
-	if strings.HasPrefix(k, "aws_attributes.") &&
-		strings.HasSuffix(k, ".zone_id") && new == "auto" {
+	if k == "aws_attributes.0.zone_id" && old != "" && new == "auto" {
 		log.Printf("[DEBUG] Suppressing diff for k=%#v old=%#v new=%#v", k, old, new)
 		return true
 	}

--- a/clusters/resource_cluster_test.go
+++ b/clusters/resource_cluster_test.go
@@ -921,6 +921,7 @@ func TestResourceClusterUpdate_AutoAz(t *testing.T) {
 					AwsAttributes: &AwsAttributes{
 						Availability:  "SPOT",
 						FirstOnDemand: 1,
+						ZoneID:        "auto",
 					},
 				},
 			},

--- a/clusters/resource_cluster_test.go
+++ b/clusters/resource_cluster_test.go
@@ -858,6 +858,100 @@ func TestResourceClusterUpdate_Error(t *testing.T) {
 	assert.Equal(t, "abc", d.Id())
 }
 
+func TestResourceClusterUpdate_AutoAzNoChange(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:       "GET",
+				Resource:     "/api/2.0/clusters/get?cluster_id=abc",
+				ReuseRequest: true,
+				Response: ClusterInfo{
+					ClusterID:              "abc",
+					NumWorkers:             100,
+					ClusterName:            "Shared Autoscaling",
+					SparkVersion:           "7.1-scala12",
+					NodeTypeID:             "i3.xlarge",
+					AutoterminationMinutes: 15,
+					State:                  ClusterStateRunning,
+					AwsAttributes: &AwsAttributes{
+						Availability:  "SPOT",
+						FirstOnDemand: 1,
+						ZoneID:        "us-west-2a",
+					},
+				},
+			},
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/clusters/events",
+				ExpectedRequest: EventsRequest{
+					ClusterID:  "abc",
+					Limit:      1,
+					Order:      SortDescending,
+					EventTypes: []ClusterEventType{EvTypePinned, EvTypeUnpinned},
+				},
+				Response: EventsResponse{
+					Events:     []ClusterEvent{},
+					TotalCount: 0,
+				},
+			},
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/clusters/start",
+				ExpectedRequest: ClusterID{
+					ClusterID: "abc",
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/libraries/cluster-status?cluster_id=abc",
+				Response: libraries.ClusterLibraryStatuses{
+					LibraryStatuses: []libraries.LibraryStatus{},
+				},
+			},
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/clusters/edit",
+				ExpectedRequest: Cluster{
+					AutoterminationMinutes: 15,
+					ClusterID:              "abc",
+					NumWorkers:             100,
+					ClusterName:            "Shared Autoscaling",
+					SparkVersion:           "7.1-scala12",
+					NodeTypeID:             "i3.xlarge",
+					AwsAttributes: &AwsAttributes{
+						Availability:  "SPOT",
+						FirstOnDemand: 1,
+					},
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/libraries/cluster-status?cluster_id=abc",
+				Response: libraries.ClusterLibraryStatuses{
+					LibraryStatuses: []libraries.LibraryStatus{},
+				},
+			},
+		},
+		ID:       "abc",
+		Update:   true,
+		Resource: ResourceCluster(),
+		HCL: `
+		autotermination_minutes = 15
+		cluster_name = "Shared Autoscaling"
+		spark_version = "7.1-scala12"
+		node_type_id = "i3.xlarge"
+		num_workers = 100,
+		aws_attributes {
+			availability            = "SPOT"
+			zone_id                 = "auto"
+			first_on_demand         = 1
+		}
+		`,
+	}.Apply(t)
+	assert.NoError(t, err, err)
+	assert.Equal(t, "abc", d.Id(), "Id should be the same as in reading")
+}
+
 func TestResourceClusterDelete(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{

--- a/clusters/resource_cluster_test.go
+++ b/clusters/resource_cluster_test.go
@@ -858,7 +858,7 @@ func TestResourceClusterUpdate_Error(t *testing.T) {
 	assert.Equal(t, "abc", d.Id())
 }
 
-func TestResourceClusterUpdate_AutoAzNoChange(t *testing.T) {
+func TestResourceClusterUpdate_AutoAz(t *testing.T) {
 	d, err := qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{

--- a/pipelines/resource_pipeline.go
+++ b/pipelines/resource_pipeline.go
@@ -200,6 +200,7 @@ func adjustPipelineResourceSchema(m map[string]*schema.Schema) map[string]*schem
 	cluster, _ := m["cluster"].Elem.(*schema.Resource)
 	clustersSchema := cluster.Schema
 	clustersSchema["spark_conf"].DiffSuppressFunc = clusters.SparkConfDiffSuppressFunc
+	clustersSchema["aws_attributes"].DiffSuppressFunc = clusters.AwsAttribsDiffSuppressFunc
 
 	awsAttributes, _ := clustersSchema["aws_attributes"].Elem.(*schema.Resource)
 	awsAttributesSchema := awsAttributes.Schema


### PR DESCRIPTION
This change will prevent Terraform to restart a cluster which AwsAttributes.zone_id = "auto", as this is an unneeded/unwanted behavior.