### PR TITLE
Added explanation to HTTP 403 errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.4.3
 
+* Added `Using XXX auth` explanation to HTTP 403 errors, which should help troubleshooting misconfigured authentication or provider aliasing. Example error message now looks like: *cannot create group: /2.0/preview/scim/v2/Groups is only accessible by admins. Using databricks-cli auth: host=https://XXX.cloud.databricks.com/, token=`***REDACTED***`, profile=demo.* All sensitive configuration parameters (`token`, `password`, and `azure_client_secret`) are redacted and replaced with `***REDACTED***` ([#821](https://github.com/databrickslabs/terraform-provider-databricks/issues/821)).
 * Improved documentation with regards to public subnets in AWS quick start ([#1005](https://github.com/databrickslabs/terraform-provider-databricks/pull/1005)).
 * Added `databricks_mount` code genration for [exporter](https://registry.terraform.io/providers/databrickslabs/databricks/latest/docs/guides/experimental-exporter) tooling ([#1006](https://github.com/databrickslabs/terraform-provider-databricks/pull/1006)).
 * Increase dependency check frequency ([#1007](https://github.com/databrickslabs/terraform-provider-databricks/pull/1007)).

--- a/common/client.go
+++ b/common/client.go
@@ -214,12 +214,16 @@ func (c *DatabricksClient) configDebugString() string {
 		if value == "" {
 			continue
 		}
+		if attr.Name == "azure_use_msi" && value == "false" {
+			// include Azure MSI info only when it's relevant
+			continue
+		}
 		if attr.Sensitive {
 			value = "***REDACTED***"
 		}
 		debug = append(debug, fmt.Sprintf("%s=%v", attr.Name, value))
 	}
-	return strings.Join(debug, ", ")
+	return strings.Join(debug, ", ") // lgtm[go/clear-text-logging]
 }
 
 // Authenticate lazily authenticates across authorizers or returns error

--- a/common/http.go
+++ b/common/http.go
@@ -210,6 +210,11 @@ func (c *DatabricksClient) parseError(resp *http.Response) APIError {
 		}
 		errorBody.ErrorCode = fmt.Sprintf("SCIM_%s", errorBody.ScimStatus)
 	}
+	if resp.StatusCode == 403 {
+		errorBody.Message = fmt.Sprintf("%s. Using %s auth: %s",
+			strings.Trim(errorBody.Message, "."), c.AuthType,
+			c.configDebugString())
+	}
 	return APIError{
 		Message:    errorBody.Message,
 		ErrorCode:  errorBody.ErrorCode,

--- a/common/http_test.go
+++ b/common/http_test.go
@@ -131,6 +131,26 @@ func TestParseError_API12(t *testing.T) {
 		"Actual message: %s", err.Error())
 }
 
+func TestParseError_Enhance403(t *testing.T) {
+	ws := DatabricksClient{
+		Host:  "qwerty.cloud.databricks.com",
+		Token: "x",
+	}
+	assert.NoError(t, ws.Authenticate(context.Background()))
+	err := ws.parseError(&http.Response{
+		Request: httptest.NewRequest(
+			"GET", "https://querty.cloud.databricks.com/api/2.0/clusters/list",
+			nil),
+		StatusCode: 403,
+		Body: ioutil.NopCloser(bytes.NewReader([]byte(`{
+			"error_code": "PERMISSION_DENIED",
+			"message": "You are not authorized."
+		}`))),
+	})
+	assert.EqualError(t, err, "You are not authorized. Using pat auth: "+
+		"host=https://qwerty.cloud.databricks.com, token=***REDACTED***")
+}
+
 func TestParseError_SCIM(t *testing.T) {
 	ws := DatabricksClient{
 		Host: "qwerty.cloud.databricks.com",


### PR DESCRIPTION
Added `Using XXX auth` explanation to HTTP 403 errors, which should help troubleshooting misconfigured authentication or provider aliasing. Example error message now looks like: *cannot create group: /2.0/preview/scim/v2/Groups is only accessible by admins. Using databricks-cli auth: host=https://XXX.cloud.databricks.com/, token=`***REDACTED***`, profile=demo.* All sensitive configuration parameters (`token`, `password`, and `azure_client_secret`) are redacted and replaced with `***REDACTED***`

Fixes #821