### PR TITLE
Fix `databricks_metastore_assignment` config drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version changelog
 
+## 0.5.2
+
+* Fixed `databricks_metastore_assignment` configuration drift by properly deleting metastore assignment and detecting manual changes from Account console. This also means that de-assigned metastore from a workspace would mark it as remotely removed. Manual assignment of different metastore would also trigger resource updates ([#1146](https://github.com/databrickslabs/terraform-provider-databricks/issues/1146)).
+
 ## 0.5.1
 
 * Added an extended documentation from provisioning AWS PrivateLink workspace ([#1084](https://github.com/databrickslabs/terraform-provider-databricks/pull/1084)).

--- a/catalog/resource_metastore_assignment.go
+++ b/catalog/resource_metastore_assignment.go
@@ -41,7 +41,7 @@ func (a MetastoreAssignmentAPI) getAssignedMetastoreID() (string, error) {
 
 func (a MetastoreAssignmentAPI) deleteMetastoreAssignment(workspaceID, metastoreID string) error {
 	path := fmt.Sprintf("/unity-catalog/workspaces/%s/metastore", workspaceID)
-	return a.client.Patch(a.context, path, map[string]string{
+	return a.client.Delete(a.context, path, map[string]string{
 		"metastore_id": metastoreID,
 	})
 }

--- a/catalog/resource_metastore_assignment_test.go
+++ b/catalog/resource_metastore_assignment_test.go
@@ -24,6 +24,13 @@ func TestMetastoreAssignment_Create(t *testing.T) {
 					DefaultCatalogName: "hive_metastore",
 				},
 			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/unity-catalog/metastore_summary",
+				Response: MetastoreAssignment{
+					MetastoreID: "a",
+				},
+			},
 		},
 		Resource: ResourceMetastoreAssignment(),
 		Create:   true,


### PR DESCRIPTION
Fixed `databricks_metastore_assignment` configuration drift by properly deleting metastore assignment and detecting manual changes from Account console. This also means that de-assigned metastore from a workspace would mark it as remotely removed. Manual assignment of different metastore would also trigger resource updates.

Fixes #1146
Closes #1147