### PR TITLE
Added `databricks_clusters` data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.4.1
 
 * Fixed refresh of `library` blocks on a stopped `databricks_cluster` ([#952](https://github.com/databrickslabs/terraform-provider-databricks/issues/952))
+* Added `databricks_clusters` data resource to list all clusters in the workspace.
 
 ## 0.4.0
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 | [databricks_aws_bucket_policy](docs/data-sources/aws_bucket_policy.md) data
 | [databricks_aws_crossaccount_policy](docs/data-sources/aws_crossaccount_policy.md) data
 | [databricks_cluster](docs/resources/cluster.md)
+| [databricks_clusters](docs/data-sources/clusters.md) data
 | [databricks_cluster_policy](docs/resources/cluster_policy.md)
 | [databricks_current_user](docs/data-sources/current_user.md)
 | [databricks_dbfs_file](docs/resources/dbfs_file.md)

--- a/clusters/data_clusters.go
+++ b/clusters/data_clusters.go
@@ -1,0 +1,47 @@
+package clusters
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func DataSourceClusters() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: func(ctx context.Context, d *schema.ResourceData, i interface{}) diag.Diagnostics {
+			clusters, err := NewClustersAPI(ctx, i).List()
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			ids := []string{}
+			name_contains := strings.ToLower(d.Get("cluster_name_contains").(string))
+			for _, v := range clusters {
+				match_name := strings.Contains(strings.ToLower(v.ClusterName), name_contains)
+				if name_contains != "" && !match_name {
+					continue
+				}
+				ids = append(ids, v.ClusterID)
+			}
+			sort.Strings(ids)
+			d.Set("ids", ids)
+			d.SetId("_")
+			return nil
+		},
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Computed: true,
+				Type:     schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"cluster_name_contains": {
+				Optional: true,
+				Type:     schema.TypeString,
+			},
+		},
+	}
+}

--- a/clusters/data_clusters_test.go
+++ b/clusters/data_clusters_test.go
@@ -1,0 +1,76 @@
+package clusters
+
+import (
+	"context"
+	"testing"
+
+	"github.com/databrickslabs/terraform-provider-databricks/common"
+	"github.com/databrickslabs/terraform-provider-databricks/qa"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClustersDataSource(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/clusters/list",
+
+				Response: ClusterList{
+					Clusters: []ClusterInfo{
+						{
+							ClusterID: "b",
+						},
+						{
+							ClusterID: "a",
+						},
+					},
+				},
+			},
+		},
+		Resource:    DataSourceClusters(),
+		NonWritable: true,
+		Read:        true,
+		ID:          "_",
+	}.Apply(t)
+	require.NoError(t, err)
+	assert.Equal(t, []interface{}{"a", "b"}, d.Get("ids"))
+}
+
+func TestClustersDataSourceContainsName(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/clusters/list",
+				Response: ClusterList{
+					Clusters: []ClusterInfo{
+						{
+							ClusterID:   "b",
+							ClusterName: "THIS NAME",
+						},
+						{
+							ClusterID:   "a",
+							ClusterName: "that name",
+						},
+					},
+				},
+			},
+		},
+		Resource:    DataSourceClusters(),
+		NonWritable: true,
+		Read:        true,
+		ID:          "_",
+		HCL:         `cluster_name_contains = "this"`,
+	}.Apply(t)
+	require.NoError(t, err)
+	assert.Equal(t, []interface{}{"b"}, d.Get("ids"))
+}
+
+func TestClustersDataSourceErrorsOut(t *testing.T) {
+	diag := DataSourceClusters().ReadContext(context.Background(), nil, &common.DatabricksClient{
+		Host: ".", Token: "."})
+	assert.NotNil(t, diag)
+	assert.True(t, diag.HasError())
+}

--- a/docs/data-sources/clusters.md
+++ b/docs/data-sources/clusters.md
@@ -1,0 +1,37 @@
+---
+subcategory: "Compute"
+---
+# databricks_clusters Data Source
+
+-> **Note** If you have a fully automated setup with workspaces created by [databricks_mws_workspaces](../resources/mws_workspaces.md) or [azurerm_databricks_workspace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/databricks_workspace), please make sure to add [depends_on attribute](../index.md#data-resources-and-authentication-is-not-configured-errors) in order to prevent _authentication is not configured for provider_ errors.
+
+Retrieves a list of [databricks_cluster](../resources/cluster.md#cluster_id) ids, that were created by Terraform or manually, with or without [databricks_cluster_policy](../resources/cluster_policy.md).
+
+## Example Usage
+
+Retrieve all clusters on this workspace on AWS or GCP:
+
+```hcl
+data "databricks_clusters" "all" {
+    depends_on = [databricks_mws_workspaces.this]
+}
+```
+
+Retrieve all clusters with "Shared" in their cluster name on this Azure Databricks workspace:
+
+```hcl
+data "databricks_clusters" "all_shared" {
+    depends_on = [azurerm_databricks_workspace.this]
+    cluster_name_contains = "shared"
+}
+```
+
+## Argument Reference
+
+* `cluster_name_contains` - (Optional) Only return [databricks_cluster](../resources/cluster.md#cluster_id) ids that match the given name string.
+
+## Attribute Reference
+
+This data source exports the following attributes:
+
+* `ids` - list of [databricks_cluster](../resources/cluster.md#cluster_id) ids

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -38,6 +38,7 @@ func DatabricksProvider() *schema.Provider {
 			"databricks_aws_crossaccount_policy": aws.DataAwsCrossAccountPolicy(),
 			"databricks_aws_assume_role_policy":  aws.DataAwsAssumeRolePolicy(),
 			"databricks_aws_bucket_policy":       aws.DataAwsBucketPolicy(),
+			"databricks_clusters":                clusters.DataSourceClusters(),
 			"databricks_current_user":            scim.DataSourceCurrentUser(),
 			"databricks_dbfs_file":               storage.DataSourceDBFSFile(),
 			"databricks_dbfs_file_paths":         storage.DataSourceDBFSFilePaths(),


### PR DESCRIPTION
# databricks_clusters Data Source

-> **Note** If you have a fully automated setup with workspaces created by [databricks_mws_workspaces](../resources/mws_workspaces.md) or [azurerm_databricks_workspace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/databricks_workspace), please make sure to add [depends_on attribute](../index.md#data-resources-and-authentication-is-not-configured-errors) in order to prevent _authentication is not configured for provider_ errors.

Retrieves a list of [databricks_cluster](../resources/cluster.md#cluster_id) ids, that were created by Terraform or manually, with or without [databricks_cluster_policy](../resources/cluster_policy.md).

## Example Usage

Retrieve all clusters on this workspace on AWS or GCP:

```hcl
data "databricks_clusters" "all" {
    depends_on = [databricks_mws_workspaces.this]
}
```

Retrieve all clusters with "Shared" in their cluster name on this Azure Databricks workspace:

```hcl
data "databricks_clusters" "all_shared" {
    depends_on = [azurerm_databricks_workspace.this]
    cluster_name_contains = "shared"
}
```

## Argument Reference

* `cluster_name_contains` - (Optional) Only return [databricks_cluster](../resources/cluster.md#cluster_id) ids that match the given name string.

## Attribute Reference

This data source exports the following attributes:

* `ids` - list of [databricks_cluster](../resources/cluster.md#cluster_id) ids
