### PR TITLE
Removed custom client-side validation in `databricks_service_principal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version changelog
 
+## 0.5.4
+
+* Completely removed custom client-side validation in `databricks_service_principal` ([#1193](https://github.com/databrickslabs/terraform-provider-databricks/issues/1193)).
+
 ## 0.5.3
 
 * Failures in [exporter](https://asciinema.org/a/Rv8ZFJQpfrfp6ggWddjtyXaOy) resource listing no longer halt the entire command run ([#1166](https://github.com/databrickslabs/terraform-provider-databricks/issues/1166)).

--- a/scim/resource_service_principal.go
+++ b/scim/resource_service_principal.go
@@ -81,18 +81,6 @@ func ResourceServicePrincipal() *schema.Resource {
 	}
 	return common.Resource{
 		Schema: servicePrincipalSchema,
-		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, c interface{}) error {
-			var sp entity
-			common.DiffToStructPointer(d, servicePrincipalSchema, &sp)
-			client := c.(*common.DatabricksClient)
-			if client.IsAws() && sp.DisplayName == "" {
-				return fmt.Errorf("display_name is required for service principals in Databricks on AWS")
-			}
-			if client.IsAws() && sp.ApplicationID != "" {
-				return fmt.Errorf("application_id is not allowed for service principals in Databricks on AWS")
-			}
-			return nil
-		},
 		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			sp := spFromData(d)
 			servicePrincipal, err := NewServicePrincipalsAPI(ctx, c).Create(sp)

--- a/scim/resource_service_principal_test.go
+++ b/scim/resource_service_principal_test.go
@@ -102,15 +102,6 @@ func TestResourceServicePrincipalRead_NotFound(t *testing.T) {
 	}.ApplyNoError(t)
 }
 
-func TestResourceServicePrincipalRead_Invalid_AWS(t *testing.T) {
-	qa.ResourceFixture{
-		Resource: ResourceServicePrincipal(),
-		New:      true,
-		Read:     true,
-		ID:       "abc",
-	}.ExpectError(t, "display_name is required for service principals in Databricks on AWS")
-}
-
 func TestResourceServicePrincipalRead_Error(t *testing.T) {
 	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{


### PR DESCRIPTION
Users will receive a bit more crypting message, but things will work in a more predictable way.

Fix #1193