### PR TITLE
Fixed a doc for SQL Endpoint + allow to disable Photon

### DIFF
--- a/docs/resources/sql_endpoint.md
+++ b/docs/resources/sql_endpoint.md
@@ -33,10 +33,10 @@ The following arguments are supported:
 * `min_num_clusters` - Minimum number of clusters available when a SQL endpoint is running. The default is `1`.
 * `max_num_clusters` - Maximum number of clusters available when a SQL endpoint is running. This field is required. If multi-cluster load balancing is not enabled, this is default to `1`.
 * `auto_stop_mins` - Time in minutes until an idle SQL endpoint terminates all clusters and stops. This field is optional. The default is 120, set to 0 to disable the auto stop.
-* `instance_profile_arn` - [databricks_instance_profile](instance_profile.md) used to access storage from the SQL endpoint. This field is optional.
 * `tags` - Databricks tags all endpoint resources with these tags.
 * `spot_instance_policy` - The spot policy to use for allocating instances to clusters: `COST_OPTIMIZED` or `RELIABILITY_OPTIMIZED`. This field is optional. Default is `COST_OPTIMIZED`.
 * `enable_photon` - Whether to enable [Photon](https://databricks.com/product/delta-engine). This field is optional and is enabled by default.
+* `enable_serverless_compute` - Whether this SQL endpoint is a Serverless endpoint. To use a Serverless SQL endpoint, you must enable Serverless SQL endpoints for the workspace.
 * `channel` block, consisting of following fields:
   * `name` - Name of the Databricks SQL release channel. Possible values are: `CHANNEL_NAME_PREVIEW` and `CHANNEL_NAME_CURRENT`. Default is `CHANNEL_NAME_CURRENT`.
  

--- a/sql/resource_sql_endpoint.go
+++ b/sql/resource_sql_endpoint.go
@@ -28,7 +28,7 @@ type SQLEndpoint struct {
 	MinNumClusters          int             `json:"min_num_clusters,omitempty" tf:"default:1"`
 	MaxNumClusters          int             `json:"max_num_clusters,omitempty" tf:"default:1"`
 	NumClusters             int             `json:"num_clusters,omitempty" tf:"default:1,suppress_diff"`
-	EnablePhoton            bool            `json:"enable_photon,omitempty" tf:"default:true"`
+	EnablePhoton            bool            `json:"enable_photon" tf:"default:true"`
 	EnableServerlessCompute bool            `json:"enable_serverless_compute,omitempty"`
 	InstanceProfileARN      string          `json:"instance_profile_arn,omitempty"`
 	State                   string          `json:"state,omitempty" tf:"computed"`
@@ -197,6 +197,8 @@ func ResourceSQLEndpoint() *schema.Resource {
 			validation.StringInSlice(ClusterSizes, false))
 		m["max_num_clusters"].ValidateDiagFunc = validation.ToDiagFunc(
 			validation.IntBetween(1, MaxNumClusters))
+		m["enable_photon"].Optional = true
+		m["enable_photon"].Required = false
 		return m
 	})
 	return common.Resource{


### PR DESCRIPTION
It was impossible to disable Photon if necessary, because it was declared as `omitempty`, so `false` value wasn't sent, and then default `true` was used instead