### PR TITLE
add `lgtm [go/clear-text-logging]` for request logging

### DIFF
--- a/common/http.go
+++ b/common/http.go
@@ -483,7 +483,7 @@ func (c *DatabricksClient) genericQuery(ctx context.Context, method, requestURL 
 	}
 	headers := c.createDebugHeaders(request.Header, c.Host)
 	log.Printf("[DEBUG] %s %s %s%v", method, escapeNewLines(request.URL.Path),
-		headers, c.redactedDump(requestBody)) // lgtm [go/log-injection]
+		headers, c.redactedDump(requestBody)) // lgtm [go/log-injection] lgtm [go/clear-text-logging]
 
 	r, err := retryablehttp.FromRequest(request)
 	if err != nil {


### PR DESCRIPTION
suppressing multiple alerts in one line. follow up on https://github.com/github/codeql/issues/7992#issuecomment-1040380074