### PR TITLE
Failures in `exporter` listing no longer halt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Version changelog
 
+## 0.5.3
+
+* Failures in [exporter](https://asciinema.org/a/Rv8ZFJQpfrfp6ggWddjtyXaOy) resource listing no longer halt the entire command run ([#1166](https://github.com/databrickslabs/terraform-provider-databricks/issues/1166)).
+
+Updated dependency versions:
+
+* Bump google.golang.org/api from 0.70.0 to 0.71.0
+
 ## 0.5.2
 
 * Added `databricks_catalogs`, `databricks_schemas`, and `databricks_tables` data resources ([#1155](https://github.com/databrickslabs/terraform-provider-databricks/pull/1155)).

--- a/exporter/context.go
+++ b/exporter/context.go
@@ -158,7 +158,9 @@ func (ic *importContext) Run() error {
 			continue
 		}
 		if err := ir.List(ic); err != nil {
-			return err
+			log.Printf("[ERROR] %s (%s service) listing failed: %s",
+				resourceName, ir.Service, err)
+			continue
 		}
 	}
 	if len(ic.Scope) == 0 {


### PR DESCRIPTION
Failures in [exporter](https://asciinema.org/a/Rv8ZFJQpfrfp6ggWddjtyXaOy) resource listing no longer halt the entire command run.

Fixes #1166