### PR TITLE
Update experimental-exporter.md

### DIFF
--- a/docs/guides/experimental-exporter.md
+++ b/docs/guides/experimental-exporter.md
@@ -20,7 +20,6 @@ export DATABRICKS_TOKEN=...
     -services=groups,secrets,access,compute,users,jobs,storage \
     -listing=jobs,compute \
     -last-active-days=90 \
-    -module=data_platform \
     -debug
 sh import.sh
 ```


### PR DESCRIPTION
I found that including the `-module=data_platform` caused the import.sh to fail with an error on each import.
The example without the -module option worked. See slack conversation.