### PR TITLE
databricks_dbfs_file data source minor fix and improvement

### DIFF
--- a/docs/data-sources/dbfs_file.md
+++ b/docs/data-sources/dbfs_file.md
@@ -18,7 +18,7 @@ data "databricks_dbfs_file" "report" {
 ## Argument Reference
 
 * `path` - (Required) Path on DBFS for the file to get content of
-* `limit_file_size` - (Required) Do lot load content for files smaller than this in bytes
+* `limit_file_size` - (Required) Do not load content for files smaller than this in bytes
 
 ## Attribute Reference
 
@@ -26,3 +26,4 @@ This data source exports the following attributes:
 
 * `content` - base64-encoded file contents
 * `file_size` - size of the file in bytes
+* `path_file` - Path, but with `dbfs:` prefix

--- a/storage/data_dbfs_file.go
+++ b/storage/data_dbfs_file.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"fmt"	
 	"encoding/base64"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -28,6 +29,7 @@ func DataSourceDBFSFile() *schema.Resource {
 			}
 			d.SetId(fileInfo.Path)
 			d.Set("path", fileInfo.Path)
+			d.Set("dbfs_path", fmt.Sprint("dbfs:", fileInfo.Path))			
 			d.Set("file_size", fileInfo.FileSize)
 			content, err := dbfsAPI.Read(fileInfo.Path)
 			if err != nil {
@@ -54,6 +56,10 @@ func DataSourceDBFSFile() *schema.Resource {
 			},
 			"file_size": {
 				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"dbfs_path": {
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 		},


### PR DESCRIPTION
Current behavior of `limit_file_size` doesn't correspond to [the doc's argument description](https://registry.terraform.io/providers/databrickslabs/databricks/latest/docs/data-sources/dbfs_file). Implemented expected behavior.

On v0.3.3, databricks_dbfs_file resource got a new `dbfs_path` attribute the data source never got. `dbfs_path` is useful to keep other resources declaration clean, such as when referencing a custom jar as a cluster library. databricks_dbfs_file data source should now mirror its resource counterpart and provide the same attributes.