### PR TITLE
Remove `databricks_mount` import from docs

### DIFF
--- a/docs/resources/mount.md
+++ b/docs/resources/mount.md
@@ -327,11 +327,3 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - mount name
 * `source` - (String) HDFS-compatible url
-
-## Import
-
-The resource can be imported using it's mount name
-
-```bash
-$ terraform import databricks_mount.this <mount_name>
-```

--- a/exporter/context.go
+++ b/exporter/context.go
@@ -222,7 +222,7 @@ func (ic *importContext) Run() error {
 		if i%50 == 0 {
 			log.Printf("[INFO] Generated %d of %d resources", i, scopeSize)
 		}
-		if r.Mode != "data" {
+		if r.Mode != "data" && ic.Resources[r.Resource].Importer != nil {
 			// nolint
 			sh.WriteString(r.ImportCommand(ic) + "\n")
 		}

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -403,12 +403,3 @@ func configureProviderAndReturnClient(t *testing.T, tt providerFixture) (*common
 
 	return client, nil
 }
-
-func TestAllResourcesMustHaveImport(t *testing.T) {
-	p := DatabricksProvider()
-	for name, r := range p.ResourcesMap {
-		if r.Importer == nil {
-			assert.Fail(t, "Missing importer: %s", name)
-		}
-	}
-}

--- a/storage/resource_mount.go
+++ b/storage/resource_mount.go
@@ -63,5 +63,6 @@ func ResourceMount() *schema.Resource {
 	r.CreateContext = mountCallback(mountCreate).preProcess(r)
 	r.ReadContext = mountCallback(mountRead).preProcess(r)
 	r.DeleteContext = mountCallback(mountDelete).preProcess(r)
+	r.Importer = nil
 	return r
 }


### PR DESCRIPTION
Generic solution for importing mounts is not possible in the current implementation of mounts, that rely on Command/Context APIs.

This PR removes documentation references and `exporter` generation for things, that have never been properly working.

Fix #1018