### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@
 * Added exporter functionality for `databricks_ip_access_list` and `databricks_workspace_conf` ([#1125](https://github.com/databrickslabs/terraform-provider-databricks/pull/1125)).
 * Added `graviton` selector for `databricks_node_type` and `databricks_spark_version` data sources ([#1127](https://github.com/databrickslabs/terraform-provider-databricks/pull/1127)).
 * Added interactive mode to resource exporter ([#1010](https://github.com/databrickslabs/terraform-provider-databricks/pull/1010)).
+* Added preview support for `git_source` in `databricks_job` ([#1090](https://github.com/databrickslabs/terraform-provider-databricks/pull/1090)).
+* Multiple other fixes and documentation improvements.
+
+Updated dependency versions:
+
+* Bump github.com/golang-jwt/jwt/v4 from 4.2.0 to 4.3.0
+* Bump google.golang.org/api from 0.67.0 to 0.68.0
+* Bump gopkg.in/ini.v1 from 1.66.3 to 1.66.4
 
 ## 0.4.9
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.9"
+      version = "0.5.0"
     }
   }
 }

--- a/docs/guides/aws-workspace.md
+++ b/docs/guides/aws-workspace.md
@@ -54,7 +54,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.9"
+      version = "0.5.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/docs/guides/experimental-exporter.md
+++ b/docs/guides/experimental-exporter.md
@@ -25,7 +25,6 @@ export DATABRICKS_TOKEN=...
     -listing=jobs,compute \
     -last-active-days=90 \
     -debug
-sh import.sh
 ```
 
 ## Argument Reference

--- a/docs/guides/experimental-exporter.md
+++ b/docs/guides/experimental-exporter.md
@@ -20,7 +20,7 @@ Exporter can also be used in a non-interactive mode:
 ```bash
 export DATABRICKS_HOST=...
 export DATABRICKS_TOKEN=...
-./terraform-provider-databricks exporter \
+./terraform-provider-databricks exporter -skip-interactive \
     -services=groups,secrets,access,compute,users,jobs,storage \
     -listing=jobs,compute \
     -last-active-days=90 \
@@ -42,6 +42,7 @@ All arguments are optional and they tune what code is being generated.
 * `-mounts` - List DBFS mount points, which is a extremely slow operation and would not trigger unless explicitly specified.
 * `-generateProviderDeclaration` - flag that toggles generation of `databricks.tf` file with declaration of the Databricks Terraform provider that is necessary for Terraform versions since Terraform 0.13 (disabled by default).
 * `-prefix` - optional prefix that will be added to the name of all exported resources - that's useful for exporting resources multiple workspaces for merging into single one.
+* `-skip-interactive` - optionally run in a non-interactive mode.
 
 ## Services
 

--- a/docs/guides/unity-catalog.md
+++ b/docs/guides/unity-catalog.md
@@ -38,7 +38,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.9"
+      version = "0.5.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/docs/guides/workspace-management.md
+++ b/docs/guides/workspace-management.md
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.9"
+      version = "0.5.0"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -338,7 +338,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.4.9"
+      version = "0.5.0"
     }
   }
 }

--- a/exporter/command_test.go
+++ b/exporter/command_test.go
@@ -38,7 +38,6 @@ func TestInteractivePrompts(t *testing.T) {
 		},
 	}
 	ic.interactivePrompts()
-	assert.Equal(t, "a,mounts", ic.listing)
 	assert.Equal(t, "y", ic.match)
 	assert.True(t, ic.mounts)
 }


### PR DESCRIPTION
# Version changelog

## 0.5.0

