### PR TITLE
Add test to ensure deterministic coverage on widget parameter sorter

### DIFF
--- a/sql/resource_widget_test.go
+++ b/sql/resource_widget_test.go
@@ -2,6 +2,7 @@ package sql
 
 import (
 	"encoding/json"
+	"sort"
 	"testing"
 
 	"github.com/databrickslabs/terraform-provider-databricks/qa"
@@ -647,4 +648,19 @@ func TestWidgetDelete(t *testing.T) {
 
 func TestResourceWidgetCornerCases(t *testing.T) {
 	qa.ResourceCornerCases(t, ResourceWidget(), qa.CornerCaseID("foo/bar"))
+}
+
+func TestWidgetParameterSorter(t *testing.T) {
+	wp := sortWidgetParameter{
+		WidgetParameter{Name: "foo"},
+		WidgetParameter{Name: "bar"},
+	}
+
+	// Widget parameters should be sorted by their name to maintain deterministic ordering.
+	// Since they are not ordered in the API payload, not ordering them means users would
+	// see false state mismatches on comparison.
+	sort.Sort(wp)
+
+	assert.Equal(t, "bar", wp[0].Name)
+	assert.Equal(t, "foo", wp[1].Name)
 }


### PR DESCRIPTION
Whether the widget parameter sorter is covered by the existing tests is non-deterministic.

This means it shows up as increasing/decreasing coverage in unrelated PRs, for example #900: https://app.codecov.io/gh/databrickslabs/terraform-provider-databricks/compare/900/changes

This PR fixes that by adding a test.