### PR TITLE
Treat auto-purged `databricks_cluster` as removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Removed client-side validation in `databricks_service_principal` for `application_id`, that may not always be available in the planning stage ([#1165](https://github.com/databrickslabs/terraform-provider-databricks/issues/1165)).
 * Use correct HTTP verb for modifying `databricks_permissions` on `databricks_sql_endpoint` entities. Authorized user, assumingly part of `admins` group, is no longer sending `CAN_MANAGE` permission in the HTTP PUT request ([#1163](https://github.com/databrickslabs/terraform-provider-databricks/issues/1163)).
 * Added diff suppression for `min_num_clusters` field in `databricks_sql_endpoint` ([#1172](https://github.com/databrickslabs/terraform-provider-databricks/pull/1172)).
+* Added special case for handling `Cannot access cluster that was terminated or unpinned more than 30 days ago` error in `databricks_cluster` as an indication of resource removed on the platform side ([#1177](https://github.com/databrickslabs/terraform-provider-databricks/issues/1177)).
 
 Updated dependency versions:
 

--- a/clusters/clusters_api_test.go
+++ b/clusters/clusters_api_test.go
@@ -1202,3 +1202,12 @@ func TestWrapMissingClusterError(t *testing.T) {
 		Message: "Cluster abc does not exist",
 	}, "abc"), "Cluster abc does not exist")
 }
+
+func TestExpiredClusterAssumedAsRemoved(t *testing.T) {
+	err := wrapMissingClusterError(common.APIError{
+		ErrorCode: "INVALID_STATE",
+		Message: "Cannot access cluster X that was terminated or unpinned more than Y days ago.",
+	}, "X")
+	ae, _ := err.(common.APIError)
+	assert.Equal(t, 404, ae.StatusCode)
+}


### PR DESCRIPTION
Added special case for handling `Cannot access cluster that was terminated or unpinned more than 30 days ago` error in `databricks_cluster` as an indication of resource removed on the platform side.

Fix #1177