### PR TITLE
fix read MLFlow model with versions

### DIFF
--- a/mlflow/resource_model.go
+++ b/mlflow/resource_model.go
@@ -14,14 +14,14 @@ type Tag struct {
 
 // ModelVersion defines a MLFlow model version as returned by the API
 type ModelVersion struct {
-	Name                 string `json:"name" tf:"computed"`
-	Version              string `json:"version" tf:"computed"`
-	CreationTimestamp    int64  `json:"creation_timestamp,omitempty" tf:"computed"`
-	LastUpdatedTimestamp int64  `json:"last_updated_timestamp,omitempty" tf:"computed"`
-	UserID               string `json:"user_id,omitempty" tf:"computed"`
-	CurrentStage         string `json:"current_stage,omitempty" tf:"computed"`
-	Source               string `json:"source,omitempty" tf:"computed"`
-	Status               string `json:"status,omitempty" tf:"computed"`
+	Name                 string `json:"name"`
+	Version              string `json:"version"`
+	CreationTimestamp    int64  `json:"creation_timestamp,omitempty"`
+	LastUpdatedTimestamp int64  `json:"last_updated_timestamp,omitempty"`
+	UserID               string `json:"user_id,omitempty"`
+	CurrentStage         string `json:"current_stage,omitempty"`
+	Source               string `json:"source,omitempty"`
+	Status               string `json:"status,omitempty"`
 }
 
 // Model defines the response object from the API

--- a/mlflow/resource_model.go
+++ b/mlflow/resource_model.go
@@ -12,16 +12,27 @@ type Tag struct {
 	Value string `json:"value"`
 }
 
+type ModelVersion struct {
+	Name                 string `json:"name" tf:"computed"`
+	Version              string `json:"version" tf:"computed"`
+	CreationTimestamp    int64  `json:"creation_timestamp,omitempty" tf:"computed"`
+	LastUpdatedTimestamp int64  `json:"last_updated_timestamp,omitempty" tf:"computed"`
+	UserID               string `json:"user_id,omitempty" tf:"computed"`
+	CurrentStage         string `json:"current_stage,omitempty" tf:"computed"`
+	Source               string `json:"source,omitempty" tf:"computed"`
+	Status               string `json:"status,omitempty" tf:"computed"`
+}
+
 // Model defines the response object from the API
 type Model struct {
-	Name                 string   `json:"name" tf:"force_new"`
-	CreationTimestamp    int64    `json:"creation_timestamp,omitempty" tf:"computed"`
-	LastUpdatedTimestamp int64    `json:"last_updated_timestamp,omitempty" tf:"computed"`
-	UserID               string   `json:"user_id,omitempty" tf:"computed"`
-	LatestVersions       []string `json:"latest_versions,omitempty" tf:"computed"`
-	Description          string   `json:"description,omitempty"`
-	Tags                 []Tag    `json:"tags,omitempty"`
-	RegisteredModelID    string   `json:"id,omitempty" tf:"computed,alias:registered_model_id"`
+	Name                 string         `json:"name" tf:"force_new"`
+	CreationTimestamp    int64          `json:"creation_timestamp,omitempty" tf:"computed"`
+	LastUpdatedTimestamp int64          `json:"last_updated_timestamp,omitempty" tf:"computed"`
+	UserID               string         `json:"user_id,omitempty" tf:"computed"`
+	LatestVersions       []ModelVersion `json:"latest_versions,omitempty" tf:"computed"`
+	Description          string         `json:"description,omitempty"`
+	Tags                 []Tag          `json:"tags,omitempty"`
+	RegisteredModelID    string         `json:"id,omitempty" tf:"computed,alias:registered_model_id"`
 }
 
 // registeredModel defines response from GET API op

--- a/mlflow/resource_model.go
+++ b/mlflow/resource_model.go
@@ -12,6 +12,7 @@ type Tag struct {
 	Value string `json:"value"`
 }
 
+// ModelVersion defines a MLFlow model version as returned by the API
 type ModelVersion struct {
 	Name                 string `json:"name" tf:"computed"`
 	Version              string `json:"version" tf:"computed"`


### PR DESCRIPTION
as described in https://github.com/databrickslabs/terraform-provider-databricks/issues/1195
the terraform provider makes incorrect assumptions about MLFlow API responses for models with versions.

This PR adjusts the schema to what the databricks MLFlow registry actually responds with.

Because this provider doesn't have support for mlflow model versions I can't write tests for this schema change just yet. Adding MLFlow model version support needs some leg work because there seems to be no go sdk for it today.