### PR TITLE
Added `auth_type` for multi-cloud states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## 0.4.2
 
 * Added `DBC` format support for `databricks_notebook` ([#989](https://github.com/databrickslabs/terraform-provider-databricks/pull/989)). 
+* Added optional `auth_type` provider conf to enforce specific auth type to be used in very rare cases, where a single Terraform state manages Databricks workspaces on more than one cloud and `More than one authorization method configured` error is a false positive. Valid values are `pat`, `basic`, `azure-client-secret`, `azure-msi`, `azure-cli`, and `databricks-cli`.
+* Added automated documentation formatting with `make fmt-docs`, so that all HCL examples look consistent.
+* Increased codebase unit test coverage to 91% to improve stability.
+
+Updated dependency versions:
+
+* Bump github.com/hashicorp/terraform-plugin-sdk/v2 from 2.10.0 to 2.10.1 
 
 ## 0.4.1
 

--- a/common/azure_auth_test.go
+++ b/common/azure_auth_test.go
@@ -374,7 +374,7 @@ func TestGetJWTProperty_Authenticate_Fail(t *testing.T) {
 		Host: "https://adb-1232.azuredatabricks.net",
 	}
 	_, err := client.GetAzureJwtProperty("tid")
-	require.EqualError(t, err, "cannot configure Azure CLI auth: "+
+	require.EqualError(t, err, "cannot configure azure-cli auth: "+
 		"Invoking Azure CLI failed with the following error: "+
 		"This is just a failing script.\n. "+
 		"Please check https://registry.terraform.io/providers/"+

--- a/common/resource.go
+++ b/common/resource.go
@@ -161,7 +161,7 @@ func makeEmptyBlockSuppressFunc(name string) func(k, old, new string, d *schema.
 	re := MustCompileKeyRE(name)
 	return func(k, old, new string, d *schema.ResourceData) bool {
 		if re.Match([]byte(name)) && old == "1" && new == "0" {
-			log.Printf("[DEBUG] Suppressing diff for name=%s k=%#v patform=%#v config=%#v", name, k, old, new)
+			log.Printf("[DEBUG] Suppressing diff for name=%s k=%#v platform=%#v config=%#v", name, k, old, new)
 			return true
 		}
 		return false

--- a/docs/index.md
+++ b/docs/index.md
@@ -176,6 +176,7 @@ Alternatively, you can provide this value as an environment variable `DATABRICKS
 * `profile` - (optional) Connection profile specified within ~/.databrickscfg. Please check [connection profiles section](https://docs.databricks.com/dev-tools/cli/index.html#connection-profiles) for more details. This field defaults to 
 `DEFAULT`.
 * `account_id` - (optional) Account Id that could be found in the bottom left corner of [Accounts Console](https://accounts.cloud.databricks.com/). Alternatively, you can provide this value as an environment variable `DATABRICKS_ACCOUNT_ID`. Only has effect when `host = "https://accounts.cloud.databricks.com/"` and currently used to provision account admins via [databricks_user](resources/user.md). In the future releases of the provider this property will also be used specify account for `databricks_mws_*` resources as well.
+* `auth_type` - (optional) enforce specific auth type to be used in very rare cases, where a single Terraform state manages Databricks workspaces on more than one cloud and `More than one authorization method configured` error is a false positive. Valid values are `pat`, `basic`, `azure-client-secret`, `azure-msi`, `azure-cli`, and `databricks-cli`.
 
 ## Special configurations for Azure
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -173,7 +173,7 @@ func configureDatabricksClient(ctx context.Context, d *schema.ResourceData) (int
 			authorizationMethodsUsed = append(authorizationMethodsUsed, name)
 		}
 	}
-	if len(authorizationMethodsUsed) > 1 {
+	if pc.AuthType == "" && len(authorizationMethodsUsed) > 1 {
 		sort.Strings(authorizationMethodsUsed)
 		return nil, diag.Errorf("More than one authorization method configured: %s",
 			strings.Join(authorizationMethodsUsed, " and "))


### PR DESCRIPTION
Added optional `auth_type` provider conf to enforce specific auth type to be used in very rare cases, where a single Terraform state manages Databricks workspaces on more than one cloud and `More than one authorization method configured` error is a false positive. Valid values are `pat`, `basic`, `azure-client-secret`, `azure-msi`, `azure-cli`, and `databricks-cli`.