* Added `workspace_url` attribute to the `databricks_current_user` data source ([#1107](https://github.com/databrickslabs/terraform-provider-databricks/pull/1107)).
* Fixed issue at `databricks_mount` where new cluster was created for S3 mount even when `cluster_id` was specified ([#1064](https://github.com/databrickslabs/terraform-provider-databricks/issues/1064)).
* Allow to disable auto-termination for Databricks SQL endpoints ([#900](https://github.com/databrickslabs/terraform-provider-databricks/pull/900)).
* Added new `gcp_attributes` to `databricks_cluster` and `databricks_instance_pool` ([#1126](https://github.com/databrickslabs/terraform-provider-databricks/pull/1126)).
* Added exporter functionality for `databricks_ip_access_list` and `databricks_workspace_conf` ([#1125](https://github.com/databrickslabs/terraform-provider-databricks/pull/1125)).
* Added `graviton` selector for `databricks_node_type` and `databricks_spark_version` data sources ([#1127](https://github.com/databrickslabs/terraform-provider-databricks/pull/1127)).
* Added interactive mode to resource exporter ([#1010](https://github.com/databrickslabs/terraform-provider-databricks/pull/1010)).
* Added preview support for `git_source` in `databricks_job` ([#1090](https://github.com/databrickslabs/terraform-provider-databricks/pull/1090)).
* Multiple other fixes and documentation improvements.

Updated dependency versions:

* Bump github.com/golang-jwt/jwt/v4 from 4.2.0 to 4.3.0
* Bump google.golang.org/api from 0.67.0 to 0.68.0
* Bump gopkg.in/ini.v1 from 1.66.3 to 1.66.4

Test run: Azure
---
 * [x] access.TestAccIPACL (4.47s)
 * [x] access/acceptance.TestAccTableACL (481.43s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateClusterWithLibraries (234.35s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateSingleNodeCluster (46.74s)
 * [x] clusters/acceptance.TestAccListClustersIntegration (110.74s)
 * [x] commands/acceptance.TestAccContext (23.31s)
 * [x] jobs/acceptance.TestAccJobResource (3.73s)
 * [x] libraries/acceptance.TestAccLibraryCreate (54.45s)
 * [x] mlflow/acceptance.TestAccMLflowExperiment (5.00s)
 * [x] mlflow/acceptance.TestAccMLflowModel (2.60s)
 * [x] permissions.TestAccessControlChangeString (0.00s)
 * [x] permissions.TestAccessControlString (0.00s)
 * [x] permissions.TestAccessControlToAccessControlChange (0.00s)
 * [x] permissions/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (10.06s)
 * [x] permissions/acceptance.TestAccDatabricksReposPermissionsResourceFullLifecycle (10.64s)
 * [x] permissions/acceptance.TestAccPermissionsClusterPolicy (3.43s)
 * [x] permissions/acceptance.TestAccPermissionsClusters (43.42s)
 * [x] permissions/acceptance.TestAccPermissionsInstancePool (3.54s)
 * [x] permissions/acceptance.TestAccPermissionsJobs (3.79s)
 * [x] permissions/acceptance.TestAccPermissionsNotebooks (3.66s)
 * [x] permissions/acceptance.TestAccPermissionsTokens (2.72s)
 * [x] policies/acceptance.TestAccClusterPolicyResourceFullLifecycle (4.49s)
 * [x] pools.TestAccInstancePools (0.93s)
 * [x] scim.TestAccCreateUser (1.94s)
 * [x] scim.TestAccFilterGroup (0.49s)
 * [x] scim.TestAccGroup (3.73s)
 * [x] scim.TestAccReadUser (0.41s)
 * [x] scim.TestAccServicePrincipalOnAzure (1.77s)
 * [x] scim/acceptance.TestAccForceUserImport (5.08s)
 * [x] scim/acceptance.TestAccGroupDataSplitMembers (6.02s)
 * [x] scim/acceptance.TestAccGroupMemberResource (5.02s)
 * [x] scim/acceptance.TestAccGroupResource (4.12s)
 * [x] scim/acceptance.TestAccGroupResource_verify_entitlements (5.31s)
 * [x] scim/acceptance.TestAccGroupsExternalIdAndScimProvisioning (5.11s)
 * [x] scim/acceptance.TestAccServicePrincipalResourceOnAzure (3.38s)
 * [x] scim/acceptance.TestAccUserResource (5.99s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipals (0.73s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipalsGroup (0.73s)
 * [x] secrets/acceptance.TestAccSecretAclResource (5.41s)
 * [x] secrets/acceptance.TestAccSecretAclResourceDefaultPrincipal (3.56s)
 * [x] secrets/acceptance.TestAccSecretResource (5.97s)
 * [x] secrets/acceptance.TestAccSecretScopeResource (7.10s)
 * [x] storage.TestAccCreateFile (1.85s)
 * [x] storage/acceptance.TestAccAzureBlobMountGeneric (138.73s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (6.76s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (3.27s)
 * [x] storage/acceptance.TestAccInvalidSecretScopeFails (4.18s)
 * [x] storage/acceptance.TestAccSourceOnInvalidMountFails (34.74s)
 * [x] tokens.TestAccCreateToken (0.55s)
 * [x] tokens.TestAccCreateToken_NoExpiration (5.38s)
 * [x] tokens/acceptance.TestAccTokenResource (3.95s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (3.34s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (4.67s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (2.50s)

Test run: AWS
---
 * [x] access.TestAccIPACL (5.31s)
 * [x] access/acceptance.TestAccTableACL (640.05s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateClusterWithLibraries (504.38s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateSingleNodeCluster (52.57s)
 * [x] clusters/acceptance.TestAccListClustersIntegration (126.75s)
 * [x] commands/acceptance.TestAccContext (14.14s)
 * [x] jobs/acceptance.TestAccJobResource (4.07s)
 * [x] libraries/acceptance.TestAccLibraryCreate (92.28s)
 * [x] mlflow/acceptance.TestAccMLflowExperiment (5.88s)
 * [x] mlflow/acceptance.TestAccMLflowModel (2.39s)
 * [x] permissions.TestAccessControlChangeString (0.00s)
 * [x] permissions.TestAccessControlString (0.00s)
 * [x] permissions.TestAccessControlToAccessControlChange (0.00s)
 * [x] permissions/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (39.64s)
 * [x] permissions/acceptance.TestAccDatabricksReposPermissionsResourceFullLifecycle (32.67s)
 * [x] permissions/acceptance.TestAccPermissionsClusterPolicy (14.68s)
 * [x] permissions/acceptance.TestAccPermissionsClusters (98.76s)
 * [x] permissions/acceptance.TestAccPermissionsInstancePool (14.34s)
 * [x] permissions/acceptance.TestAccPermissionsJobs (14.65s)
 * [x] permissions/acceptance.TestAccPermissionsNotebooks (15.44s)
 * [x] permissions/acceptance.TestAccPermissionsTokens (13.10s)
 * [x] policies/acceptance.TestAccClusterPolicyResourceFullLifecycle (4.36s)
 * [x] pools.TestAccInstancePools (2.15s)
 * [x] scim.TestAccCreateUser (8.02s)
 * [x] scim.TestAccFilterGroup (1.45s)
 * [x] scim.TestAccGroup (21.01s)
 * [x] scim.TestAccReadUser (1.81s)
 * [x] scim/acceptance.TestAccForceUserImport (12.81s)
 * [x] scim/acceptance.TestAccGroupMemberResource (23.69s)
 * [x] scim/acceptance.TestAccGroupResource (12.22s)
 * [x] scim/acceptance.TestAccGroupResource_verify_entitlements (11.85s)
 * [x] scim/acceptance.TestAccGroupsExternalIdAndScimProvisioning (17.31s)
 * [x] scim/acceptance.TestAccServicePrincipalResourceOnAws (8.46s)
 * [x] scim/acceptance.TestAccUserResource (10.71s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipals (1.89s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipalsGroup (0.99s)
 * [x] secrets/acceptance.TestAccSecretAclResource (11.43s)
 * [x] secrets/acceptance.TestAccSecretAclResourceDefaultPrincipal (4.49s)
 * [x] secrets/acceptance.TestAccSecretResource (7.32s)
 * [x] secrets/acceptance.TestAccSecretScopeResource (7.34s)
 * [x] storage.TestAccCreateFile (5.44s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (4.64s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (2.48s)
 * [x] storage/acceptance.TestAccInvalidSecretScopeFails (3.26s)
 * [x] storage/acceptance.TestAccSourceOnInvalidMountFails (32.07s)
 * [x] tokens.TestAccCreateToken (0.46s)
 * [x] tokens.TestAccCreateToken_NoExpiration (0.31s)
 * [x] tokens/acceptance.TestAccTokenResource (3.84s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (4.26s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (4.16s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (2.27s)