### PR TITLE
Skip lib refresh for clusters with no libs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## 0.4.4
 
 * Added support for [running provider in a debug mode](https://www.terraform.io/plugin/sdkv2/debugging#running-terraform-with-a-provider-in-debug-mode) from Visual Studio Code through `Debug Provider` run configuration in order to troubleshoot more complicated issues.
+* Allowed managing of libraries on `databricks_cluster` outside of Terraform state for resources without any `library` configuration blocks. This should simplify PaaS-like CI/CD workflows.
+
+**Behavior changes**
+
+* Whenever library is installed on `databricks_cluster` without any [`library` configuration blocks](https://registry.terraform.io/providers/databrickslabs/databricks/latest/docs/resources/cluster#library-configuration-block), it won't be removed anymore.
 
 ## 0.4.3
 

--- a/clusters/resource_cluster_test.go
+++ b/clusters/resource_cluster_test.go
@@ -419,22 +419,6 @@ func TestResourceClusterRead(t *testing.T) {
 					TotalCount: 0,
 				},
 			},
-			{
-				Method:   "GET",
-				Resource: "/api/2.0/libraries/cluster-status?cluster_id=abc",
-				Response: libraries.ClusterLibraryStatuses{
-					LibraryStatuses: []libraries.LibraryStatus{
-						{
-							Library: &libraries.Library{
-								Pypi: &libraries.PyPi{
-									Package: "requests",
-								},
-							},
-							Status: "INSTALLED",
-						},
-					},
-				},
-			},
 		},
 		Resource: ResourceCluster(),
 		Read:     true,
@@ -447,7 +431,6 @@ func TestResourceClusterRead(t *testing.T) {
 	assert.Equal(t, "Shared Autoscaling", d.Get("cluster_name"))
 	assert.Equal(t, "i3.xlarge", d.Get("node_type_id"))
 	assert.Equal(t, 4, d.Get("autoscale.0.max_workers"))
-	assert.Equal(t, "requests", d.Get("library.2047590238.pypi.0.package"))
 	assert.Equal(t, "RUNNING", d.Get("state"))
 	assert.Equal(t, false, d.Get("is_pinned"))
 


### PR DESCRIPTION
Allowed managing of libraries on `databricks_cluster` outside of Terraform state for resources without any `library` configuration blocks.

**Behavior changes**

* Whenever library is installed on `databricks_cluster` without any [`library` configuration blocks](https://registry.terraform.io/providers/databrickslabs/databricks/latest/docs/resources/cluster#library-configuration-block), it won't be removed anymore.