### PR TITLE
Release v0.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.1"
+      version = "0.4.2"
     }
   }
 }

--- a/docs/guides/aws-e2-firewall-hub-and-spoke.md
+++ b/docs/guides/aws-e2-firewall-hub-and-spoke.md
@@ -91,7 +91,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.1"
+      version = "0.4.2"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/docs/guides/aws-e2-firewall-workspace.md
+++ b/docs/guides/aws-e2-firewall-workspace.md
@@ -89,7 +89,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.1"
+      version = "0.4.2"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/docs/guides/aws-workspace.md
+++ b/docs/guides/aws-workspace.md
@@ -54,7 +54,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.1"
+      version = "0.4.2"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/docs/guides/workspace-management.md
+++ b/docs/guides/workspace-management.md
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.1"
+      version = "0.4.2"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -336,7 +336,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.1"
+      version = "0.4.2"
     }
   }
 }


### PR DESCRIPTION
Version changelog:

* Added optional `auth_type` provider conf to enforce specific auth type to be used in very rare cases, where a single Terraform state manages Databricks workspaces on more than one cloud and `More than one authorization method configured` error is a false positive. Valid values are `pat`, `basic`, `azure-client-secret`, `azure-msi`, `azure-cli`, and `databricks-cli` ([#1000](https://github.com/databrickslabs/terraform-provider-databricks/pull/1000)).
* Added `DBC` format support for `databricks_notebook` ([#989](https://github.com/databrickslabs/terraform-provider-databricks/pull/989)). 
* Fixed creating new `databricks_mws_workspaces` with `token {}` block ([#994](https://github.com/databrickslabs/terraform-provider-databricks/issues/994)).
* Added automated documentation formatting with `make fmt-docs`, so that all HCL examples look consistent ([#999](https://github.com/databrickslabs/terraform-provider-databricks/pull/999)).
* Increased codebase unit test coverage to 91% to improve stability ([#996](https://github.com/databrickslabs/terraform-provider-databricks/pull/996), [#992](https://github.com/databrickslabs/terraform-provider-databricks/pull/992), [#991](https://github.com/databrickslabs/terraform-provider-databricks/pull/991), [#990](https://github.com/databrickslabs/terraform-provider-databricks/pull/990)).

Updated dependency versions:

* Bump github.com/hashicorp/terraform-plugin-sdk/v2 from 2.10.0 to 2.10.1 

Test run: Databricks Accounts
---

 * [x] mws.TestMwsAccCreds (5.85s)
 * [x] mws.TestMwsAccCustomerManagedKeys (4.80s)
 * [x] mws.TestMwsAccLogDelivery (9.96s)
 * [x] mws.TestMwsAccPAS (4.04s)
 * [x] mws.TestMwsAccStorageConfigurations (3.24s)
 * [x] mws.TestMwsAccVPCEndpointIntegration (101.20s)
 * [x] mws.TestMwsAccWorkspace (0.97s)
 * [x] mws/acceptance.TestMwsAccCredentials (6.02s)
 * [x] mws/acceptance.TestMwsAccCustomerManagedKeys (8.62s)
 * [x] mws/acceptance.TestMwsAccLogDelivery (13.40s)
 * [x] mws/acceptance.TestMwsAccNetworks (6.53s)
 * [x] mws/acceptance.TestMwsAccPrivateAccessSettings (6.17s)
 * [x] mws/acceptance.TestMwsAccStorageConfigurations (5.78s)
 * [x] mws/acceptance.TestMwsAccVpcEndpoint (99.02s)
 * [x] mws/acceptance.TestMwsAccWorkspaces (98.32s)

Test run: Azure MSI
---

 * [x] access.TestAccIPACL (5.47s)
 * [x] access/acceptance.TestAccTableACL (808.60s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateClusterWithLibraries (247.67s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateSingleNodeCluster (44.31s)
 * [x] clusters/acceptance.TestAccListClustersIntegration (115.59s)
 * [x] commands/acceptance.TestAccContext (25.21s)
 * [x] jobs/acceptance.TestAccJobResource (3.82s)
 * [x] libraries/acceptance.TestAccLibraryCreate (41.04s)
 * [x] mlflow/acceptance.TestAccMLflowExperiment (6.61s)
 * [x] mlflow/acceptance.TestAccMLflowModel (3.01s)
 * [x] permissions.TestAccessControlChangeString (0.00s)
 * [x] permissions.TestAccessControlString (0.00s)
 * [x] permissions.TestAccessControlToAccessControlChange (0.00s)
 * [x] permissions/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (10.96s)
 * [x] permissions/acceptance.TestAccDatabricksReposPermissionsResourceFullLifecycle (11.84s)
 * [x] permissions/acceptance.TestAccPermissionsClusterPolicy (5.52s)
 * [x] permissions/acceptance.TestAccPermissionsClusters (45.05s)
 * [x] permissions/acceptance.TestAccPermissionsInstancePool (5.17s)
 * [x] permissions/acceptance.TestAccPermissionsJobs (6.00s)
 * [x] permissions/acceptance.TestAccPermissionsNotebooks (5.98s)
 * [x] permissions/acceptance.TestAccPermissionsTokens (4.57s)
 * [x] policies/acceptance.TestAccClusterPolicyResourceFullLifecycle (4.15s)
 * [x] pools.TestAccInstancePools (1.33s)
 * [x] scim.TestAccCreateUser (3.07s)
 * [x] scim.TestAccFilterGroup (0.52s)
 * [x] scim.TestAccGroup (6.33s)
 * [x] scim.TestAccReadUser (0.48s)
 * [x] scim.TestAccServicePrincipalOnAzure (2.41s)
 * [x] scim/acceptance.TestAccGroupMemberResource (7.18s)
 * [x] scim/acceptance.TestAccGroupResource (4.74s)
 * [x] scim/acceptance.TestAccGroupResource_verify_entitlements (4.89s)
 * [x] scim/acceptance.TestAccServicePrincipalResourceOnAzure (3.76s)
 * [x] scim/acceptance.TestAccUserResource (6.81s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipals (1.12s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipalsGroup (0.85s)
 * [x] secrets/acceptance.TestAccSecretAclResource (5.13s)
 * [x] secrets/acceptance.TestAccSecretAclResourceDefaultPrincipal (4.08s)
 * [x] secrets/acceptance.TestAccSecretResource (5.19s)
 * [x] secrets/acceptance.TestAccSecretScopeResource (5.20s)
 * [x] storage.TestAccCreateFile (2.06s)
 * [x] storage/acceptance.TestAccAzureBlobMountGeneric (140.48s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (4.50s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (2.20s)
 * [x] storage/acceptance.TestAccInvalidSecretScopeFails (5.14s)
 * [x] storage/acceptance.TestAccSourceOnInvalidMountFails (35.67s)
 * [x] tokens.TestAccCreateToken (0.63s)
 * [x] tokens.TestAccCreateToken_NoExpiration (0.47s)
 * [x] tokens/acceptance.TestAccTokenResource (4.32s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (3.04s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (4.65s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (2.49s)

Test run: AWS
---

 * [x] access.TestAccIPACL (1.66s)
 * [x] access/acceptance.TestAccTableACL (641.20s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateClusterWithLibraries (474.57s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateSingleNodeCluster (69.11s)
 * [x] clusters/acceptance.TestAccListClustersIntegration (126.71s)
 * [x] commands/acceptance.TestAccContext (13.23s)
 * [x] jobs/acceptance.TestAccJobResource (4.00s)
 * [x] libraries/acceptance.TestAccLibraryCreate (72.37s)
 * [x] mlflow/acceptance.TestAccMLflowExperiment (5.46s)
 * [x] mlflow/acceptance.TestAccMLflowModel (2.55s)
 * [x] permissions.TestAccessControlChangeString (0.00s)
 * [x] permissions.TestAccessControlString (0.00s)
 * [x] permissions.TestAccessControlToAccessControlChange (0.00s)
 * [x] permissions/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (41.48s)
 * [x] permissions/acceptance.TestAccDatabricksReposPermissionsResourceFullLifecycle (28.25s)
 * [x] permissions/acceptance.TestAccPermissionsClusterPolicy (15.14s)
 * [x] permissions/acceptance.TestAccPermissionsClusters (83.63s)
 * [x] permissions/acceptance.TestAccPermissionsInstancePool (15.24s)
 * [x] permissions/acceptance.TestAccPermissionsJobs (14.94s)
 * [x] permissions/acceptance.TestAccPermissionsNotebooks (16.76s)
 * [x] permissions/acceptance.TestAccPermissionsTokens (14.08s)
 * [x] policies/acceptance.TestAccClusterPolicyResourceFullLifecycle (4.77s)
 * [x] pools.TestAccInstancePools (1.53s)
 * [x] scim.TestAccCreateUser (7.91s)
 * [x] scim.TestAccFilterGroup (1.83s)
 * [x] scim.TestAccGroup (24.31s)
 * [x] scim.TestAccReadUser (1.78s)
 * [x] scim/acceptance.TestAccGroupMemberResource (31.48s)
 * [x] scim/acceptance.TestAccGroupResource (11.60s)
 * [x] scim/acceptance.TestAccGroupResource_verify_entitlements (13.00s)
 * [x] scim/acceptance.TestAccServicePrincipalResourceOnAws (8.05s)
 * [x] scim/acceptance.TestAccUserResource (10.31s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipals (1.58s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipalsGroup (0.71s)
 * [x] secrets/acceptance.TestAccSecretAclResource (13.64s)
 * [x] secrets/acceptance.TestAccSecretAclResourceDefaultPrincipal (4.96s)
 * [x] secrets/acceptance.TestAccSecretResource (4.92s)
 * [x] secrets/acceptance.TestAccSecretScopeResource (5.81s)
 * [x] storage.TestAccCreateFile (4.94s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (4.70s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (2.50s)
 * [x] storage/acceptance.TestAccInvalidSecretScopeFails (4.14s)
 * [x] storage/acceptance.TestAccSourceOnInvalidMountFails (31.43s)
 * [x] tokens.TestAccCreateToken (0.57s)
 * [x] tokens.TestAccCreateToken_NoExpiration (0.28s)
 * [x] tokens/acceptance.TestAccTokenResource (3.37s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (4.60s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (5.59s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (2.35s)
