### PR TITLE
Impement `replacePermissions` for `databricks_grant`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Added diff suppression for `min_num_clusters` field in `databricks_sql_endpoint` ([#1172](https://github.com/databrickslabs/terraform-provider-databricks/pull/1172)).
 * Added special case for handling `Cannot access cluster that was terminated or unpinned more than 30 days ago` error in `databricks_cluster` as an indication of resource removed on the platform side ([#1177](https://github.com/databrickslabs/terraform-provider-databricks/issues/1177)).
 * Fixed updating of `databricks_table` resources ([#1175](https://github.com/databrickslabs/terraform-provider-databricks/issues/1175)).
+* Fixed configuration drift in `databricks_grant` by reading existing permissions and removing them in subsequent update calls ([#1164](https://github.com/databrickslabs/terraform-provider-databricks/issues/1164)).
 
 Updated dependency versions:
 

--- a/catalog/resource_grants_test.go
+++ b/catalog/resource_grants_test.go
@@ -173,13 +173,34 @@ func TestGrantCreate(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
+				Method:   "GET",
+				Resource: "/api/2.0/unity-catalog/permissions/table/foo.bar.baz",
+				Response: PermissionsList{
+					Assignments: []PrivilegeAssignment{
+						{
+							Principal:  "me",
+							Privileges: []string{"SELECT"},
+						},
+						{
+							Principal:  "someone-else",
+							Privileges: []string{"MODIFY", "SELECT"},
+						},
+					},
+				},
+			},
+			{
 				Method:   "PATCH",
 				Resource: "/api/2.0/unity-catalog/permissions/table/foo.bar.baz",
 				ExpectedRequest: PermissionsDiff{
 					Changes: []PermissionsChange{
 						{
 							Principal: "me",
-							Add:       []string{"MODIFY", "SELECT"},
+							Add:       []string{"MODIFY"},
+							Remove:    []string{"SELECT"},
+						},
+						{
+							Principal: "someone-else",
+							Remove:    []string{"MODIFY", "SELECT"},
 						},
 					},
 				},
@@ -187,12 +208,11 @@ func TestGrantCreate(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/unity-catalog/permissions/table/foo.bar.baz",
-
 				Response: PermissionsList{
 					Assignments: []PrivilegeAssignment{
 						{
 							Principal:  "me",
-							Privileges: []string{"MODIFY", "SELECT"},
+							Privileges: []string{"MODIFY"},
 						},
 					},
 				},
@@ -205,15 +225,21 @@ func TestGrantCreate(t *testing.T) {
 
 		grant {
 			principal = "me"
-			privileges = ["MODIFY", "SELECT"]
-		}
-		`,
+			privileges = ["MODIFY"]
+		}`,
 	}.ApplyNoError(t)
 }
 
 func TestGrantUpdate(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/unity-catalog/permissions/table/foo.bar.baz",
+				Response: PermissionsList{
+					Assignments: []PrivilegeAssignment{},
+				},
+			},
 			{
 				Method:   "PATCH",
 				Resource: "/api/2.0/unity-catalog/permissions/table/foo.bar.baz",
@@ -229,7 +255,6 @@ func TestGrantUpdate(t *testing.T) {
 			{
 				Method:   "GET",
 				Resource: "/api/2.0/unity-catalog/permissions/table/foo.bar.baz",
-
 				Response: PermissionsList{
 					Assignments: []PrivilegeAssignment{
 						{


### PR DESCRIPTION
Read existing permissions from platform before updating them, further improving drift detection. Existing permissions are merged onto diffs as removals.

Fix #1164