### PR TITLE
Fix `databricks_sql_endpoint` timeout propagation

### DIFF
--- a/sql/resource_sql_endpoint.go
+++ b/sql/resource_sql_endpoint.go
@@ -202,6 +202,9 @@ func ResourceSQLEndpoint() *schema.Resource {
 		return m
 	})
 	return common.Resource{
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			var se SQLEndpoint
 			common.DataToStructPointer(d, s, &se)


### PR DESCRIPTION
Previously, `timeout` meta-block was documented, but resulting in error. It was due to `Timeouts: &schema.ResourceTimeout` not added on resource.

Fixes #1142