### PR TITLE
Remove validation for SPN resource for `application_id` on Azure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.5.3
 
 * Failures in [exporter](https://asciinema.org/a/Rv8ZFJQpfrfp6ggWddjtyXaOy) resource listing no longer halt the entire command run ([#1166](https://github.com/databrickslabs/terraform-provider-databricks/issues/1166)).
+* Removed client-side validation in `databricks_service_principal` for `application_id`, that may not always be available in the planning stage ([#1165](https://github.com/databrickslabs/terraform-provider-databricks/issues/1165)).
 
 Updated dependency versions:
 

--- a/scim/resource_service_principal.go
+++ b/scim/resource_service_principal.go
@@ -85,20 +85,16 @@ func ResourceServicePrincipal() *schema.Resource {
 			var sp entity
 			common.DiffToStructPointer(d, servicePrincipalSchema, &sp)
 			client := c.(*common.DatabricksClient)
-			if client.IsAzure() && sp.ApplicationID == "" {
-				// TODO: verify cases for non-existing resources
-				return fmt.Errorf("application_id is required for service principals in Azure Databricks")
-			}
 			if client.IsAws() && sp.DisplayName == "" {
 				return fmt.Errorf("display_name is required for service principals in Databricks on AWS")
+			}
+			if client.IsAws() && sp.ApplicationID != "" {
+				return fmt.Errorf("application_id is not allowed for service principals in Databricks on AWS")
 			}
 			return nil
 		},
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			sp := spFromData(d)
-			if c.IsAws() && sp.ApplicationID != "" {
-				return fmt.Errorf("application_id is not allowed for service principals in Databricks on AWS")
-			}
 			servicePrincipal, err := NewServicePrincipalsAPI(ctx, c).Create(sp)
 			if err != nil {
 				return err

--- a/scim/resource_service_principal_test.go
+++ b/scim/resource_service_principal_test.go
@@ -102,16 +102,6 @@ func TestResourceServicePrincipalRead_NotFound(t *testing.T) {
 	}.ApplyNoError(t)
 }
 
-func TestResourceServicePrincipalRead_Invalid_Azure(t *testing.T) {
-	qa.ResourceFixture{
-		Resource: ResourceServicePrincipal(),
-		New:      true,
-		Read:     true,
-		Azure:    true,
-		ID:       "abc",
-	}.ExpectError(t, "application_id is required for service principals in Azure Databricks")
-}
-
 func TestResourceServicePrincipalRead_Invalid_AWS(t *testing.T) {
 	qa.ResourceFixture{
 		Resource: ResourceServicePrincipal(),
@@ -217,17 +207,6 @@ func TestResourceServicePrincipalCreate_Error(t *testing.T) {
 		`,
 	}.Apply(t)
 	require.Error(t, err, err)
-}
-
-func TestResourceServicePrincipalCreate_Error_AzureNoApplicationID(t *testing.T) {
-	qa.ResourceFixture{
-		Resource: ResourceServicePrincipal(),
-		Create:   true,
-		Azure:    true,
-		HCL: `
-		display_name = "abc"
-		`,
-	}.ExpectError(t, "application_id is required for service principals in Azure Databricks")
 }
 
 func TestResourceServicePrincipalUpdate(t *testing.T) {


### PR DESCRIPTION
Remove client-side validation in `databricks_service_principal` for `application_id`, that may not always be available in the planning stage.

Fixes #1165