### PR TITLE
Release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Added an extended documentation from provisioning AWS PrivateLink workspace ([#1084](https://github.com/databrickslabs/terraform-provider-databricks/pull/1084)).
 * Added `databricks_jobs` data resource to get a map of all job names and their ids ([#1138](https://github.com/databrickslabs/terraform-provider-databricks/pull/1138)).
 
+Updated dependency versions:
+
+* Bump google.golang.org/api from 0.68.0 to 0.69.0
+
 ## 0.5.0
 
 * Added `workspace_url` attribute to the `databricks_current_user` data source ([#1107](https://github.com/databrickslabs/terraform-provider-databricks/pull/1107)).

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.5.0"
+      version = "0.5.1"
     }
   }
 }

--- a/docs/guides/aws-workspace.md
+++ b/docs/guides/aws-workspace.md
@@ -53,8 +53,7 @@ Before [managing workspace](workspace-management.md), you have to create:
 terraform {
   required_providers {
     databricks = {
-      source  = "databrickslabs/databricks"
-      version = "0.5.0"
+      source = "databrickslabs/databricks"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/docs/guides/unity-catalog.md
+++ b/docs/guides/unity-catalog.md
@@ -37,8 +37,7 @@ Initialize [provider with `mws` alias](https://www.terraform.io/language/provide
 terraform {
   required_providers {
     databricks = {
-      source  = "databrickslabs/databricks"
-      version = "0.5.0"
+      source = "databrickslabs/databricks"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/docs/guides/workspace-management.md
+++ b/docs/guides/workspace-management.md
@@ -10,8 +10,7 @@ Once you have the workspace setup on [Azure](azure-workspace.md) or [AWS](aws-wo
 terraform {
   required_providers {
     databricks = {
-      source  = "databrickslabs/databricks"
-      version = "0.5.0"
+      source = "databrickslabs/databricks"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -338,7 +338,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.5.0"
+      version = "0.5.1"
     }
   }
 }


### PR DESCRIPTION
# Version changelog

## 0.5.1

* Added an extended documentation from provisioning AWS PrivateLink workspace ([#1084](https://github.com/databrickslabs/terraform-provider-databricks/pull/1084)).
* Added `databricks_jobs` data resource to get a map of all job names and their ids ([#1138](https://github.com/databrickslabs/terraform-provider-databricks/pull/1138)).

Updated dependency versions:

* Bump google.golang.org/api from 0.68.0 to 0.69.0