### PR TITLE
Release v0.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 **Deprecations**
 
-* `databricks_user_instance_profile` is deprecated in favor of `databricks_user_role`.
+* `databricks_user_instance_profile` is deprecated in favor of `databricks_user_role`. Please do slight modifications of your configuration.
 
 Updated dependency versions:
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.5"
+      version = "0.4.6"
     }
   }
 }

--- a/docs/guides/aws-e2-firewall-hub-and-spoke.md
+++ b/docs/guides/aws-e2-firewall-hub-and-spoke.md
@@ -91,7 +91,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.5"
+      version = "0.4.6"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/docs/guides/aws-e2-firewall-workspace.md
+++ b/docs/guides/aws-e2-firewall-workspace.md
@@ -89,7 +89,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.5"
+      version = "0.4.6"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/docs/guides/aws-workspace.md
+++ b/docs/guides/aws-workspace.md
@@ -54,7 +54,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.5"
+      version = "0.4.6"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/docs/guides/workspace-management.md
+++ b/docs/guides/workspace-management.md
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.5"
+      version = "0.4.6"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -338,7 +338,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.5"
+      version = "0.4.6"
     }
   }
 }


### PR DESCRIPTION
# Version changelog

## 0.4.6

* Clarified error messages around `azure_workspace_resource_id` provider configuration ([#1049](https://github.com/databrickslabs/terraform-provider-databricks/issues/1049)).
* Added optional `force` argument to `databricks_user` resource to ignore `cannot create user: User with username X already exists` errors and implicitly import the specific user into Terraform state, enforcing entitlements defined in the instance of resource ([#1048](https://github.com/databrickslabs/terraform-provider-databricks/pull/1048)).
* Added `databricks_user_role` resource, that can assign roles on Databricks Account or `databricks_instance_profile` for data access ([#1047](https://github.com/databrickslabs/terraform-provider-databricks/pull/1047)).

**Deprecations**

* `databricks_user_instance_profile` is deprecated in favor of `databricks_user_role`.

Updated dependency versions:

* Bump github.com/Azure/go-autorest/autorest/azure/auth from 0.5.10 to 0.5.11
* Bump github.com/Azure/go-autorest/autorest/azure/cli from 0.4.3 to 0.4.5
* Bump github.com/Azure/go-autorest/autorest from 0.11.23 to 0.11.24

Test run: Azure
---

 * [x] access.TestAccIPACL (5.45s)
 * [x] access/acceptance.TestAccTableACL (527.99s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateClusterWithLibraries (295.14s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateSingleNodeCluster (44.39s)
 * [x] clusters/acceptance.TestAccListClustersIntegration (111.35s)
 * [x] commands/acceptance.TestAccContext (32.54s)
 * [x] jobs/acceptance.TestAccJobResource (3.97s)
 * [x] libraries/acceptance.TestAccLibraryCreate (40.99s)
 * [x] mlflow/acceptance.TestAccMLflowExperiment (7.19s)
 * [x] mlflow/acceptance.TestAccMLflowModel (3.04s)
 * [x] permissions.TestAccessControlChangeString (0.00s)
 * [x] permissions.TestAccessControlString (0.00s)
 * [x] permissions.TestAccessControlToAccessControlChange (0.00s)
 * [x] permissions/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (12.64s)
 * [x] permissions/acceptance.TestAccDatabricksReposPermissionsResourceFullLifecycle (12.50s)
 * [x] permissions/acceptance.TestAccPermissionsClusterPolicy (4.83s)
 * [x] permissions/acceptance.TestAccPermissionsClusters (59.62s)
 * [x] permissions/acceptance.TestAccPermissionsInstancePool (5.04s)
 * [x] permissions/acceptance.TestAccPermissionsJobs (5.80s)
 * [x] permissions/acceptance.TestAccPermissionsNotebooks (5.95s)
 * [x] permissions/acceptance.TestAccPermissionsTokens (4.58s)
 * [x] policies/acceptance.TestAccClusterPolicyResourceFullLifecycle (5.00s)
 * [x] pools.TestAccInstancePools (1.13s)
 * [x] scim.TestAccCreateUser (2.68s)
 * [x] scim.TestAccFilterGroup (0.52s)
 * [x] scim.TestAccGroup (5.94s)
 * [x] scim.TestAccReadUser (0.44s)
 * [x] scim.TestAccServicePrincipalOnAzure (2.55s)
 * [x] scim/acceptance.TestAccGroupMemberResource (7.21s)
 * [x] scim/acceptance.TestAccGroupResource (4.87s)
 * [x] scim/acceptance.TestAccGroupResource_verify_entitlements (5.23s)
 * [x] scim/acceptance.TestAccServicePrincipalResourceOnAzure (4.37s)
 * [x] scim/acceptance.TestAccUserResource (7.12s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipals (1.21s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipalsGroup (0.96s)
 * [x] secrets/acceptance.TestAccSecretAclResource (5.73s)
 * [x] secrets/acceptance.TestAccSecretAclResourceDefaultPrincipal (4.35s)
 * [x] secrets/acceptance.TestAccSecretResource (6.74s)
 * [x] secrets/acceptance.TestAccSecretScopeResource (5.42s)
 * [x] storage.TestAccCreateFile (2.09s)
 * [x] storage/acceptance.TestAccAzureBlobMountGeneric (145.22s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (4.80s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (2.27s)
 * [x] storage/acceptance.TestAccInvalidSecretScopeFails (4.99s)
 * [x] storage/acceptance.TestAccSourceOnInvalidMountFails (36.63s)
 * [x] tokens.TestAccCreateToken (0.62s)
 * [x] tokens.TestAccCreateToken_NoExpiration (0.57s)
 * [x] tokens/acceptance.TestAccTokenResource (4.28s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (2.92s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (4.88s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (2.42s)

Test run: AWS
---

 * [x] access.TestAccIPACL (1.98s)
 * [x] access/acceptance.TestAccTableACL (562.06s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateClusterWithLibraries (352.66s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateSingleNodeCluster (63.01s)
 * [x] clusters/acceptance.TestAccListClustersIntegration (60.28s)
 * [x] commands/acceptance.TestAccContext (14.07s)
 * [x] jobs/acceptance.TestAccJobResource (3.76s)
 * [x] libraries/acceptance.TestAccLibraryCreate (60.05s)
 * [x] mlflow/acceptance.TestAccMLflowExperiment (4.15s)
 * [x] mlflow/acceptance.TestAccMLflowModel (3.53s)
 * [x] permissions.TestAccessControlChangeString (0.00s)
 * [x] permissions.TestAccessControlString (0.00s)
 * [x] permissions.TestAccessControlToAccessControlChange (0.00s)
 * [x] permissions/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (39.19s)
 * [x] permissions/acceptance.TestAccDatabricksReposPermissionsResourceFullLifecycle (25.81s)
 * [x] permissions/acceptance.TestAccPermissionsClusterPolicy (15.82s)
 * [x] permissions/acceptance.TestAccPermissionsClusters (81.83s)
 * [x] permissions/acceptance.TestAccPermissionsInstancePool (15.62s)
 * [x] permissions/acceptance.TestAccPermissionsJobs (17.04s)
 * [x] permissions/acceptance.TestAccPermissionsNotebooks (18.65s)
 * [x] permissions/acceptance.TestAccPermissionsTokens (17.18s)
 * [x] policies/acceptance.TestAccClusterPolicyResourceFullLifecycle (4.86s)
 * [x] pools.TestAccInstancePools (1.51s)
 * [x] scim.TestAccCreateUser (8.74s)
 * [x] scim.TestAccFilterGroup (1.74s)
 * [x] scim.TestAccGroup (28.00s)
 * [x] scim.TestAccReadUser (1.77s)
 * [x] scim/acceptance.TestAccGroupMemberResource (29.46s)
 * [x] scim/acceptance.TestAccGroupResource (13.05s)
 * [x] scim/acceptance.TestAccGroupResource_verify_entitlements (13.62s)
 * [x] scim/acceptance.TestAccServicePrincipalResourceOnAws (9.61s)
 * [x] scim/acceptance.TestAccUserResource (12.28s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipals (1.83s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipalsGroup (0.73s)
 * [x] secrets/acceptance.TestAccSecretAclResource (15.23s)
 * [x] secrets/acceptance.TestAccSecretAclResourceDefaultPrincipal (4.77s)
 * [x] secrets/acceptance.TestAccSecretResource (3.83s)
 * [x] secrets/acceptance.TestAccSecretScopeResource (5.29s)
 * [x] storage.TestAccCreateFile (4.83s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (4.47s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (2.19s)
 * [x] storage/acceptance.TestAccInvalidSecretScopeFails (3.38s)
 * [x] storage/acceptance.TestAccSourceOnInvalidMountFails (31.46s)
 * [x] tokens.TestAccCreateToken (0.46s)
 * [x] tokens.TestAccCreateToken_NoExpiration (0.27s)
 * [x] tokens/acceptance.TestAccTokenResource (3.79s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (4.89s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (4.22s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (2.37s)