### PR TITLE
Release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,26 @@
 
 ## 0.4.1
 
-* Fixed refresh of `library` blocks on a stopped `databricks_cluster` ([#952](https://github.com/databrickslabs/terraform-provider-databricks/issues/952)).
-* Added `databricks_clusters` data resource to list all clusters in the workspace ([#955](https://github.com/databrickslabs/terraform-provider-databricks/pull/955)).
 * Added `databricks_library` resource to install library on `databricks_cluster` ([#904](https://github.com/databrickslabs/terraform-provider-databricks/pull/904)).
+* Added `databricks_clusters` data resource to list all clusters in the workspace, which might be used to install `databricks_library` on all clusters ([#955](https://github.com/databrickslabs/terraform-provider-databricks/pull/955)).
+* Fixed refresh of `library` blocks on a stopped `databricks_cluster` ([#952](https://github.com/databrickslabs/terraform-provider-databricks/issues/952)).
 * Whenever a library fails to get installed on a running `databricks_cluster`, we now automatically remove this library, so that the clean state of managed libraries is properly maintained. Without this fix users had to manually go to Clusters UI and remove library from a cluster, where it failed to install. Libraries add up to CREATE and UPDATE timeouts of `databricks_cluster` resource. ([#599](https://github.com/databrickslabs/terraform-provider-databricks/issues/599)).
 * Added `token` block to `databricks_mws_workspaces` to avoid unnecessary provider aliasing ([#957](https://github.com/databrickslabs/terraform-provider-databricks/issues/957)).
+* Fixed disabling `databricks_global_init_script` ([#958](https://github.com/databrickslabs/terraform-provider-databricks/issues/958)).
+* Fixed configuration drift issues with `aws_attributes`, `azure_attributes`, `gcp_attributes`, and `email_notifications` configuration blocks in `databricks_cluster`, `databricks_job`, and `databricks_instance_pool` resources ([#981](https://github.com/databrickslabs/terraform-provider-databricks/pull/981)).
+* Improved Databricks CLI auth by eagerly resolving `host`, `username`, `password`, and `token` from the specified `profile`. Added explicit logging of auth parameters in debug logs ([#965](https://github.com/databrickslabs/terraform-provider-databricks/pull/965)).
+* TLS timeouts, which may occur during Azure MSI auth, are no longer failing API requests and retried within a normal policy ([#966](https://github.com/databrickslabs/terraform-provider-databricks/pull/966)).
+* `debug_headers` provider conf is also logging the `Host` header to help troubleshooting auth issues ([#964](https://github.com/databrickslabs/terraform-provider-databricks/pull/964)).
 * Added new experimental resources and increased test coverage.
+
+Updated dependency versions:
+
+* Bump github.com/golang-jwt/jwt/v4 from 4.1.0 to 4.2.0
+* Bump google.golang.org/api from 0.60.0 to 0.63.0
+* Bump github.com/Azure/go-autorest/autorest from 0.11.22 to 0.11.23
+* Bump github.com/Azure/go-autorest/autorest/azure/auth from 0.5.9 to 0.5.10
+* Bump gopkg.in/ini.v1 from 1.66.0 to 1.66.2
+* Bump github.com/hashicorp/terraform-plugin-sdk/v2 from 2.9.0 to 2.10.0
 
 ## 0.4.0
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ vendor:
 
 test-azcli: install
 	@echo "✓ Running Terraform Acceptance Tests for Azure..."
-	@/bin/bash scripts/run.sh azcli '^(TestAcc|TestAzureAcc)' --debug --tee
+	@/bin/bash scripts/run.sh azcli '^TestAzureAcc' --debug --tee
 
 test-azsp: install
 	@echo "✓ Running Terraform Acceptance Tests for Azure..."

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ terraform {
   required_providers {
     databricks = {
       source = "databrickslabs/databricks"
-      version = "0.4.0"
+      version = "0.4.1"
     }
   }
 }

--- a/docs/guides/aws-e2-firewall-hub-and-spoke.md
+++ b/docs/guides/aws-e2-firewall-hub-and-spoke.md
@@ -91,7 +91,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.0"
+      version = "0.4.1"
     }
     aws = {
       source = "hashicorp/aws"

--- a/docs/guides/aws-e2-firewall-workspace.md
+++ b/docs/guides/aws-e2-firewall-workspace.md
@@ -89,7 +89,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.0"
+      version = "0.4.1"
     }
     aws = {
       source = "hashicorp/aws"

--- a/docs/guides/aws-workspace.md
+++ b/docs/guides/aws-workspace.md
@@ -54,7 +54,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.0"
+      version = "0.4.1"
     }
     aws = {
       source = "hashicorp/aws"

--- a/docs/guides/workspace-management.md
+++ b/docs/guides/workspace-management.md
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.0"
+      version = "0.4.1"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,7 @@
 layout: "databricks"
 page_title: "Provider: Databricks"
 sidebar_current: "docs-databricks-index"
-description: |-
-  Terraform provider databricks.
+description: Terraform provider for the Databricks Lakehouse platform
 ---
 
 # Databricks Provider
@@ -336,7 +335,7 @@ terraform {
   required_providers {
     databricks = {
       source = "databrickslabs/databricks"
-      version = "0.4.0"
+      version = "0.4.1"
     }
   }
 }

--- a/scripts/azcli-integration/main.tf
+++ b/scripts/azcli-integration/main.tf
@@ -84,7 +84,7 @@ output "test_key_vault_secret_value" {
   sensitive = true
 }
 
-output "databricks_azure_workspace_resource_id" {
+output "databricks_azure_resource_id" {
   value = module.this.databricks_azure_workspace_resource_id
 }
 


### PR DESCRIPTION
* Added `databricks_library` resource to install library on `databricks_cluster` ([#904](https://github.com/databrickslabs/terraform-provider-databricks/pull/904)).
* Added `databricks_clusters` data resource to list all clusters in the workspace, which might be used to install `databricks_library` on all clusters ([#955](https://github.com/databrickslabs/terraform-provider-databricks/pull/955)).
* Fixed refresh of `library` blocks on a stopped `databricks_cluster` ([#952](https://github.com/databrickslabs/terraform-provider-databricks/issues/952)).
* Whenever a library fails to get installed on a running `databricks_cluster`, we now automatically remove this library, so that the clean state of managed libraries is properly maintained. Without this fix users had to manually go to Clusters UI and remove library from a cluster, where it failed to install. Libraries add up to CREATE and UPDATE timeouts of `databricks_cluster` resource. ([#599](https://github.com/databrickslabs/terraform-provider-databricks/issues/599)).
* Added `token` block to `databricks_mws_workspaces` to avoid unnecessary provider aliasing ([#957](https://github.com/databrickslabs/terraform-provider-databricks/issues/957)).
* Fixed disabling `databricks_global_init_script` ([#958](https://github.com/databrickslabs/terraform-provider-databricks/issues/958)).
* Fixed configuration drift issues with `aws_attributes`, `azure_attributes`, `gcp_attributes`, and `email_notifications` configuration blocks in `databricks_cluster`, `databricks_job`, and `databricks_instance_pool` resources ([#981](https://github.com/databrickslabs/terraform-provider-databricks/pull/981)).
* Improved Databricks CLI auth by eagerly resolving `host`, `username`, `password`, and `token` from the specified `profile`. Added explicit logging of auth parameters in debug logs ([#965](https://github.com/databrickslabs/terraform-provider-databricks/pull/965)).
* TLS timeouts, which may occur during Azure MSI auth, are no longer failing API requests and retried within a normal policy ([#966](https://github.com/databrickslabs/terraform-provider-databricks/pull/966)).
* `debug_headers` provider conf is also logging the `Host` header to help troubleshooting auth issues ([#964](https://github.com/databrickslabs/terraform-provider-databricks/pull/964)).
* Added new experimental resources and increased test coverage.

Updated dependency versions:

* Bump github.com/golang-jwt/jwt/v4 from 4.1.0 to 4.2.0
* Bump google.golang.org/api from 0.60.0 to 0.63.0
* Bump github.com/Azure/go-autorest/autorest from 0.11.22 to 0.11.23
* Bump github.com/Azure/go-autorest/autorest/azure/auth from 0.5.9 to 0.5.10
* Bump gopkg.in/ini.v1 from 1.66.0 to 1.66.2
* Bump github.com/hashicorp/terraform-plugin-sdk/v2 from 2.9.0 to 2.10.0

azure msi
---

 * [x] access.TestAccIPACL (6.95s)
 * [x] access/acceptance.TestAccTableACL (520.96s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateClusterWithLibraries (243.38s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateSingleNodeCluster (44.75s)
 * [x] clusters/acceptance.TestAccListClustersIntegration (115.54s)
 * [x] commands/acceptance.TestAccContext (28.09s)
 * [x] jobs/acceptance.TestAccJobResource (3.38s)
 * [x] libraries/acceptance.TestAccLibraryCreate (54.91s)
 * [x] mlflow/acceptance.TestAccMLflowExperiment (5.35s)
 * [x] mlflow/acceptance.TestAccMLflowModel (2.67s)
 * [x] permissions.TestAccessControlChangeString (0.00s)
 * [x] permissions.TestAccessControlString (0.00s)
 * [x] permissions.TestAccessControlToAccessControlChange (0.00s)
 * [x] permissions/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (10.81s)
 * [x] permissions/acceptance.TestAccDatabricksReposPermissionsResourceFullLifecycle (12.16s)
 * [x] permissions/acceptance.TestAccPermissionsClusterPolicy (5.48s)
 * [x] permissions/acceptance.TestAccPermissionsClusters (58.96s)
 * [x] permissions/acceptance.TestAccPermissionsInstancePool (5.15s)
 * [x] permissions/acceptance.TestAccPermissionsJobs (6.89s)
 * [x] permissions/acceptance.TestAccPermissionsNotebooks (6.13s)
 * [x] permissions/acceptance.TestAccPermissionsTokens (4.19s)
 * [x] policies/acceptance.TestAccClusterPolicyResourceFullLifecycle (3.82s)
 * [x] pools.TestAccInstancePools (1.09s)
 * [x] scim.TestAccCreateUser (2.73s)
 * [x] scim.TestAccFilterGroup (0.49s)
 * [x] scim.TestAccGroup (6.32s)
 * [x] scim.TestAccReadUser (0.38s)
 * [x] scim.TestAccServicePrincipalOnAzure (2.35s)
 * [x] scim/acceptance.TestAccGroupMemberResource (6.85s)
 * [x] scim/acceptance.TestAccGroupResource (4.85s)
 * [x] scim/acceptance.TestAccGroupResource_verify_entitlements (4.81s)
 * [x] scim/acceptance.TestAccServicePrincipalResourceOnAzure (4.22s)
 * [x] scim/acceptance.TestAccUserResource (7.51s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipals (1.29s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipalsGroup (0.95s)
 * [x] secrets/acceptance.TestAccSecretAclResource (5.12s)
 * [x] secrets/acceptance.TestAccSecretAclResourceDefaultPrincipal (4.30s)
 * [x] secrets/acceptance.TestAccSecretResource (5.16s)
 * [x] secrets/acceptance.TestAccSecretScopeResource (4.89s)
 * [x] storage.TestAccCreateFile (2.42s)
 * [x] storage/acceptance.TestAccAzureBlobMountGeneric (139.72s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (4.14s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (2.10s)
 * [x] storage/acceptance.TestAccInvalidSecretScopeFails (5.38s)
 * [x] storage/acceptance.TestAccSourceOnInvalidMountFails (36.74s)
 * [x] tokens.TestAccCreateToken (0.58s)
 * [x] tokens.TestAccCreateToken_NoExpiration (0.65s)
 * [x] tokens/acceptance.TestAccTokenResource (3.75s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (2.80s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (4.11s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (2.19s)

aws
---

 * [x] access.TestAccIPACL (3.09s)
 * [x] access/acceptance.TestAccTableACL (639.47s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateClusterWithLibraries (596.35s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateSingleNodeCluster (65.34s)
 * [x] clusters/acceptance.TestAccListClustersIntegration (123.33s)
 * [x] commands/acceptance.TestAccContext (14.36s)
 * [x] jobs/acceptance.TestAccJobResource (4.71s)
 * [x] libraries/acceptance.TestAccLibraryCreate (180.88s)
 * [x] mlflow/acceptance.TestAccMLflowExperiment (4.75s)
 * [x] mlflow/acceptance.TestAccMLflowModel (2.05s)
 * [x] permissions.TestAccessControlChangeString (0.00s)
 * [x] permissions.TestAccessControlString (0.00s)
 * [x] permissions.TestAccessControlToAccessControlChange (0.00s)
 * [x] permissions/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (37.61s)
 * [x] permissions/acceptance.TestAccDatabricksReposPermissionsResourceFullLifecycle (24.70s)
 * [x] permissions/acceptance.TestAccPermissionsClusterPolicy (14.86s)
 * [x] permissions/acceptance.TestAccPermissionsClusters (85.71s)
 * [x] permissions/acceptance.TestAccPermissionsInstancePool (15.40s)
 * [x] permissions/acceptance.TestAccPermissionsJobs (15.16s)
 * [x] permissions/acceptance.TestAccPermissionsNotebooks (17.32s)
 * [x] permissions/acceptance.TestAccPermissionsTokens (15.36s)
 * [x] policies/acceptance.TestAccClusterPolicyResourceFullLifecycle (4.01s)
 * [x] pools.TestAccInstancePools (1.50s)
 * [x] scim.TestAccCreateUser (8.18s)
 * [x] scim.TestAccFilterGroup (2.35s)
 * [x] scim.TestAccGroup (24.02s)
 * [x] scim.TestAccReadUser (1.80s)
 * [x] scim/acceptance.TestAccGroupMemberResource (31.96s)
 * [x] scim/acceptance.TestAccGroupResource (11.86s)
 * [x] scim/acceptance.TestAccGroupResource_verify_entitlements (12.07s)
 * [x] scim/acceptance.TestAccServicePrincipalResourceOnAws (6.95s)
 * [x] scim/acceptance.TestAccUserResource (11.19s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipals (1.79s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipalsGroup (0.73s)
 * [x] secrets/acceptance.TestAccSecretAclResource (12.13s)
 * [x] secrets/acceptance.TestAccSecretAclResourceDefaultPrincipal (4.65s)
 * [x] secrets/acceptance.TestAccSecretResource (3.97s)
 * [x] secrets/acceptance.TestAccSecretScopeResource (4.87s)
 * [x] storage.TestAccCreateFile (5.50s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (4.26s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (2.24s)
 * [x] storage/acceptance.TestAccInvalidSecretScopeFails (3.34s)
 * [x] storage/acceptance.TestAccSourceOnInvalidMountFails (31.44s)
 * [x] tokens.TestAccCreateToken (0.60s)
 * [x] tokens.TestAccCreateToken_NoExpiration (0.31s)
 * [x] tokens/acceptance.TestAccTokenResource (3.01s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (3.88s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (5.05s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (2.22s)

gcp
---
~~TestAccInstancePools~~ - #984 
~~TestAccListClustersIntegration~~ - #985
~~TestAccTableACL~~ - #986
 * [x] access.TestAccIPACL (3.56s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateClusterWithLibraries (410.53s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateSingleNodeCluster (162.93s)
 * [x] commands/acceptance.TestAccContext (356.97s)
 * [x] jobs/acceptance.TestAccJobResource (10.23s)
 * [x] libraries/acceptance.TestAccLibraryCreate (377.51s)
 * [x] mlflow/acceptance.TestAccMLflowExperiment (10.51s)
 * [x] mlflow/acceptance.TestAccMLflowModel (6.93s)
 * [x] permissions.TestAccessControlChangeString (0.00s)
 * [x] permissions.TestAccessControlString (0.00s)
 * [x] permissions.TestAccessControlToAccessControlChange (0.00s)
 * [x] permissions/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (33.62s)
 * [x] permissions/acceptance.TestAccDatabricksReposPermissionsResourceFullLifecycle (21.24s)
 * [x] permissions/acceptance.TestAccPermissionsClusterPolicy (9.03s)
 * [x] permissions/acceptance.TestAccPermissionsClusters (354.11s)
 * [x] permissions/acceptance.TestAccPermissionsInstancePool (8.63s)
 * [x] permissions/acceptance.TestAccPermissionsJobs (8.84s)
 * [x] permissions/acceptance.TestAccPermissionsNotebooks (9.50s)
 * [x] permissions/acceptance.TestAccPermissionsTokens (6.95s)
 * [x] policies/acceptance.TestAccClusterPolicyResourceFullLifecycle (14.62s)
 * [x] scim.TestAccCreateUser (4.08s)
 * [x] scim.TestAccFilterGroup (1.81s)
 * [x] scim.TestAccGroup (8.59s)
 * [x] scim.TestAccReadUser (2.01s)
 * [x] scim/acceptance.TestAccGroupMemberResource (14.81s)
 * [x] scim/acceptance.TestAccGroupResource (11.98s)
 * [x] scim/acceptance.TestAccGroupResource_verify_entitlements (11.22s)
 * [x] scim/acceptance.TestAccUserResource (11.74s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipals (1.63s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipalsGroup (1.06s)
 * [x] secrets/acceptance.TestAccSecretAclResource (12.09s)
 * [x] secrets/acceptance.TestAccSecretAclResourceDefaultPrincipal (7.94s)
 * [x] secrets/acceptance.TestAccSecretResource (14.41s)
 * [x] secrets/acceptance.TestAccSecretScopeResource (14.09s)
 * [x] storage.TestAccCreateFile (9.74s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (15.24s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (7.30s)
 * [x] storage/acceptance.TestAccInvalidSecretScopeFails (5.72s)
 * [x] storage/acceptance.TestAccSourceOnInvalidMountFails (376.25s)
 * [x] tokens.TestAccCreateToken (3.07s)
 * [x] tokens.TestAccCreateToken_NoExpiration (2.59s)
 * [x] tokens/acceptance.TestAccTokenResource (12.24s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (13.30s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (13.46s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (6.69s)

mws
---

 * [x] mws.TestMwsAccCreds (4.86s)
 * [x] mws.TestMwsAccCustomerManagedKeys (4.78s)
 * [x] mws.TestMwsAccLogDelivery (11.29s)
 * [x] mws.TestMwsAccPAS (8.05s)
 * [x] mws.TestMwsAccStorageConfigurations (6.37s)
 * [x] mws.TestMwsAccVPCEndpointIntegration (111.89s)
 * [x] mws.TestMwsAccWorkspace (0.61s)
 * [x] mws/acceptance.TestMwsAccCredentials (7.73s)
 * [x] mws/acceptance.TestMwsAccCustomerManagedKeys (8.16s)
 * [x] mws/acceptance.TestMwsAccLogDelivery (19.05s)
 * [x] mws/acceptance.TestMwsAccNetworks (5.76s)
 * [x] mws/acceptance.TestMwsAccPrivateAccessSettings (6.96s)
 * [x] mws/acceptance.TestMwsAccStorageConfigurations (7.75s)
 * [x] mws/acceptance.TestMwsAccVpcEndpoint (91.56s)
 * [x] mws/acceptance.TestMwsAccWorkspaces (124.87s)

azure cli
---

 * [x] secrets/acceptance.TestAzureAccKeyVaultSimple (11.82s)
 * [x] storage/acceptance.TestAzureAccBlobMount (172.32s)
 * [x] storage/acceptance.TestAzureAccBlobMount_correctly_mounts (726.83s)
