### PR TITLE
Release v0.4.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.8"
+      version = "0.4.9"
     }
   }
 }

--- a/common/version.go
+++ b/common/version.go
@@ -3,7 +3,7 @@ package common
 import "context"
 
 var (
-	version = "0.4.8"
+	version = "0.4.9"
 	// ResourceName is resource name without databricks_ prefix
 	ResourceName contextKey = 1
 	// Provider is the current instance of provider

--- a/docs/guides/aws-workspace.md
+++ b/docs/guides/aws-workspace.md
@@ -54,7 +54,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.8"
+      version = "0.4.9"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/docs/guides/unity-catalog.md
+++ b/docs/guides/unity-catalog.md
@@ -38,7 +38,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.8"
+      version = "0.4.9"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/docs/guides/workspace-management.md
+++ b/docs/guides/workspace-management.md
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.8"
+      version = "0.4.9"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -338,7 +338,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.8"
+      version = "0.4.9"
     }
   }
 }

--- a/scim/acceptance/data_group_test.go
+++ b/scim/acceptance/data_group_test.go
@@ -26,7 +26,7 @@ func createUuid() string {
 }
 
 func TestAccGroupDataSplitMembers(t *testing.T) {
-	if cloudEnv, ok := os.LookupEnv("CLOUD_ENV"); !ok && cloudEnv != "azure" {
+	if cloudEnv, ok := os.LookupEnv("CLOUD_ENV"); !ok || cloudEnv != "azure" {
 		t.Skip("This test will only run on Azure. For simplicity.")
 	}
 

--- a/scripts/gcp-integration/main.tf
+++ b/scripts/gcp-integration/main.tf
@@ -77,7 +77,7 @@ output "databricks_host" {
   value = databricks_mws_workspaces.this.workspace_url
 }
 
-output "databricks_token" {
+output "token" {
   value     = databricks_mws_workspaces.this.token[0].token_value
   sensitive = true
 }


### PR DESCRIPTION
# Version changelog

## 0.4.9

* Prevent creation of `databricks_group` with `users` and `admins` reserved names ([#1089](https://github.com/databrickslabs/terraform-provider-databricks/issues/1089)).
* Added support for shared clusters in multi-task `databricks_job` ([#1082](https://github.com/databrickslabs/terraform-provider-databricks/issues/1082)).
* Added diff suppression for `external_id` in `databricks_group` ([#1099](https://github.com/databrickslabs/terraform-provider-databricks/issues/1099)).
* Added diff suppression for `external_id` in `databricks_user` ([#1097](https://github.com/databrickslabs/terraform-provider-databricks/issues/1097)).
* Added `users`, `service_principals`, and `child_groups` exported properties to `databricks_group` data resource ([#1085](https://github.com/databrickslabs/terraform-provider-databricks/issues/1085)).
* Added various documentation improvements.

Test run: Azure
---

 * [x] access.TestAccIPACL (6.63s)
 * [x] access/acceptance.TestAccTableACL (672.30s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateClusterWithLibraries (308.58s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateSingleNodeCluster (44.06s)
 * [x] clusters/acceptance.TestAccListClustersIntegration (132.89s)
 * [x] commands/acceptance.TestAccContext (28.60s)
 * [x] jobs/acceptance.TestAccJobResource (3.79s)
 * [x] libraries/acceptance.TestAccLibraryCreate (44.60s)
 * [x] mlflow/acceptance.TestAccMLflowExperiment (5.97s)
 * [x] mlflow/acceptance.TestAccMLflowModel (3.25s)
 * [x] permissions.TestAccessControlChangeString (0.00s)
 * [x] permissions.TestAccessControlString (0.00s)
 * [x] permissions.TestAccessControlToAccessControlChange (0.00s)
 * [x] permissions/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (9.75s)
 * [x] permissions/acceptance.TestAccDatabricksReposPermissionsResourceFullLifecycle (11.26s)
 * [x] permissions/acceptance.TestAccPermissionsClusterPolicy (4.47s)
 * [x] permissions/acceptance.TestAccPermissionsClusters (43.23s)
 * [x] permissions/acceptance.TestAccPermissionsInstancePool (3.65s)
 * [x] permissions/acceptance.TestAccPermissionsJobs (4.32s)
 * [x] permissions/acceptance.TestAccPermissionsNotebooks (3.75s)
 * [x] permissions/acceptance.TestAccPermissionsTokens (2.82s)
 * [x] policies/acceptance.TestAccClusterPolicyResourceFullLifecycle (5.28s)
 * [x] pools.TestAccInstancePools (0.90s)
 * [x] scim.TestAccCreateUser (1.72s)
 * [x] scim.TestAccFilterGroup (0.26s)
 * [x] scim.TestAccGroup (3.94s)
 * [x] scim.TestAccReadUser (0.49s)
 * [x] scim.TestAccServicePrincipalOnAzure (1.70s)
 * [x] scim/acceptance.TestAccForceUserImport (7.23s)
 * [x] scim/acceptance.TestAccGroupDataSplitMembers (6.87s)
 * [x] scim/acceptance.TestAccGroupMemberResource (7.99s)
 * [x] scim/acceptance.TestAccGroupResource (6.33s)
 * [x] scim/acceptance.TestAccGroupResource_verify_entitlements (7.85s)
 * [x] scim/acceptance.TestAccGroupsExternalIdAndScimProvisioning (7.40s)
 * [x] scim/acceptance.TestAccServicePrincipalResourceOnAzure (5.73s)
 * [x] scim/acceptance.TestAccUserResource (8.49s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipals (0.82s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipalsGroup (0.81s)
 * [x] secrets/acceptance.TestAccSecretAclResource (6.43s)
 * [x] secrets/acceptance.TestAccSecretAclResourceDefaultPrincipal (6.39s)
 * [x] secrets/acceptance.TestAccSecretResource (11.71s)
 * [x] secrets/acceptance.TestAccSecretScopeResource (7.74s)
 * [x] storage.TestAccCreateFile (1.87s)
 * [x] storage/acceptance.TestAccAzureBlobMountGeneric (140.38s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (5.13s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (2.66s)
 * [x] storage/acceptance.TestAccInvalidSecretScopeFails (5.08s)
 * [x] storage/acceptance.TestAccSourceOnInvalidMountFails (36.30s)
 * [x] tokens.TestAccCreateToken (0.48s)
 * [x] tokens.TestAccCreateToken_NoExpiration (0.50s)
 * [x] tokens/acceptance.TestAccTokenResource (4.75s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (3.25s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (5.20s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (2.83s)

Test run: AWS
---
 * [x] TestAccGroupDataSplitMembers (20.51s)
 * [x] access.TestAccIPACL (5.31s)
 * [x] access/acceptance.TestAccTableACL (640.05s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateClusterWithLibraries (504.38s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateSingleNodeCluster (52.57s)
 * [x] clusters/acceptance.TestAccListClustersIntegration (126.75s)
 * [x] commands/acceptance.TestAccContext (14.14s)
 * [x] jobs/acceptance.TestAccJobResource (4.07s)
 * [x] libraries/acceptance.TestAccLibraryCreate (92.28s)
 * [x] mlflow/acceptance.TestAccMLflowExperiment (5.88s)
 * [x] mlflow/acceptance.TestAccMLflowModel (2.39s)
 * [x] permissions.TestAccessControlChangeString (0.00s)
 * [x] permissions.TestAccessControlString (0.00s)
 * [x] permissions.TestAccessControlToAccessControlChange (0.00s)
 * [x] permissions/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (39.64s)
 * [x] permissions/acceptance.TestAccDatabricksReposPermissionsResourceFullLifecycle (32.67s)
 * [x] permissions/acceptance.TestAccPermissionsClusterPolicy (14.68s)
 * [x] permissions/acceptance.TestAccPermissionsClusters (98.76s)
 * [x] permissions/acceptance.TestAccPermissionsInstancePool (14.34s)
 * [x] permissions/acceptance.TestAccPermissionsJobs (14.65s)
 * [x] permissions/acceptance.TestAccPermissionsNotebooks (15.44s)
 * [x] permissions/acceptance.TestAccPermissionsTokens (13.10s)
 * [x] policies/acceptance.TestAccClusterPolicyResourceFullLifecycle (4.36s)
 * [x] pools.TestAccInstancePools (2.15s)
 * [x] scim.TestAccCreateUser (8.02s)
 * [x] scim.TestAccFilterGroup (1.45s)
 * [x] scim.TestAccGroup (21.01s)
 * [x] scim.TestAccReadUser (1.81s)
 * [x] scim/acceptance.TestAccForceUserImport (12.81s)
 * [x] scim/acceptance.TestAccGroupMemberResource (23.69s)
 * [x] scim/acceptance.TestAccGroupResource (12.22s)
 * [x] scim/acceptance.TestAccGroupResource_verify_entitlements (11.85s)
 * [x] scim/acceptance.TestAccGroupsExternalIdAndScimProvisioning (17.31s)
 * [x] scim/acceptance.TestAccServicePrincipalResourceOnAws (8.46s)
 * [x] scim/acceptance.TestAccUserResource (10.71s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipals (1.89s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipalsGroup (0.99s)
 * [x] secrets/acceptance.TestAccSecretAclResource (11.43s)
 * [x] secrets/acceptance.TestAccSecretAclResourceDefaultPrincipal (4.49s)
 * [x] secrets/acceptance.TestAccSecretResource (7.32s)
 * [x] secrets/acceptance.TestAccSecretScopeResource (7.34s)
 * [x] storage.TestAccCreateFile (5.44s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (4.64s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (2.48s)
 * [x] storage/acceptance.TestAccInvalidSecretScopeFails (3.26s)
 * [x] storage/acceptance.TestAccSourceOnInvalidMountFails (32.07s)
 * [x] tokens.TestAccCreateToken (0.46s)
 * [x] tokens.TestAccCreateToken_NoExpiration (0.31s)
 * [x] tokens/acceptance.TestAccTokenResource (3.84s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (4.26s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (4.16s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (2.27s)

gcp
---
 * [x] access.TestAccIPACL (1.43s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateClusterWithLibraries (426.15s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateSingleNodeCluster (100.50s)
 * [x] clusters/acceptance.TestAccListClustersIntegration (369.85s)
 * [x] commands/acceptance.TestAccContext (214.52s)
 * [x] jobs/acceptance.TestAccJobResource (16.64s)
 * [x] libraries/acceptance.TestAccLibraryCreate (370.34s)
 * [x] mlflow/acceptance.TestAccMLflowExperiment (18.47s)
 * [x] mlflow/acceptance.TestAccMLflowModel (5.63s)
 * [x] permissions.TestAccessControlChangeString (0.00s)
 * [x] permissions.TestAccessControlString (0.00s)
 * [x] permissions.TestAccessControlToAccessControlChange (0.00s)
 * [x] permissions/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (18.16s)
 * [x] permissions/acceptance.TestAccDatabricksReposPermissionsResourceFullLifecycle (13.83s)
 * [x] permissions/acceptance.TestAccPermissionsClusterPolicy (5.53s)
 * [x] permissions/acceptance.TestAccPermissionsClusters (334.70s)
 * [x] permissions/acceptance.TestAccPermissionsInstancePool (5.49s)
 * [x] permissions/acceptance.TestAccPermissionsJobs (5.90s)
 * [x] permissions/acceptance.TestAccPermissionsNotebooks (6.29s)
 * [x] permissions/acceptance.TestAccPermissionsTokens (5.06s)
 * [x] policies/acceptance.TestAccClusterPolicyResourceFullLifecycle (15.75s)
 * [x] scim.TestAccCreateUser (2.72s)
 * [x] scim.TestAccFilterGroup (0.81s)
 * [x] scim.TestAccGroup (6.26s)
 * [x] scim.TestAccReadUser (0.90s)
 * [x] scim/acceptance.TestAccForceUserImport (6.69s)
 * [x] scim/acceptance.TestAccGroupMemberResource (9.36s)
 * [x] scim/acceptance.TestAccGroupResource (6.11s)
 * [x] scim/acceptance.TestAccGroupResource_verify_entitlements (6.38s)
 * [x] scim/acceptance.TestAccGroupsExternalIdAndScimProvisioning (7.93s)
 * [x] scim/acceptance.TestAccUserResource (6.60s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipals (0.96s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipalsGroup (0.70s)
 * [x] secrets/acceptance.TestAccSecretAclResource (10.95s)
 * [x] secrets/acceptance.TestAccSecretAclResourceDefaultPrincipal (4.51s)
 * [x] secrets/acceptance.TestAccSecretResource (7.49s)
 * [x] secrets/acceptance.TestAccSecretScopeResource (6.77s)
 * [x] storage.TestAccCreateFile (3.84s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (7.86s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (3.85s)
 * [x] storage/acceptance.TestAccInvalidSecretScopeFails (4.40s)
 * [x] storage/acceptance.TestAccSourceOnInvalidMountFails (205.22s)
 * [x] tokens.TestAccCreateToken (1.44s)
 * [x] tokens.TestAccCreateToken_NoExpiration (1.15s)
 * [x] tokens/acceptance.TestAccTokenResource (7.26s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (9.26s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (6.87s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (3.57s)
