### PR TITLE
Implicitly force import manually added user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Version changelog
 
+## 0.4.6
+
+* Added optional `force` argument to `databricks_user` resource to ignore `cannot create user: User with username X already exists` errors and implicitly import the specific user into Terraform state, enforcing entitlements defined in the instance of resource.
+
+Updated dependency versions:
+
+* Bump github.com/Azure/go-autorest/autorest/azure/auth from 0.5.10 to 0.5.11
+* Bump github.com/Azure/go-autorest/autorest/azure/cli from 0.4.3 to 0.4.5
+* Bump github.com/Azure/go-autorest/autorest from 0.11.23 to 0.11.24
+
 ## 0.4.5
 
 * Cross-linked resource documentation ([#1027](https://github.com/databrickslabs/terraform-provider-databricks/pull/1027)).

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -53,6 +53,7 @@ The following arguments are available:
 * `allow_instance_pool_create` -  (Optional) Allow the user to have [instance pool](instance_pool.md) create privileges. Defaults to false. More fine grained permissions could be assigned with [databricks_permissions](permissions.md#Instance-Pool-usage) and [instance_pool_id](permissions.md#instance_pool_id) argument.
 * `databricks_sql_access` - (Optional) This is a field to allow the group to have access to [Databricks SQL](https://databricks.com/product/databricks-sql) feature in User Interface and through [databricks_sql_endpoint](sql_endpoint.md).
 * `active` - (Optional) Either user is active or not. True by default, but can be set to false in case of user deactivation with preserving user assets.
+* `force` - (Optional) Ignore `cannot create user: User with username X already exists` errors and implicitly import the specific user into Terraform state, enforcing entitlements defined in the instance of resource. _This functionality is experimental_ and is designed to simplify corner cases, like Azure Active Directory synchronisation.
 
 ## Attribute Reference
 

--- a/scim/resource_user.go
+++ b/scim/resource_user.go
@@ -3,6 +3,7 @@ package scim
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/databrickslabs/terraform-provider-databricks/common"
 
@@ -83,7 +84,7 @@ func createForceOverridesManuallyAddedUser(err error, d *schema.ResourceData, us
 		return err
 	}
 	// corner-case for overriding manually provisioned users
-	userName := u.UserName
+	userName := strings.ReplaceAll(u.UserName, "'", "")
 	force := fmt.Sprintf("User with username %s already exists.", userName)
 	if err.Error() != force {
 		return err


### PR DESCRIPTION
Add `force` parameter to `databricks_user`, so that SCIM sync corner cases might be simplified

![image](https://user-images.githubusercontent.com/259697/150187628-998d2558-229f-4eeb-b33b-bd9516ab70af.png)
 