### PR TITLE
Add attribute workspace_url for current_user data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version changelog
 
+## 0.5.0
+
+* Added `workspace_url` attribute to the `databricks_current_user` data source ([#1107](https://github.com/databrickslabs/terraform-provider-databricks/pull/1107))
+
 ## 0.4.9
 
 * Prevent creation of `databricks_group` with `users` and `admins` reserved names ([#1089](https://github.com/databrickslabs/terraform-provider-databricks/issues/1089)).

--- a/common/http.go
+++ b/common/http.go
@@ -482,7 +482,7 @@ func (c *DatabricksClient) genericQuery(ctx context.Context, method, requestURL 
 		}
 	}
 	headers := c.createDebugHeaders(request.Header, c.Host)
-	log.Printf("[DEBUG] %s %s %s%v", method, escapeNewLines(request.URL.Path), 
+	log.Printf("[DEBUG] %s %s %s%v", method, escapeNewLines(request.URL.Path),
 		headers, c.redactedDump(requestBody)) // lgtm [go/log-injection]
 
 	r, err := retryablehttp.FromRequest(request)

--- a/docs/data-sources/current_user.md
+++ b/docs/data-sources/current_user.md
@@ -61,6 +61,7 @@ Data source exposes the following attributes:
 * `home` - Home folder of the [user](../resources/user.md), e.g. `/Users/mr.foo@example.com`.
 * `repos` - Personal Repos location of the [user](../resources/user.md), e.g. `/Repos/mr.foo@example.com`.
 * `alphanumeric` - Alphanumeric representation of user local name. e.g. `mr_foo`.
+* `workspace_url` - URL of the current Databricks workspace.
 
 
 ## Related Resources

--- a/docs/resources/mlflow_webhook.md
+++ b/docs/resources/mlflow_webhook.md
@@ -10,13 +10,6 @@ This resource allows you to create [MLflow Model Registry Webhooks](https://docs
 ### Triggering Databricks job
 
 ```hcl
-variable "dbhost" {
-  description = "URL of Databricks workspace"
-}
-variable "dbtoken" {
-  description = "Token to access Databricks workspace"
-}
-
 data "databricks_current_user" "me" {}
 data "databricks_spark_version" "latest" {}
 data "databricks_node_type" "smallest" {
@@ -50,14 +43,19 @@ resource "databricks_job" "this" {
   }
 }
 
+resource "databricks_token" "pat_for_webhook" {
+  comment          = "MLflow Webhook"
+  lifetime_seconds = 86400000
+}
+
 resource "databricks_mlflow_webhook" "job" {
   events      = ["TRANSITION_REQUEST_CREATED"]
   description = "Databricks Job webhook trigger"
   status      = "ACTIVE"
   job_spec {
     job_id        = databricks_job.this.id
-    workspace_url = var.dbhost
-    access_token  = var.dbtoken
+    workspace_url = data.databricks_current_user.me.workspace_url
+    access_token  = databricks_token.pat_for_webhook.token_value
   }
 }
 ```

--- a/scim/data_current_user.go
+++ b/scim/data_current_user.go
@@ -36,6 +36,10 @@ func DataSourceCurrentUser() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"workspace_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 		ReadContext: func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 			usersAPI := NewUsersAPI(ctx, m)
@@ -51,6 +55,7 @@ func DataSourceCurrentUser() *schema.Resource {
 			norm := nonAlphanumeric.ReplaceAllLiteralString(splits[0], "_")
 			norm = strings.ToLower(norm)
 			d.Set("alphanumeric", norm)
+			d.Set("workspace_url", usersAPI.client.Host)
 			d.SetId(me.ID)
 			return nil
 		},


### PR DESCRIPTION
it helps to work with some resources, like, `mlflow_webhook` that require URL of the workspace

this fixes #1079 