### PR TITLE
Found broken doc links in UC docs.

### DIFF
--- a/docs/resources/catalog.md
+++ b/docs/resources/catalog.md
@@ -43,6 +43,6 @@ $ terraform import databricks_catalog.this <name>
 
 The following resources are used in the same context:
 
-* [databricks_table](../data-sources/table.md) data to list tables within Unity Catalog.
-* [databricks_schema](../data-sources/schema.md) data to list schemas within Unity Catalog.
-* [databricks_catalog](../data-sources/catalog.md) data to list catalogs within Unity Catalog.
+* [databricks_table](../data-sources/tables.md) data to list tables within Unity Catalog.
+* [databricks_schema](../data-sources/schemas.md) data to list schemas within Unity Catalog.
+* [databricks_catalog](../data-sources/catalogs.md) data to list catalogs within Unity Catalog.

--- a/docs/resources/schema.md
+++ b/docs/resources/schema.md
@@ -53,6 +53,6 @@ $ terraform import databricks_schema.this <name>
 
 The following resources are used in the same context:
 
-* [databricks_table](../data-sources/table.md) data to list tables within Unity Catalog.
-* [databricks_schema](../data-sources/schema.md) data to list schemas within Unity Catalog.
-* [databricks_catalog](../data-sources/catalog.md) data to list catalogs within Unity Catalog.
+* [databricks_table](../data-sources/tables.md) data to list tables within Unity Catalog.
+* [databricks_schema](../data-sources/schemas.md) data to list schemas within Unity Catalog.
+* [databricks_catalog](../data-sources/catalogs.md) data to list catalogs within Unity Catalog.

--- a/docs/resources/table.md
+++ b/docs/resources/table.md
@@ -102,6 +102,6 @@ $ terraform import databricks_table.this <full-name>
 
 The following resources are used in the same context:
 
-* [databricks_table](../data-sources/table.md) data to list tables within Unity Catalog.
-* [databricks_schema](../data-sources/schema.md) data to list schemas within Unity Catalog.
-* [databricks_catalog](../data-sources/catalog.md) data to list catalogs within Unity Catalog.
+* [databricks_table](../data-sources/tables.md) data to list tables within Unity Catalog.
+* [databricks_schema](../data-sources/schemas.md) data to list schemas within Unity Catalog.
+* [databricks_catalog](../data-sources/catalogs.md) data to list catalogs within Unity Catalog.


### PR DESCRIPTION
Specific pages were missing 's' in the file names.