### PR TITLE
ISSUE-1120 Cluster Exporter uses Policy ID as value rather than reference

### DIFF
--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -207,7 +207,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			{Path: "library.jar", Resource: "databricks_dbfs_file", Match: "dbfs_path"},
 			{Path: "library.whl", Resource: "databricks_dbfs_file", Match: "dbfs_path"},
 			{Path: "library.egg", Resource: "databricks_dbfs_file", Match: "dbfs_path"},
-                        {Path: "policy_id", Resource: "databricks_cluster_policy"},
+			{Path: "policy_id", Resource: "databricks_cluster_policy"},
 		},
 		List: func(ic *importContext) error {
 			clusters, err := clusters.NewClustersAPI(ic.Context, ic.Client).List()

--- a/exporter/importables.go
+++ b/exporter/importables.go
@@ -207,6 +207,7 @@ var resourcesMap map[string]importable = map[string]importable{
 			{Path: "library.jar", Resource: "databricks_dbfs_file", Match: "dbfs_path"},
 			{Path: "library.whl", Resource: "databricks_dbfs_file", Match: "dbfs_path"},
 			{Path: "library.egg", Resource: "databricks_dbfs_file", Match: "dbfs_path"},
+                        {Path: "policy_id", Resource: "databricks_cluster_policy"},
 		},
 		List: func(ic *importContext) error {
 			clusters, err := clusters.NewClustersAPI(ic.Context, ic.Client).List()


### PR DESCRIPTION
Add to path values in importables.go

Fixes #1120 