### PR TITLE
Add debugger mode for the binary

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,14 @@
    "version": "0.2.0",
    "configurations": [
        {
+           "name": "Debug Provider",
+           "type": "go",
+           "request": "launch",
+           "mode": "debug",
+           "program": "main.go",
+           "args": ["debug"],
+       },
+       {
            "name": "Launch test function",
            "type": "go",
            "request": "launch",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version changelog
 
+## 0.4.4
+
+* Added support for [running provider in a debug mode](https://www.terraform.io/plugin/sdkv2/debugging#running-terraform-with-a-provider-in-debug-mode) from Visual Studio Code through `Debug Provider` run configuration in order to troubleshoot more complicated issues.
+
 ## 0.4.3
 
 * Added support for `databricks_permissions` for `databricks_mlflow_experiment` and `databricks_mlflow_model` ([#1013](https://github.com/databrickslabs/terraform-provider-databricks/pull/1013)).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,9 @@ After this, you should be able to run `make coverage` to run the tests and see t
 
 ## Debugging
 
-**TF_LOG=DEBUG terraform apply** allows you to see the internal logs from `terraform apply`.
+**TF_LOG_PROVIDER=DEBUG terraform apply** allows you to see the internal logs from `terraform apply`.
+
+You can [run provider in a debug mode](https://www.terraform.io/plugin/sdkv2/debugging#running-terraform-with-a-provider-in-debug-mode) from VScode IDE by launching `Debug Provider` run configuration and invoking `terraform apply` with `TF_REATTACH_PROVIDERS` environment variable.
 
 ## Adding a new resource
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -21,6 +22,14 @@ func main() {
 		if err := exporter.Run(os.Args...); err != nil {
 			log.Printf("[ERROR] %s", err.Error())
 			os.Exit(1)
+		}
+		return
+	}
+	if len(os.Args) > 1 && os.Args[1] == "debug" {
+		err := plugin.Debug(context.Background(), "registry.terraform.io/databrickslabs/databricks",
+			&plugin.ServeOpts{ProviderFunc: provider.DatabricksProvider})
+		if err != nil {
+			log.Fatal(err.Error())
 		}
 		return
 	}


### PR DESCRIPTION
You can [run provider in a debug mode](https://www.terraform.io/plugin/sdkv2/debugging#running-terraform-with-a-provider-in-debug-mode) from VScode IDE by launching `Debug Provider` run configuration and invoking `terraform apply` with `TF_REATTACH_PROVIDERS` environment variable.