### PR TITLE
docs: Updated permissions documentation with a note about Token Usage requirements

### DIFF
--- a/docs/resources/permissions.md
+++ b/docs/resources/permissions.md
@@ -429,6 +429,8 @@ resource "databricks_permissions" "password_usage" {
 
 ## Token usage
 
+-> **Note** It is required to have at least 1 personal access token in the workspace before you can manage tokens permissions.
+
 Only [possible permission](https://docs.databricks.com/administration-guide/access-control/tokens.html) to assign to non-admin group is `CAN_USE`, where _admins_ `CAN_MANAGE` all tokens:
 
 ```hcl


### PR DESCRIPTION
Hi team,

This PR adds a small note in the doc to highlight that tokens permissions require to have at least 1 token in the workspace.

Closes https://github.com/databrickslabs/terraform-provider-databricks/issues/1122