### PR TITLE
Fixed creating workspaces with `token {}` block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.4.2
 
+* Fixed creating new `databricks_mws_workspaces` with `token {}` block ([#994](https://github.com/databrickslabs/terraform-provider-databricks/issues/994)).
 * Added `DBC` format support for `databricks_notebook` ([#989](https://github.com/databrickslabs/terraform-provider-databricks/pull/989)). 
 * Added optional `auth_type` provider conf to enforce specific auth type to be used in very rare cases, where a single Terraform state manages Databricks workspaces on more than one cloud and `More than one authorization method configured` error is a false positive. Valid values are `pat`, `basic`, `azure-client-secret`, `azure-msi`, `azure-cli`, and `databricks-cli`.
 * Added automated documentation formatting with `make fmt-docs`, so that all HCL examples look consistent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## 0.4.2
 
-* Fixed creating new `databricks_mws_workspaces` with `token {}` block ([#994](https://github.com/databrickslabs/terraform-provider-databricks/issues/994)).
+* Added optional `auth_type` provider conf to enforce specific auth type to be used in very rare cases, where a single Terraform state manages Databricks workspaces on more than one cloud and `More than one authorization method configured` error is a false positive. Valid values are `pat`, `basic`, `azure-client-secret`, `azure-msi`, `azure-cli`, and `databricks-cli` ([#1000](https://github.com/databrickslabs/terraform-provider-databricks/pull/1000)).
 * Added `DBC` format support for `databricks_notebook` ([#989](https://github.com/databrickslabs/terraform-provider-databricks/pull/989)). 
-* Added optional `auth_type` provider conf to enforce specific auth type to be used in very rare cases, where a single Terraform state manages Databricks workspaces on more than one cloud and `More than one authorization method configured` error is a false positive. Valid values are `pat`, `basic`, `azure-client-secret`, `azure-msi`, `azure-cli`, and `databricks-cli`.
-* Added automated documentation formatting with `make fmt-docs`, so that all HCL examples look consistent.
-* Increased codebase unit test coverage to 91% to improve stability.
+* Fixed creating new `databricks_mws_workspaces` with `token {}` block ([#994](https://github.com/databrickslabs/terraform-provider-databricks/issues/994)).
+* Added automated documentation formatting with `make fmt-docs`, so that all HCL examples look consistent ([#999](https://github.com/databrickslabs/terraform-provider-databricks/pull/999)).
+* Increased codebase unit test coverage to 91% to improve stability ([#996](https://github.com/databrickslabs/terraform-provider-databricks/pull/996), [#992](https://github.com/databrickslabs/terraform-provider-databricks/pull/992), [#991](https://github.com/databrickslabs/terraform-provider-databricks/pull/991), [#990](https://github.com/databrickslabs/terraform-provider-databricks/pull/990)).
 
 Updated dependency versions:
 

--- a/common/client.go
+++ b/common/client.go
@@ -260,7 +260,7 @@ func (c *DatabricksClient) Authenticate(ctx context.Context) error {
 		if authorizer == nil {
 			continue
 		}
-		// even though this may complain about clear text loggin, passwords are replaced with `***`
+		// even though this may complain about clear text logging, passwords are replaced with `***`
 		log.Printf("[INFO] Configured %s auth: %s", auth.name, c.configDebugString()) // lgtm[go/clear-text-logging]
 		c.authVisitor = authorizer
 		c.AuthType = auth.name

--- a/mws/acceptance/workspace_test.go
+++ b/mws/acceptance/workspace_test.go
@@ -55,6 +55,10 @@ func TestMwsAccWorkspaces(t *testing.T) {
 				storage_configuration_id = databricks_mws_storage_configurations.this.storage_configuration_id
 				managed_services_customer_managed_key_id = databricks_mws_customer_managed_keys.this.customer_managed_key_id
 				network_id = databricks_mws_networks.this.network_id
+
+				token {
+					comment = "Test {var.RANDOM}"
+				}
 			}`,
 		},
 	})

--- a/mws/resource_workspace.go
+++ b/mws/resource_workspace.go
@@ -144,6 +144,11 @@ func (a WorkspacesAPI) Create(ws *Workspace, timeout time.Duration) error {
 		}
 		return err
 	}
+	if ws.WorkspaceURL == "" {
+		// WorkspaceURL is computed, yet very important field
+		host := generateWorkspaceHostname(a.client, *ws)
+		ws.WorkspaceURL = fmt.Sprintf("https://%s", host)
+	}
 	return nil
 }
 
@@ -497,7 +502,7 @@ func ResourceWorkspace() *schema.Resource {
 				return err
 			}
 			d.Set("workspace_id", workspace.WorkspaceID)
-			d.Set("workspace_url", workspace.WorkspaceURL) // bug: workspace is not here yet...
+			d.Set("workspace_url", workspace.WorkspaceURL)
 			p.Pack(d)
 			return CreateTokenIfNeeded(workspacesAPI, workspaceSchema, d)
 		},

--- a/mws/resource_workspace.go
+++ b/mws/resource_workspace.go
@@ -497,6 +497,7 @@ func ResourceWorkspace() *schema.Resource {
 				return err
 			}
 			d.Set("workspace_id", workspace.WorkspaceID)
+			d.Set("workspace_url", workspace.WorkspaceURL) // bug: workspace is not here yet...
 			p.Pack(d)
 			return CreateTokenIfNeeded(workspacesAPI, workspaceSchema, d)
 		},


### PR DESCRIPTION
Fix #994 