### PR TITLE
Rename `allow_sql_analytics_access` to `databricks_sql_access`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,31 @@
 
 ## 0.4.0
 
+* Added `databricks_mlflow_model` and `databricks_mlflow_experiment` resources ([#931](https://github.com/databrickslabs/terraform-provider-databricks/pull/931)) 
 * Added support for `repo_path` to `databricks_permissions` resource ([#875](https://github.com/databrickslabs/terraform-provider-databricks/issues/875)).
+* Added `external_id` to `databricks_user` and `databricks_group` ([#927](https://github.com/databrickslabs/terraform-provider-databricks/pull/927)).
+* Fixed `databricks_repo` creation corner cases on MS Windows OS ([#911](https://github.com/databrickslabs/terraform-provider-databricks/issues/911)).
+* Fixed configuration drift for `databricks_cluster`.`aws_attributes`.`zone_id` with `auto`, which resulted in unwanted cluster restarts ([#937](https://github.com/databrickslabs/terraform-provider-databricks/pull/937)).
+* Added new experimental resources, increased test coverage, and automated integration testing infrastructure.
+* Multiple documentation improvements and new guides.
 
 **Behavior changes**
 
+* Renamed `allow_sql_analytics_access` to `databricks_sql_access` in `databricks_user`, `databricks_group`, and `databricks_service_principal` resources.
 * Removed deprecated `azure_use_pat_for_spn`, `azure_use_pat_for_cli`, `azure_pat_token_duration_seconds` provider attributes.
 * Removed deprecated `azure_workspace_name`, `azure_resource_group`, `azure_subscription_id` in favor of just using `azure_workspace_resource_id`.
 * Renamed `DATABRICKS_AZURE_WORKSPACE_RESOURCE_ID` environment variable to `DATABRICKS_AZURE_RESOURCE_ID`.
 * `DATABRICKS_AZURE_CLIENT_SECRET` environment variable is no longer having any effect in favor of just using `ARM_CLIENT_SECRET`.
 * `DATABRICKS_AZURE_CLIENT_ID` environment variable is no longer having any effect in favor of just using `ARM_CLIENT_ID`.
 * `DATABRICKS_AZURE_TENANT_ID` environment variable is no longer having any effect in favor of just using `ARM_TENANT_ID`.
+
+Updated dependency versions:
+
+* Bump github.com/hashicorp/terraform-plugin-sdk/v2 from 2.7.1 to 2.9.0
+* Bump github.com/Azure/go-autorest/autorest/adal from 0.9.16 to 0.9.17
+* Bump github.com/golang-jwt/jwt/v4 from 4.0.0 to 4.1.0
+* Bump github.com/zclconf/go-cty from 1.9.1 to 1.10.0
+* Bump github.com/Azure/go-autorest/autorest from 0.11.21 to 0.11.22
 
 ## 0.3.11
 

--- a/docs/guides/migration-0.4.x.md
+++ b/docs/guides/migration-0.4.x.md
@@ -17,3 +17,7 @@ Certain resources undergone changes in order to improve long-term maintainabilit
 ## databricks_mount
 
 * Rewrite deprecated `databricks_aws_s3_mount`, `databricks_azure_adls_gen1_mount`, `databricks_azure_adls_gen2_mount`, and `databricks_azure_blob_mount` resources into `databricks_mount`.
+
+## databricks_user and databricks_group
+
+* Globally rename `allow_sql_analytics_access` to `databricks_sql_access` field to allow users and groups access to Databricks SQL

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -50,7 +50,7 @@ The following arguments are supported:
 * `external_id` - (Optional) ID of the group in an external identity provider.
 * `allow_cluster_create` -  (Optional) This is a field to allow the group to have [cluster](cluster.md) create privileges. More fine grained permissions could be assigned with [databricks_permissions](permissions.md#Cluster-usage) and [cluster_id](permissions.md#cluster_id) argument. Everyone without `allow_cluster_create` argument set, but with [permission to use](permissions.md#Cluster-Policy-usage) Cluster Policy would be able to create clusters, but within boundaries of that specific policy.
 * `allow_instance_pool_create` -  (Optional) This is a field to allow the group to have [instance pool](instance_pool.md) create privileges. More fine grained permissions could be assigned with [databricks_permissions](permissions.md#Instance-Pool-usage) and [instance_pool_id](permissions.md#instance_pool_id) argument.
-* `allow_sql_analytics_access` - (Optional) This is a field to allow the group to have access to [Databricks SQL](https://databricks.com/product/databricks-sql) feature through [databricks_sql_endpoint](sql_endpoint.md).
+* `databricks_sql_access` - (Optional) This is a field to allow the group to have access to [Databricks SQL](https://databricks.com/product/databricks-sql) feature in User Interface and through [databricks_sql_endpoint](sql_endpoint.md).
 * `workspace_access` - (Optional) This is a field to allow the group to have access to Databricks Workspace.
 
 ## Attribute Reference

--- a/docs/resources/service_principal.md
+++ b/docs/resources/service_principal.md
@@ -52,6 +52,8 @@ The following arguments are available:
 * `display_name` - (Required) This is an alias for the service principal and can be the full name of the service principal.
 * `allow_cluster_create` -  (Optional) Allow the service principal to have [cluster](cluster.md) create privileges. Defaults to false. More fine grained permissions could be assigned with [databricks_permissions](permissions.md#Cluster-usage) and `cluster_id` argument. Everyone without `allow_cluster_create` argument set, but with [permission to use](permissions.md#Cluster-Policy-usage) Cluster Policy would be able to create clusters, but within the boundaries of that specific policy.
 * `allow_instance_pool_create` -  (Optional) Allow the service principal to have [instance pool](instance_pool.md) create privileges. Defaults to false. More fine grained permissions could be assigned with [databricks_permissions](permissions.md#Instance-Pool-usage) and [instance_pool_id](permissions.md#instance_pool_id) argument.
+* `databricks_sql_access` - (Optional) This is a field to allow the group to have access to [Databricks SQL](https://databricks.com/product/databricks-sql) feature through [databricks_sql_endpoint](sql_endpoint.md).
+* `workspace_access` - (Optional) This is a field to allow the group to have access to Databricks Workspace.
 * `active` - (Optional) Either service principal is active or not. True by default, but can be set to false in case of service principal deactivation with preserving service principal assets.
 
 ## Attribute Reference

--- a/docs/resources/sql_dashboard.md
+++ b/docs/resources/sql_dashboard.md
@@ -5,7 +5,7 @@ subcategory: "Databricks SQL"
 
 -> **Public Preview** This feature is in [Public Preview](https://docs.databricks.com/release-notes/release-types.html).
 
-To manage [SQLA resources](https://docs.databricks.com/sql/get-started/concepts.html) you must have `allow_sql_analytics_access` on your [databricks_group](group.md#allow_sql_analytics_access) or [databricks_user](user.md#allow_sql_analytics_access).
+To manage [SQLA resources](https://docs.databricks.com/sql/get-started/concepts.html) you must have `databricks_sql_access` on your [databricks_group](group.md#databricks_sql_access) or [databricks_user](user.md#databricks_sql_access).
 
 **Note:** documentation for this resource is a work in progress.
 

--- a/docs/resources/sql_endpoint.md
+++ b/docs/resources/sql_endpoint.md
@@ -5,7 +5,7 @@ subcategory: "Databricks SQL"
 
 -> **Public Preview** This feature is in [Public Preview](https://docs.databricks.com/release-notes/release-types.html).
 
-To create [SQL endpoints](https://docs.databricks.com/sql/get-started/concepts.html) you must have `allow_sql_analytics_access` on your [databricks_group](group.md#allow_sql_analytics_access) or [databricks_user](user.md#allow_sql_analytics_access).
+To create [SQL endpoints](https://docs.databricks.com/sql/get-started/concepts.html) you must have `databricks_sql_access` on your [databricks_group](group.md#databricks_sql_access) or [databricks_user](user.md#databricks_sql_access).
 
 ## Example usage
 
@@ -51,7 +51,7 @@ In addition to all arguments above, the following attributes are exported:
 ## Access Control
 
 * [databricks_permissions](permissions.md#Job-Endpoint-usage) can control which groups or individual users can *Can Use* or *Can Manage* SQL endpoints.
-* `allow_sql_analytics_access` on [databricks_group](group.md#allow_sql_analytics_access) or [databricks_user](user.md#allow_sql_analytics_access).
+* `databricks_sql_access` on [databricks_group](group.md#databricks_sql_access) or [databricks_user](user.md#databricks_sql_access).
 
 ## Timeouts
 

--- a/docs/resources/sql_query.md
+++ b/docs/resources/sql_query.md
@@ -5,7 +5,7 @@ subcategory: "Databricks SQL"
 
 -> **Public Preview** This feature is in [Public Preview](https://docs.databricks.com/release-notes/release-types.html).
 
-To manage [SQLA resources](https://docs.databricks.com/sql/get-started/concepts.html) you must have `allow_sql_analytics_access` on your [databricks_group](group.md#allow_sql_analytics_access) or [databricks_user](user.md#allow_sql_analytics_access).
+To manage [SQLA resources](https://docs.databricks.com/sql/get-started/concepts.html) you must have `databricks_sql_access` on your [databricks_group](group.md#databricks_sql_access) or [databricks_user](user.md#databricks_sql_access).
 
 **Note:** documentation for this resource is a work in progress.
 

--- a/docs/resources/sql_visualization.md
+++ b/docs/resources/sql_visualization.md
@@ -5,7 +5,7 @@ subcategory: "Databricks SQL"
 
 -> **Public Preview** This feature is in [Public Preview](https://docs.databricks.com/release-notes/release-types.html).
 
-To manage [SQLA resources](https://docs.databricks.com/sql/get-started/concepts.html) you must have `allow_sql_analytics_access` on your [databricks_group](group.md#allow_sql_analytics_access) or [databricks_user](user.md#allow_sql_analytics_access).
+To manage [SQLA resources](https://docs.databricks.com/sql/get-started/concepts.html) you must have `databricks_sql_access` on your [databricks_group](group.md#databricks_sql_access) or [databricks_user](user.md#databricks_sql_access).
 
 **Note:** documentation for this resource is a work in progress.
 

--- a/docs/resources/sql_widget.md
+++ b/docs/resources/sql_widget.md
@@ -5,7 +5,7 @@ subcategory: "Databricks SQL"
 
 -> **Public Preview** This feature is in [Public Preview](https://docs.databricks.com/release-notes/release-types.html).
 
-To manage [SQLA resources](https://docs.databricks.com/sql/get-started/concepts.html) you must have `allow_sql_analytics_access` on your [databricks_group](group.md#allow_sql_analytics_access) or [databricks_user](user.md#allow_sql_analytics_access).
+To manage [SQLA resources](https://docs.databricks.com/sql/get-started/concepts.html) you must have `databricks_sql_access` on your [databricks_group](group.md#databricks_sql_access) or [databricks_user](user.md#databricks_sql_access).
 
 **Note:** documentation for this resource is a work in progress.
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -51,7 +51,7 @@ The following arguments are available:
 * `external_id` - (Optional) ID of the user in an external identity provider.
 * `allow_cluster_create` -  (Optional) Allow the user to have [cluster](cluster.md) create privileges. Defaults to false. More fine grained permissions could be assigned with [databricks_permissions](permissions.md#Cluster-usage) and `cluster_id` argument. Everyone without `allow_cluster_create` argument set, but with [permission to use](permissions.md#Cluster-Policy-usage) Cluster Policy would be able to create clusters, but within boundaries of that specific policy.
 * `allow_instance_pool_create` -  (Optional) Allow the user to have [instance pool](instance_pool.md) create privileges. Defaults to false. More fine grained permissions could be assigned with [databricks_permissions](permissions.md#Instance-Pool-usage) and [instance_pool_id](permissions.md#instance_pool_id) argument.
-* `allow_sql_analytics_access` - (Optional) This is a field to allow the group to have access to [Databricks SQL](https://databricks.com/product/sql-analytics) feature through [databricks_sql_endpoint](sql_endpoint.md).
+* `databricks_sql_access` - (Optional) This is a field to allow the group to have access to [Databricks SQL](https://databricks.com/product/databricks-sql) feature in User Interface and through [databricks_sql_endpoint](sql_endpoint.md).
 * `active` - (Optional) Either user is active or not. True by default, but can be set to false in case of user deactivation with preserving user assets.
 
 ## Attribute Reference

--- a/identity/resource_group_test.go
+++ b/identity/resource_group_test.go
@@ -60,7 +60,7 @@ func TestResourceGroupCreate(t *testing.T) {
 		display_name = "Data Scientists"
 		allow_instance_pool_create = true
 		allow_cluster_create = true
-		allow_sql_analytics_access = true
+		databricks_sql_access = true
 		`,
 		Create: true,
 	}.Apply(t)
@@ -69,7 +69,7 @@ func TestResourceGroupCreate(t *testing.T) {
 	assert.Equal(t, "Data Scientists", d.Get("display_name"))
 	assert.Equal(t, true, d.Get("allow_cluster_create"))
 	assert.Equal(t, true, d.Get("allow_instance_pool_create"))
-	assert.Equal(t, true, d.Get("allow_sql_analytics_access"))
+	assert.Equal(t, true, d.Get("databricks_sql_access"))
 }
 
 func TestResourceGroupCreate_Error(t *testing.T) {
@@ -125,7 +125,7 @@ func TestResourceGroupRead(t *testing.T) {
 	assert.Equal(t, "abc", d.Id(), "Id should not be empty")
 	assert.Equal(t, true, d.Get("allow_cluster_create"))
 	assert.Equal(t, true, d.Get("allow_instance_pool_create"))
-	assert.Equal(t, true, d.Get("allow_sql_analytics_access"))
+	assert.Equal(t, true, d.Get("databricks_sql_access"))
 	assert.Equal(t, "Data Scientists", d.Get("display_name"))
 }
 
@@ -150,7 +150,7 @@ func TestResourceGroupRead_NoEntitlements(t *testing.T) {
 	assert.Equal(t, "abc", d.Id(), "Id should not be empty")
 	assert.Equal(t, false, d.Get("allow_cluster_create"))
 	assert.Equal(t, false, d.Get("allow_instance_pool_create"))
-	assert.Equal(t, false, d.Get("allow_sql_analytics_access"))
+	assert.Equal(t, false, d.Get("databricks_sql_access"))
 	assert.Equal(t, "Data Scientists", d.Get("display_name"))
 }
 
@@ -276,7 +276,7 @@ func TestResourceGroupUpdate(t *testing.T) {
 		display_name = "Data Ninjas"
 		allow_instance_pool_create = true
 		allow_cluster_create = true
-		allow_sql_analytics_access = true
+		databricks_sql_access = true
 		`,
 		RequiresNew: true,
 		Update:      true,
@@ -287,7 +287,7 @@ func TestResourceGroupUpdate(t *testing.T) {
 	assert.Equal(t, "Data Ninjas", d.Get("display_name"))
 	assert.Equal(t, true, d.Get("allow_cluster_create"))
 	assert.Equal(t, true, d.Get("allow_instance_pool_create"))
-	assert.Equal(t, true, d.Get("allow_sql_analytics_access"))
+	assert.Equal(t, true, d.Get("databricks_sql_access"))
 }
 
 func TestResourceGroupUpdate_Error(t *testing.T) {

--- a/identity/scim.go
+++ b/identity/scim.go
@@ -41,7 +41,7 @@ func (cv complexValues) HasValue(value string) bool {
 var entitlementMapping = map[string]string{
 	"allow-cluster-create":       "allow_cluster_create",
 	"allow-instance-pool-create": "allow_instance_pool_create",
-	"databricks-sql-access":      "allow_sql_analytics_access", // TODO: state change
+	"databricks-sql-access":      "databricks_sql_access",
 	"workspace-access":           "workspace_access",
 }
 


### PR DESCRIPTION
Now `databricks_user`, `databricks_group`, and `databricks_service_principal` resources are more in line with Databricks SQL product naming.

Fixes #844