### PR TITLE
Implicitly force import manually added group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Version changelog
 
+## 0.4.7
+* Added optional `force` argument to `databricks_group` resource to ignore `cannot create group: Group with name X already exists.` errors and implicitly import the specific group into Terraform state, enforcing entitlements defined in the instance of resource ([#1066](https://github.com/databrickslabs/terraform-provider-databricks/pull/1066)).
+
 ## 0.4.6
 
 * Clarified error messages around `azure_workspace_resource_id` provider configuration ([#1049](https://github.com/databrickslabs/terraform-provider-databricks/issues/1049)).

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -52,6 +52,7 @@ The following arguments are supported:
 * `allow_instance_pool_create` -  (Optional) This is a field to allow the group to have [instance pool](instance_pool.md) create privileges. More fine grained permissions could be assigned with [databricks_permissions](permissions.md#Instance-Pool-usage) and [instance_pool_id](permissions.md#instance_pool_id) argument.
 * `databricks_sql_access` - (Optional) This is a field to allow the group to have access to [Databricks SQL](https://databricks.com/product/databricks-sql) feature in User Interface and through [databricks_sql_endpoint](sql_endpoint.md).
 * `workspace_access` - (Optional) This is a field to allow the group to have access to Databricks Workspace.
+* `force` - (Optional) Ignore `cannot create group: Group with name X already exists.` errors and implicitly import the specific group into Terraform state, enforcing entitlements defined in the instance of resource. _This functionality is experimental_ and is designed to simplify corner cases, like Azure Active Directory synchronisation.
 
 ## Attribute Reference
 

--- a/scim/resource_group.go
+++ b/scim/resource_group.go
@@ -3,6 +3,7 @@ package scim
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/databrickslabs/terraform-provider-databricks/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -74,17 +75,16 @@ func createForceOverridesManuallyAddedGroup(err error, d *schema.ResourceData, g
 	if !forceCreate {
 		return err
 	}
-	// corner-case for overriding manually provisioned users
-	groupName := g.DisplayName
+	// corner-case for overriding manually provisioned groups
+	groupName := strings.ReplaceAll(g.DisplayName, "'", "")
 	force := fmt.Sprintf("Group with name %s already exists.", groupName)
 	if err.Error() != force {
 		return err
 	}
-	groupList, err := groupsAPI.Filter(fmt.Sprintf("displayName eq '%s'", groupName))
+	group, err := groupsAPI.ReadByDisplayName(groupName)
 	if err != nil {
 		return err
 	}
-	group := groupList.Resources[0]
 	d.SetId(group.ID)
 	return groupsAPI.UpdateNameAndEntitlements(d.Id(), g.DisplayName, g.ExternalID, g.Entitlements)
 }

--- a/scim/resource_group.go
+++ b/scim/resource_group.go
@@ -2,6 +2,7 @@ package scim
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/databrickslabs/terraform-provider-databricks/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -24,18 +25,24 @@ func ResourceGroup() *schema.Resource {
 			Optional: true,
 			ForceNew: true,
 		},
+		"force": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
 	}
 	addEntitlementsToSchema(&groupSchema)
 	return common.Resource{
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			groupName := d.Get("display_name").(string)
-			group, err := NewGroupsAPI(ctx, c).Create(Group{
+			g := Group{
 				DisplayName:  groupName,
 				Entitlements: readEntitlementsFromData(d),
 				ExternalID:   d.Get("external_id").(string),
-			})
+			}
+			groupsAPI := NewGroupsAPI(ctx, c)
+			group, err := groupsAPI.Create(g)
 			if err != nil {
-				return err
+				return createForceOverridesManuallyAddedGroup(err, d, groupsAPI, g)
 			}
 			d.SetId(group.ID)
 			return nil
@@ -60,4 +67,24 @@ func ResourceGroup() *schema.Resource {
 		},
 		Schema: groupSchema,
 	}.ToResource()
+}
+
+func createForceOverridesManuallyAddedGroup(err error, d *schema.ResourceData, groupsAPI GroupsAPI, g Group) error {
+	forceCreate := d.Get("force").(bool)
+	if !forceCreate {
+		return err
+	}
+	// corner-case for overriding manually provisioned users
+	groupName := g.DisplayName
+	force := fmt.Sprintf("Group with name %s already exists.", groupName)
+	if err.Error() != force {
+		return err
+	}
+	groupList, err := groupsAPI.Filter(fmt.Sprintf("displayName eq '%s'", groupName))
+	if err != nil {
+		return err
+	}
+	group := groupList.Resources[0]
+	d.SetId(group.ID)
+	return groupsAPI.UpdateNameAndEntitlements(d.Id(), g.DisplayName, g.ExternalID, g.Entitlements)
 }


### PR DESCRIPTION
Add `force` parameter to `databricks_group`, so that SCIM sync corner cases might be simplified

![image](https://user-images.githubusercontent.com/44292934/151552228-18f19a8c-9e8b-4690-82b5-2312e17e52f2.png)

Closes #1066
