### PR TITLE
Added `users`, `service_principals` to group data resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@
 * Added support for shared clusters in multi-task `databricks_job` ([#1082](https://github.com/databrickslabs/terraform-provider-databricks/issues/1082)).
 * Added diff suppression for `external_id` in `databricks_group` ([#1099](https://github.com/databrickslabs/terraform-provider-databricks/issues/1099)).
 * Added diff suppression for `external_id` in `databricks_user` ([#1097](https://github.com/databrickslabs/terraform-provider-databricks/issues/1097)).
+* Added `users`, `service_principals`, and `child_groups` exported properties to `databricks_group` data resource ([#1085](https://github.com/databrickslabs/terraform-provider-databricks/issues/1085)).
 * Added various documentation improvements.
+
+**Deprecations**
+
+* `databricks_group`.`members` is deprecated in favor of `users`, `service_principals`, and `child_groups` exported properties. Please do slight modifications of your configuration.
 
 Updated dependency versions:
 

--- a/docs/data-sources/group.md
+++ b/docs/data-sources/group.md
@@ -39,7 +39,9 @@ Data source exposes the following attributes:
 
 * `id` -  The id for the group object.
 * `external_id` - ID of the group in an external identity provider.
-* `members` - Set of [user](../resources/user.md) identifiers, that can be modified with [databricks_group_member](../resources/group_member.md) resource.
+* `users` - Set of [databricks_user](../resources/user.md) identifiers, that can be modified with [databricks_group_member](../resources/group_member.md) resource.
+* `service_principals` - Set of [databricks_service_principal](../resources/service_principal.md) identifiers, that can be modified with [databricks_group_member](../resources/group_member.md) resource.
+* `child_groups` - Set of [databricks_group](../resources/group.md) identifiers, that can be modified with [databricks_group_member](../resources/group_member.md) resource.
 * `groups` - Set of [group](../resources/group.md) identifiers, that can be modified with [databricks_group_member](../resources/group_member.md) resource.
 * `instance_profiles` - Set of [instance profile](../resources/instance_profile.md) ARNs, that can be modified by [databricks_group_instance_profile](../resources/group_instance_profile.md) resource.
 * `allow_cluster_create` - True if group members can create [clusters](../resources/cluster.md)

--- a/scim/acceptance/data_group_test.go
+++ b/scim/acceptance/data_group_test.go
@@ -1,0 +1,86 @@
+package acceptance
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/databrickslabs/terraform-provider-databricks/common"
+	"github.com/databrickslabs/terraform-provider-databricks/internal/acceptance"
+	"github.com/databrickslabs/terraform-provider-databricks/qa"
+	"github.com/databrickslabs/terraform-provider-databricks/scim"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createUuid() string {
+	b := make([]byte, 16)
+	_, err := rand.Read(b)
+	if err != nil {
+		return "10000000-2000-3000-4000-500000000000"
+	}
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
+}
+
+func TestAccGroupDataSplitMembers(t *testing.T) {
+	if cloudEnv, ok := os.LookupEnv("CLOUD_ENV"); !ok && cloudEnv != "azure" {
+		t.Skip("This test will only run on Azure. For simplicity.")
+	}
+
+	ctx := context.Background()
+	client := common.CommonEnvironmentClient()
+
+	usersAPI := scim.NewUsersAPI(ctx, client)
+	groupsAPI := scim.NewGroupsAPI(ctx, client)
+	spAPI := scim.NewServicePrincipalsAPI(ctx, client)
+
+	user, err := usersAPI.Create(scim.User{
+		UserName: fmt.Sprintf("%s@example.com", qa.RandomName("tfuser-")),
+	})
+	assert.NoError(t, err)
+	defer usersAPI.Delete(user.ID)
+
+	sp, err := spAPI.Create(scim.User{
+		ApplicationID: createUuid(),
+		DisplayName:   qa.RandomName("spn-"),
+	})
+	assert.NoError(t, err)
+	defer spAPI.Delete(sp.ID)
+
+	childGroup, err := groupsAPI.Create(scim.Group{
+		DisplayName: qa.RandomName("child-"),
+	})
+	assert.NoError(t, err)
+	defer groupsAPI.Delete(childGroup.ID)
+
+	parentGroup, err := groupsAPI.Create(scim.Group{
+		DisplayName: qa.RandomName("parent-"),
+		Members: []scim.ComplexValue{
+			{Value: user.ID},
+			{Value: sp.ID},
+			{Value: childGroup.ID},
+		},
+	})
+	assert.NoError(t, err)
+	defer groupsAPI.Delete(parentGroup.ID)
+
+	acceptance.Test(t, []acceptance.Step{
+		{
+			Template: `data "databricks_group" "this" {
+				display_name = "` + parentGroup.DisplayName + `"
+			}`,
+			Check: func(s *terraform.State) error {
+				r, ok := s.Modules[0].Resources["data.databricks_group.this"]
+				require.True(t, ok, "data.databricks_group.this has to be there")
+				attr := r.Primary.Attributes
+				assert.Equal(t, user.ID, attr["users.0"])
+				assert.Equal(t, sp.ID, attr["service_principals.0"])
+				assert.Equal(t, childGroup.ID, attr["child_groups.0"])
+				return nil
+			},
+		},
+	})
+}

--- a/scim/acceptance/resource_user_test.go
+++ b/scim/acceptance/resource_user_test.go
@@ -20,12 +20,12 @@ func TestAccForceUserImport(t *testing.T) {
 		t.Skip("Acceptance tests skipped unless env 'CLOUD_ENV' is set")
 	}
 	username := qa.RandomEmail()
-	os.Setenv("TEST_USERNAME", username) 
+	os.Setenv("TEST_USERNAME", username)
 	ctx := context.Background()
 	client := common.CommonEnvironmentClient()
 	usersAPI := scim.NewUsersAPI(ctx, client)
 	user, err := usersAPI.Create(scim.User{
-		UserName: username,
+		UserName:   username,
 		ExternalID: qa.RandomName("ext-id"),
 	})
 	assert.NoError(t, err)

--- a/scim/data_group_test.go
+++ b/scim/data_group_test.go
@@ -36,7 +36,16 @@ func TestDataSourceGroup(t *testing.T) {
 							},
 							Members: []ComplexValue{
 								{
+									Ref:   "Users/1112",
 									Value: "1112",
+								},
+								{
+									Ref:   "ServicePrincipals/1113",
+									Value: "1113",
+								},
+								{
+									Ref:   "Groups/1114",
+									Value: "1114",
 								},
 							},
 							Groups: []ComplexValue{
@@ -89,4 +98,8 @@ func TestDataSourceGroup(t *testing.T) {
 	assertContains(t, d.Get("groups"), "abc")
 	assert.Equal(t, true, d.Get("allow_instance_pool_create"))
 	assert.Equal(t, true, d.Get("allow_cluster_create"))
+
+	assertContains(t, d.Get("users"), "1112")
+	assertContains(t, d.Get("service_principals"), "1113")
+	assertContains(t, d.Get("child_groups"), "1114")
 }


### PR DESCRIPTION
* Added `users`, `service_principals`, and `child_groups` exported properties to `databricks_group` data resource ([#1085](https://github.com/databrickslabs/terraform-provider-databricks/issues/1085)).

Fixes #1085