### PR TITLE
Added DBC format support for `databricks_notebook`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version changelog
 
+## 0.4.2
+
+* Added `DBC` format support for `databricks_notebook` ([#989](https://github.com/databrickslabs/terraform-provider-databricks/pull/989)). 
+
 ## 0.4.1
 
 * Added `databricks_library` resource to install library on `databricks_cluster` ([#904](https://github.com/databrickslabs/terraform-provider-databricks/pull/904)).

--- a/docs/resources/notebook.md
+++ b/docs/resources/notebook.md
@@ -32,7 +32,16 @@ resource "databricks_notebook" "notebook" {
   language = "PYTHON"
 }
 ```
-    
+
+You can also manage [Databricks Archives](https://docs.databricks.com/notebooks/notebooks-manage.html#databricks-archive) to import the whole folders of notebooks statically. Whenever you update `.dbc` file, terraform-managed notebook folder is removed and replaced with contents of the new `.dbc` file. You are strongly advised to use `.dbc` format only with `source` attribute of the resource:
+
+```hcl
+resource "databricks_notebook" "lesson" {
+  source = "${path.module}/IntroNotebooks.dbc"
+  path = "/Shared/Intro" 
+}
+```
+
 ## Argument Reference
 
 -> **Note** Notebook on Databricks workspace would only be changed, if Terraform stage did change. This means that any manual changes to managed notebook won't be overwritten by Terraform, if there's no local change to notebook sources. Notebooks are identified by their path, so changing notebook's name manually on the workspace and then applying Terraform state would result in creation of notebook from Terraform state.

--- a/permissions/acceptance/api_test.go
+++ b/permissions/acceptance/api_test.go
@@ -267,7 +267,7 @@ func TestAccPermissionsNotebooks(t *testing.T) {
 
 		notebookPath := fmt.Sprintf("%s/Dummy", notebookDir)
 
-		err = workspaceAPI.Create(workspace.ImportRequest{
+		err = workspaceAPI.Create(workspace.ImportPath{
 			Path:      notebookPath,
 			Content:   "MSsx",
 			Format:    "SOURCE",

--- a/workspace/data_notebook.go
+++ b/workspace/data_notebook.go
@@ -22,9 +22,9 @@ func DataSourceNotebook() *schema.Resource {
 			Required: true,
 			ForceNew: true,
 			ValidateFunc: validation.StringInSlice([]string{
-				string(DBC),
-				string(Source),
-				string(HTML),
+				"DBC",
+				"SOURCE",
+				"HTML",
 			}, false),
 		},
 		"content": {
@@ -53,7 +53,7 @@ func DataSourceNotebook() *schema.Resource {
 			notebooksAPI := NewNotebooksAPI(ctx, m)
 			path := d.Get("path").(string)
 			format := d.Get("format").(string)
-			notebookContent, err := notebooksAPI.Export(path, ExportFormat(format))
+			notebookContent, err := notebooksAPI.Export(path, format)
 			if err != nil {
 				return diag.FromErr(err)
 			}

--- a/workspace/data_notebook_paths.go
+++ b/workspace/data_notebook_paths.go
@@ -18,12 +18,6 @@ func DataSourceNotebookPaths() *schema.Resource {
 				return diag.FromErr(err)
 			}
 			d.SetId(path)
-			if err = d.Set("recursive", recursive); err != nil {
-				return diag.FromErr(err)
-			}
-			if err = d.Set("path", path); err != nil {
-				return diag.FromErr(err)
-			}
 			var notebookPathList []map[string]string
 			for _, v := range notebookList {
 				notebookPathMap := map[string]string{}

--- a/workspace/data_notebook_paths_test.go
+++ b/workspace/data_notebook_paths_test.go
@@ -4,12 +4,10 @@ import (
 	"testing"
 
 	"github.com/databrickslabs/terraform-provider-databricks/qa"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestDataSourceNotebookPaths(t *testing.T) {
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   "GET",
@@ -53,7 +51,40 @@ func TestDataSourceNotebookPaths(t *testing.T) {
 			"path":      "/a/b/c",
 			"recursive": true,
 		},
-	}.Apply(t)
-	require.NoError(t, err)
-	assert.Equal(t, "/a/b/c", d.Id())
+	}.ApplyNoError(t)
+}
+
+func TestDataSourceNotebookPaths_NoRecursive(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/workspace/list?path=%2Fa%2Fb%2Fc",
+				Response: objectList{
+					Objects: []ObjectStatus{
+						{
+							ObjectID:   988,
+							ObjectType: Notebook,
+							Language:   Python,
+							Path:       "/a/b/c/d/e",
+						},
+						{
+							ObjectID:   989,
+							ObjectType: Notebook,
+							Language:   SQL,
+							Path:       "/a/b/c/d/f",
+						},
+					},
+				},
+			},
+		},
+		Read:        true,
+		NonWritable: true,
+		Resource:    DataSourceNotebookPaths(),
+		ID:          ".",
+		State: map[string]interface{}{
+			"path":      "/a/b/c",
+			"recursive": false,
+		},
+	}.ApplyNoError(t)
 }

--- a/workspace/data_notebook_test.go
+++ b/workspace/data_notebook_test.go
@@ -24,7 +24,7 @@ func TestDataSourceNotebook(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/workspace/export?format=SOURCE&path=%2Fa%2Fb%2Fc",
-				Response: NotebookContent{
+				Response: ExportPath{
 					Content: "SGVsbG8gd29ybGQK",
 				},
 			},

--- a/workspace/file_resource.go
+++ b/workspace/file_resource.go
@@ -44,7 +44,6 @@ func ReadContent(d *schema.ResourceData) (content []byte, err error) {
 	if err != nil {
 		return
 	}
-	// TODO: file size
 	d.Set("md5", fmt.Sprintf("%x", md5.Sum(content)))
 	log.Printf("[INFO] Setting file content hash to %s", d.Get("md5"))
 	return

--- a/workspace/resource_directory_test.go
+++ b/workspace/resource_directory_test.go
@@ -47,7 +47,7 @@ func TestResourceDirectoryDelete(t *testing.T) {
 				Method:          http.MethodPost,
 				Resource:        "/api/2.0/workspace/delete",
 				Status:          http.StatusOK,
-				ExpectedRequest: NotebookDeleteRequest{Path: path, Recursive: delete_recursive},
+				ExpectedRequest: DeletePath{Path: path, Recursive: delete_recursive},
 			},
 		},
 		Resource: ResourceDirectory(),
@@ -172,7 +172,7 @@ func TestResourceDirectoryDelete_Error(t *testing.T) {
 			{
 				Method:          "POST",
 				Resource:        "/api/2.0/workspace/delete",
-				ExpectedRequest: NotebookDeleteRequest{Path: path, Recursive: false},
+				ExpectedRequest: DeletePath{Path: path, Recursive: false},
 				Response: common.APIErrorBody{
 					ErrorCode: "INVALID_REQUEST",
 					Message:   "Internal error happened",

--- a/workspace/resource_notebook.go
+++ b/workspace/resource_notebook.go
@@ -13,45 +13,36 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-// Language is a custom type for language types in Databricks notebooks
-type Language string
-
-// ObjectType is a custom type for object types in Databricks workspaces
-type ObjectType string
-
-// ExportFormat is a custom type for formats in which you can export Databricks workspace components
-type ExportFormat string
-
 // ...
 const (
-	Source  ExportFormat = "SOURCE"
-	HTML    ExportFormat = "HTML"
-	Jupyter ExportFormat = "JUPYTER"
-	DBC     ExportFormat = "DBC"
-
-	Scala  Language = "SCALA"
-	Python Language = "PYTHON"
-	SQL    Language = "SQL"
-	R      Language = "R"
-
-	Notebook      ObjectType = "NOTEBOOK"
-	Directory     ObjectType = "DIRECTORY"
-	LibraryObject ObjectType = "LIBRARY"
+	Notebook  string = "NOTEBOOK"
+	Directory string = "DIRECTORY"
+	Scala     string = "SCALA"
+	Python    string = "PYTHON"
+	SQL       string = "SQL"
+	R         string = "R"
 )
 
-var extMap = map[string]string{
-	".scala": "SCALA",
-	".py":    "PYTHON",
-	".sql":   "SQL",
-	".r":     "R",
+type notebookLanguageFormat struct {
+	Language  string
+	Format    string
+	Overwrite bool
+}
+
+var extMap = map[string]notebookLanguageFormat{
+	".scala": {"SCALA", "SOURCE", true},
+	".py":    {"PYTHON", "SOURCE", true},
+	".sql":   {"SQL", "SOURCE", true},
+	".r":     {"R", "SOURCE", true},
+	".dbc":   {"", "DBC", false},
 }
 
 // ObjectStatus contains information when doing a get request or list request on the workspace api
 type ObjectStatus struct {
-	ObjectID   int64      `json:"object_id,omitempty" tf:"computed"`
-	ObjectType ObjectType `json:"object_type,omitempty" tf:"computed"`
-	Path       string     `json:"path"`
-	Language   Language   `json:"language,omitempty"`
+	ObjectID   int64  `json:"object_id,omitempty" tf:"computed"`
+	ObjectType string `json:"object_type,omitempty" tf:"computed"`
+	Path       string `json:"path"`
+	Language   string `json:"language,omitempty"`
 }
 
 // NotebookContent contains the base64 content of the notebook
@@ -108,12 +99,12 @@ func (a NotebooksAPI) Read(path string) (ObjectStatus, error) {
 }
 
 type workspacePathRequest struct {
-	Format ExportFormat `url:"format,omitempty"`
-	Path   string       `url:"path,omitempty"`
+	Format string `url:"format,omitempty"`
+	Path   string `url:"path,omitempty"`
 }
 
 // Export returns the notebook content as a base64 string
-func (a NotebooksAPI) Export(path string, format ExportFormat) (string, error) {
+func (a NotebooksAPI) Export(path string, format string) (string, error) {
 	var notebookContent NotebookContent
 	err := a.client.Get(a.context, "/workspace/export", workspacePathRequest{
 		Format: format,
@@ -196,32 +187,44 @@ func ResourceNotebook() *schema.Resource {
 			Type:     schema.TypeString,
 			Optional: true,
 			ValidateFunc: validation.StringInSlice([]string{
-				string(Scala),
-				string(Python),
-				string(R),
-				string(SQL),
+				Scala,
+				Python,
+				R,
+				SQL,
 			}, false),
 			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 				source := d.Get("source").(string)
 				if source == "" {
 					return false
 				}
-				return old == extMap[strings.ToLower(filepath.Ext(source))]
+				ext := strings.ToLower(filepath.Ext(source))
+				return old == extMap[ext].Language
 			},
+		},
+		"format": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Default:  "SOURCE",
+			ValidateFunc: validation.StringInSlice([]string{
+				"SOURCE",
+				"DBC",
+			}, false),
 		},
 		"url": {
 			Type:     schema.TypeString,
 			Computed: true,
 		},
 		"object_type": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
+			Type:       schema.TypeString,
+			Optional:   true,
+			Computed:   true,
+			Deprecated: "Always is a notebook",
 		},
 		"object_id": {
-			Type:     schema.TypeInt,
-			Optional: true,
-			Computed: true,
+			Type:       schema.TypeInt,
+			Optional:   true,
+			Computed:   true,
+			Deprecated: "Use id argument to retrieve object id",
 		},
 	})
 	s["content_base64"].RequiredWith = []string{"language"}
@@ -239,22 +242,28 @@ func ResourceNotebook() *schema.Resource {
 			if parent != "/" {
 				err = notebooksAPI.Mkdirs(parent)
 				if err != nil {
-					// TODO: handle RESOURCE_ALREADY_EXISTS
 					return err
 				}
 			}
-			lang := d.Get("language").(string)
-			if lang == "" {
-				// TODO: check what happens with empty source
-				lang = extMap[strings.ToLower(filepath.Ext(d.Get("source").(string)))]
-			}
-			if err = notebooksAPI.Create(ImportRequest{
+			createNotebook := ImportRequest{
 				Content:   base64.StdEncoding.EncodeToString(content),
-				Language:  lang,
-				Format:    "SOURCE",
-				Overwrite: true,
+				Language:  d.Get("language").(string),
+				Format:    d.Get("format").(string),
 				Path:      path,
-			}); err != nil {
+				Overwrite: true,
+			}
+			if createNotebook.Language == "" {
+				// TODO: check what happens with empty source
+				ext := strings.ToLower(filepath.Ext(d.Get("source").(string)))
+				createNotebook.Language = extMap[ext].Language
+				createNotebook.Format = extMap[ext].Format
+				// Overwrite cannot be used for Dbc format
+				createNotebook.Overwrite = extMap[ext].Overwrite
+				// by default it's SOURCE, but for DBC we have to change it
+				d.Set("format", createNotebook.Format)
+			}
+			err = notebooksAPI.Create(createNotebook)
+			if err != nil {
 				return err
 			}
 			d.SetId(path)
@@ -275,13 +284,26 @@ func ResourceNotebook() *schema.Resource {
 			if err != nil {
 				return err
 			}
-			return notebooksAPI.Create(ImportRequest{
+			err = notebooksAPI.Create(ImportRequest{
 				Content:   base64.StdEncoding.EncodeToString(content),
 				Language:  d.Get("language").(string),
-				Format:    "SOURCE",
+				Format:    d.Get("format").(string),
 				Overwrite: true,
 				Path:      d.Id(),
 			})
+			// INVALID_PARAMETER_VALUE: Overwrite cannot be used for source format when importing a folder
+			if err != nil && strings.Contains(err.Error(), "Overwrite cannot be used") {
+				err = notebooksAPI.Delete(d.Id(), true)
+				if err != nil {
+					return err
+				}
+				return notebooksAPI.Create(ImportRequest{
+					Content: base64.StdEncoding.EncodeToString(content),
+					Format:  "DBC",
+					Path:    d.Id(),
+				})
+			}
+			return err
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			return NewNotebooksAPI(ctx, c).Delete(d.Id(), true)


### PR DESCRIPTION
Fixes #988

```hcl
locals {
  url = "https://files/XYZ.dbc"
}

// though this can be replaced with data http & local file
resource "null_resource" "dbc" {
  triggers = {
    on_version_change = local.url
  }

  provisioner "local-exec" {
    command = "curl -o ${path.root}/.terraform/import.dbc ${local.url}"
  }

  provisioner "local-exec" {
    when    = destroy
    command = "rm ${path.root}/.terraform/import.dbc"
  }
}

// "downloaded_file" module then... or hack with https://registry.terraform.io/providers/anschoewe/curl/latest/docs/data-sources/curl
data "null_data_source" "values" {
  inputs = {
    x = "${path.root}/.terraform/import.dbc"
  }
  depends_on = [null_resource.dbc]
}

data "databricks_current_user" "me" {
}

resource "databricks_notebook" "lesson" {
  source = data.null_data_source.values.outputs["x"]
  path = "${data.databricks_current_user.me.home}/Foo" 
}
```