### PR TITLE
Use correct verb for permissions on SQL Endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 * Failures in [exporter](https://asciinema.org/a/Rv8ZFJQpfrfp6ggWddjtyXaOy) resource listing no longer halt the entire command run ([#1166](https://github.com/databrickslabs/terraform-provider-databricks/issues/1166)).
 * Removed client-side validation in `databricks_service_principal` for `application_id`, that may not always be available in the planning stage ([#1165](https://github.com/databrickslabs/terraform-provider-databricks/issues/1165)).
-* Use correct HTTP verb for `databricks_permissions` on `databricks_sql_endpoint`. Authorized user, assumingly part of `admins` group, is no longer sending `CAN_MANAGE` permission in the HTTP PUT request ([#1163](https://github.com/databrickslabs/terraform-provider-databricks/issues/1163)).
+* Use correct HTTP verb for modifying `databricks_permissions` on `databricks_sql_endpoint` entities. Authorized user, assumingly part of `admins` group, is no longer sending `CAN_MANAGE` permission in the HTTP PUT request ([#1163](https://github.com/databrickslabs/terraform-provider-databricks/issues/1163)).
+* Added diff suppression for `min_num_clusters` field in `databricks_sql_endpoint` ([#1172](https://github.com/databrickslabs/terraform-provider-databricks/pull/1172)).
 
 Updated dependency versions:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Failures in [exporter](https://asciinema.org/a/Rv8ZFJQpfrfp6ggWddjtyXaOy) resource listing no longer halt the entire command run ([#1166](https://github.com/databrickslabs/terraform-provider-databricks/issues/1166)).
 * Removed client-side validation in `databricks_service_principal` for `application_id`, that may not always be available in the planning stage ([#1165](https://github.com/databrickslabs/terraform-provider-databricks/issues/1165)).
+* Use correct HTTP verb for `databricks_permissions` on `databricks_sql_endpoint`. Authorized user, assumingly part of `admins` group, is no longer sending `CAN_MANAGE` permission in the HTTP PUT request ([#1163](https://github.com/databrickslabs/terraform-provider-databricks/issues/1163)).
 
 Updated dependency versions:
 

--- a/permissions/resource_permissions_test.go
+++ b/permissions/resource_permissions_test.go
@@ -506,17 +506,13 @@ func TestResourcePermissionsCreate_SQLA_Endpoint(t *testing.T) {
 		Fixtures: []qa.HTTPFixture{
 			me,
 			{
-				Method:   http.MethodPatch,
+				Method:   "PUT",
 				Resource: "/api/2.0/permissions/sql/endpoints/abc",
 				ExpectedRequest: AccessControlChangeList{
 					AccessControlList: []AccessControlChange{
 						{
 							UserName:        TestingUser,
 							PermissionLevel: "CAN_USE",
-						},
-						{
-							UserName:        TestingAdminUser,
-							PermissionLevel: "CAN_MANAGE",
 						},
 					},
 				},
@@ -531,10 +527,6 @@ func TestResourcePermissionsCreate_SQLA_Endpoint(t *testing.T) {
 						{
 							UserName:        TestingUser,
 							PermissionLevel: "CAN_USE",
-						},
-						{
-							UserName:        TestingAdminUser,
-							PermissionLevel: "CAN_MANAGE",
 						},
 					},
 				},

--- a/sql/resource_sql_endpoint.go
+++ b/sql/resource_sql_endpoint.go
@@ -25,7 +25,7 @@ type SQLEndpoint struct {
 	Name                    string          `json:"name"`
 	ClusterSize             string          `json:"cluster_size"`
 	AutoStopMinutes         int             `json:"auto_stop_mins" tf:"default:120"`
-	MinNumClusters          int             `json:"min_num_clusters,omitempty" tf:"default:1"`
+	MinNumClusters          int             `json:"min_num_clusters,omitempty" tf:"default:1,suppress_diff"`
 	MaxNumClusters          int             `json:"max_num_clusters,omitempty" tf:"default:1"`
 	NumClusters             int             `json:"num_clusters,omitempty" tf:"default:1,suppress_diff"`
 	EnablePhoton            bool            `json:"enable_photon" tf:"default:true"`


### PR DESCRIPTION
Use correct HTTP verb for `databricks_permissions` on `databricks_sql_endpoint`. Authorized user, assumingly part of `admins` group, is no longer sending `CAN_MANAGE` permission in the HTTP PUT request.

Fixes #1163