### PR TITLE
Release v0.4.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.6"
+      version = "0.4.7"
     }
   }
 }

--- a/docs/guides/aws-e2-firewall-hub-and-spoke.md
+++ b/docs/guides/aws-e2-firewall-hub-and-spoke.md
@@ -91,7 +91,6 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.6"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/docs/guides/aws-e2-firewall-workspace.md
+++ b/docs/guides/aws-e2-firewall-workspace.md
@@ -89,7 +89,6 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.6"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/docs/guides/aws-workspace.md
+++ b/docs/guides/aws-workspace.md
@@ -54,7 +54,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.6"
+      version = "0.4.7"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/docs/guides/workspace-management.md
+++ b/docs/guides/workspace-management.md
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.6"
+      version = "0.4.7"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -338,7 +338,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.6"
+      version = "0.4.7"
     }
   }
 }


### PR DESCRIPTION
* Added optional `force` argument to `databricks_group` resource to ignore `cannot create group: Group with name X already exists.` errors and implicitly import the specific group into Terraform state, enforcing entitlements defined in the instance of resource ([#1066](https://github.com/databrickslabs/terraform-provider-databricks/pull/1066)).
* Added support to configure permissions for all MLflow models ([#1044](https://github.com/databrickslabs/terraform-provider-databricks/issues/1044)).
* Fixed `databricks_service_principal` `display_name` update ([#1065](https://github.com/databrickslabs/terraform-provider-databricks/issues/1065)).
* Added documentation for Unity Catalog resources.

Updated dependency versions:

* Bump gopkg.in/ini.v1 from 1.66.2 to 1.66.3

Test run: Azure
---

 * [x] access.TestAccIPACL (5.00s)
 * [x] access/acceptance.TestAccTableACL (496.16s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateClusterWithLibraries (253.11s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateSingleNodeCluster (44.24s)
 * [x] clusters/acceptance.TestAccListClustersIntegration (115.27s)
 * [x] commands/acceptance.TestAccContext (28.88s)
 * [x] jobs/acceptance.TestAccJobResource (3.45s)
 * [x] libraries/acceptance.TestAccLibraryCreate (40.99s)
 * [x] mlflow/acceptance.TestAccMLflowExperiment (5.55s)
 * [x] mlflow/acceptance.TestAccMLflowModel (2.89s)
 * [x] permissions.TestAccessControlChangeString (0.00s)
 * [x] permissions.TestAccessControlString (0.00s)
 * [x] permissions.TestAccessControlToAccessControlChange (0.00s)
 * [x] permissions/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (11.46s)
 * [x] permissions/acceptance.TestAccDatabricksReposPermissionsResourceFullLifecycle (10.05s)
 * [x] permissions/acceptance.TestAccPermissionsClusterPolicy (5.45s)
 * [x] permissions/acceptance.TestAccPermissionsClusters (44.92s)
 * [x] permissions/acceptance.TestAccPermissionsInstancePool (5.10s)
 * [x] permissions/acceptance.TestAccPermissionsJobs (5.44s)
 * [x] permissions/acceptance.TestAccPermissionsNotebooks (5.58s)
 * [x] permissions/acceptance.TestAccPermissionsTokens (4.02s)
 * [x] policies/acceptance.TestAccClusterPolicyResourceFullLifecycle (4.47s)
 * [x] pools.TestAccInstancePools (1.11s)
 * [x] scim.TestAccCreateUser (2.65s)
 * [x] scim.TestAccFilterGroup (0.38s)
 * [x] scim.TestAccGroup (6.00s)
 * [x] scim.TestAccReadUser (0.41s)
 * [x] scim.TestAccServicePrincipalOnAzure (2.40s)
 * [x] scim/acceptance.TestAccGroupMemberResource (6.82s)
 * [x] scim/acceptance.TestAccGroupResource (4.50s)
 * [x] scim/acceptance.TestAccGroupResource_verify_entitlements (4.79s)
 * [x] scim/acceptance.TestAccServicePrincipalResourceOnAzure (3.50s)
 * [x] scim/acceptance.TestAccUserResource (6.22s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipals (1.39s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipalsGroup (0.86s)
 * [x] secrets/acceptance.TestAccSecretAclResource (4.95s)
 * [x] secrets/acceptance.TestAccSecretAclResourceDefaultPrincipal (4.33s)
 * [x] secrets/acceptance.TestAccSecretResource (5.08s)
 * [x] secrets/acceptance.TestAccSecretScopeResource (5.75s)
 * [x] storage.TestAccCreateFile (2.58s)
 * [x] storage/acceptance.TestAccAzureBlobMountGeneric (139.65s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (5.07s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (2.33s)
 * [x] storage/acceptance.TestAccInvalidSecretScopeFails (4.90s)
 * [x] storage/acceptance.TestAccSourceOnInvalidMountFails (27.18s)
 * [x] tokens.TestAccCreateToken (0.83s)
 * [x] tokens.TestAccCreateToken_NoExpiration (0.43s)
 * [x] tokens/acceptance.TestAccTokenResource (3.93s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (3.21s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (4.60s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (2.50s)

Test run: AWS
---

 * [x] access.TestAccIPACL (2.30s)
 * [x] access/acceptance.TestAccTableACL (663.03s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateClusterWithLibraries (603.49s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateSingleNodeCluster (64.29s)
 * [x] clusters/acceptance.TestAccListClustersIntegration (122.90s)
 * [x] commands/acceptance.TestAccContext (13.41s)
 * [x] jobs/acceptance.TestAccJobResource (2.86s)
 * [x] libraries/acceptance.TestAccLibraryCreate (177.14s)
 * [x] mlflow/acceptance.TestAccMLflowExperiment (4.88s)
 * [x] mlflow/acceptance.TestAccMLflowModel (2.29s)
 * [x] permissions.TestAccessControlChangeString (0.00s)
 * [x] permissions.TestAccessControlString (0.00s)
 * [x] permissions.TestAccessControlToAccessControlChange (0.00s)
 * [x] permissions/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (37.25s)
 * [x] permissions/acceptance.TestAccDatabricksReposPermissionsResourceFullLifecycle (19.39s)
 * [x] permissions/acceptance.TestAccPermissionsClusterPolicy (14.47s)
 * [x] permissions/acceptance.TestAccPermissionsClusters (83.65s)
 * [x] permissions/acceptance.TestAccPermissionsInstancePool (16.45s)
 * [x] permissions/acceptance.TestAccPermissionsJobs (14.50s)
 * [x] permissions/acceptance.TestAccPermissionsNotebooks (16.05s)
 * [x] permissions/acceptance.TestAccPermissionsTokens (12.73s)
 * [x] policies/acceptance.TestAccClusterPolicyResourceFullLifecycle (3.65s)
 * [x] pools.TestAccInstancePools (1.49s)
 * [x] scim.TestAccCreateUser (8.43s)
 * [x] scim.TestAccFilterGroup (1.41s)
 * [x] scim.TestAccGroup (21.96s)
 * [x] scim.TestAccReadUser (1.76s)
 * [x] scim/acceptance.TestAccGroupMemberResource (25.84s)
 * [x] scim/acceptance.TestAccGroupResource (9.98s)
 * [x] scim/acceptance.TestAccGroupResource_verify_entitlements (11.69s)
 * [x] scim/acceptance.TestAccServicePrincipalResourceOnAws (6.54s)
 * [x] scim/acceptance.TestAccUserResource (9.80s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipals (1.62s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipalsGroup (0.71s)
 * [x] secrets/acceptance.TestAccSecretAclResource (10.49s)
 * [x] secrets/acceptance.TestAccSecretAclResourceDefaultPrincipal (4.68s)
 * [x] secrets/acceptance.TestAccSecretResource (3.76s)
 * [x] secrets/acceptance.TestAccSecretScopeResource (4.68s)
 * [x] storage.TestAccCreateFile (3.51s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (3.96s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (2.05s)
 * [x] storage/acceptance.TestAccInvalidSecretScopeFails (2.62s)
 * [x] storage/acceptance.TestAccSourceOnInvalidMountFails (31.38s)
 * [x] tokens.TestAccCreateToken (0.45s)
 * [x] tokens.TestAccCreateToken_NoExpiration (0.28s)
 * [x] tokens/acceptance.TestAccTokenResource (3.29s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (3.92s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (3.77s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (1.99s)