### PR TITLE
Add data source for service principals

### DIFF
--- a/docs/data-sources/current_user.md
+++ b/docs/data-sources/current_user.md
@@ -56,6 +56,7 @@ output "job_url" {
 Data source exposes the following attributes:
 
 * `id` -  The id of the calling user.
+* `application_id` - Application ID of the [service principal](../resources/service_principal.md) if the currently logged-in user is a service principal, e.g. `813073e7-3b08-4c0d-8619-39bcfa4ac632`
 * `external_id` - ID of the user in an external identity provider.
 * `user_name` - Name of the [user](../resources/user.md), e.g. `mr.foo@example.com`.
 * `home` - Home folder of the [user](../resources/user.md), e.g. `/Users/mr.foo@example.com`.

--- a/docs/data-sources/service_principal.md
+++ b/docs/data-sources/service_principal.md
@@ -1,0 +1,57 @@
+---
+subcategory: "Security"
+---
+
+# databricks_service_principal Data Source
+
+-> **Note** If you have a fully automated setup with workspaces created by [databricks_mws_workspaces](../resources/mws_workspaces.md) or [azurerm_databricks_workspace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/databricks_workspace), please make sure to add [depends_on attribute](../index.md#data-resources-and-authentication-is-not-configured-errors) in order to prevent _authentication is not configured for provider_ errors.
+
+Retrieves information about [databricks_service_principal](../resources/user.md).
+
+## Example Usage
+
+Adding service principal "813073e7-3b08-4c0d-8619-39bcfa4ac632" to administrative group
+
+```hcl
+data "databricks_group" "admins" {
+  display_name = "admins"
+}
+
+data "databricks_service_principal" "spn" {
+  application_id = "813073e7-3b08-4c0d-8619-39bcfa4ac632"
+}
+
+resource "databricks_group_member" "my_member_a" {
+  group_id  = data.databricks_group.admins.id
+  member_id = data.databricks_service_principal.spn.id
+}
+```
+
+## Argument Reference
+
+Data source allows you to pick service principals by the following attributes
+
+- `application_id` - (Required) ID of the service principal. The service principal must exist before this resource can be retrieved.
+
+## Attribute Reference
+
+Data source exposes the following attributes:
+
+- `id` - The id of the service principal.
+- `external_id` - ID of the service principal in an external identity provider.
+- `display_name` - Display name of the [service principal](../resources/service_principal.md), e.g. `Foo SPN`.
+- `home` - Home folder of the [service principal](../resources/service_principal.md), e.g. `/Users/813073e7-3b08-4c0d-8619-39bcfa4ac632`.
+- `repos` - Repos location of the [service principal](../resources/service_principal.md), e.g. `/Repos/813073e7-3b08-4c0d-8619-39bcfa4ac632`.
+
+## Related Resources
+
+The following resources are used in the same context:
+
+* [End to end workspace management](../guides/passthrough-cluster-per-user.md) guide
+* [databricks_current_user](current_user.md) data to retrieve information about [databricks_user](../resources/user.md) or [databricks_service_principal](../resources/service_principal.md), that is calling Databricks REST API.
+* [databricks_group](../resources/group.md) to manage [groups in Databricks Workspace](https://docs.databricks.com/administration-guide/users-groups/groups.html) or [Account Console](https://accounts.cloud.databricks.com/) (for AWS deployments).
+* [databricks_group](group.md) data to retrieve information about [databricks_group](../resources/group.md) members, entitlements and instance profiles.
+* [databricks_group_instance_profile](../resources/group_instance_profile.md) to attach [databricks_instance_profile](../resources/instance_profile.md) (AWS) to [databricks_group](../resources/group.md).
+* [databricks_group_member](../resources/group_member.md) to attach [users](../resources/user.md) and [groups](../resources/group.md) as group members.
+* [databricks_permissions](../resources/permissions.md) to manage [access control](https://docs.databricks.com/security/access-control/index.html) in Databricks workspace.
+* [databricks_service principal](../resources/service_principal.md) to manage [service principals](../resources/service_principal.md)

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -50,6 +50,7 @@ func DatabricksProvider() *schema.Provider {
 			"databricks_notebook":                workspace.DataSourceNotebook(),
 			"databricks_notebook_paths":          workspace.DataSourceNotebookPaths(),
 			"databricks_schemas":                 catalog.DataSourceSchemas(),
+			"databricks_service_principal":       scim.DataSourceServicePrincipal(),
 			"databricks_spark_version":           clusters.DataSourceSparkVersion(),
 			"databricks_tables":                  catalog.DataSourceTables(),
 			"databricks_user":                    scim.DataSourceUser(),

--- a/scim/data_service_principal.go
+++ b/scim/data_service_principal.go
@@ -1,0 +1,52 @@
+package scim
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// DataSourceUser returns information about user specified by user name
+func DataSourceServicePrincipal() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"display_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"application_id": {
+				Type:     schema.TypeString,
+				Computed: true
+			},
+			"home": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"repos": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"external_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			}
+		},
+		ReadContext: func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+			spnAPI := NewServicePrincipalsAPI(ctx, m)
+			spn, err := spnAPI.read(d.Get("application_id").(string))
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			d.Set("display_name", spn.DisplayName)
+			d.Set("home", fmt.Sprintf("/Users/%s", spn.UserName))
+			d.Set("repos", fmt.Sprintf("/Repos/%s", spn.UserName))
+			d.Set("external_id", spn.ExternalID)
+			d.Set("application_id", spn.ApplicationID)
+			d.SetId(spn.ID)
+			return nil
+		},
+	}
+}

--- a/scim/data_service_principal_test.go
+++ b/scim/data_service_principal_test.go
@@ -1,0 +1,47 @@
+package scim
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/databrickslabs/terraform-provider-databricks/common"
+
+	"github.com/databrickslabs/terraform-provider-databricks/qa"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceServicePrincipalRead(t *testing.T) {
+	d, err := qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/preview/scim/v2/ServicePrincipals/abc",
+				Response: User{
+					ID:          "abc",
+					DisplayName: "Example Service Principal",
+					Groups: []ComplexValue{
+						{
+							Display: "admins",
+							Value:   "4567",
+						},
+						{
+							Display: "ds",
+							Value:   "9877",
+						},
+					},
+				},
+			},
+		},
+		Resource: DataSourceServicePrincipal(),
+		HCL:      `display_name = "Sylens"`,
+		New:      true,
+		Read:     true,
+		ID:       "abc",
+	}.Apply(t)
+	require.NoError(t, err, err)
+	assert.Equal(t, "abc", d.Id(), "Id should not be empty")
+	assert.Equal(t, d.Get("application_id"), d.Id(), "Id should match application Id")
+	assert.Equal(t, "Example Service Principal", d.Get("display_name"))
+}

--- a/scim/data_user.go
+++ b/scim/data_user.go
@@ -59,6 +59,10 @@ func DataSourceUser() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"application_id": {
+				Type:     schema.TypeString,
+				Computed: true
+			}
 		},
 		ReadContext: func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 			usersAPI := NewUsersAPI(ctx, m)
@@ -71,6 +75,7 @@ func DataSourceUser() *schema.Resource {
 			d.Set("home", fmt.Sprintf("/Users/%s", user.UserName))
 			d.Set("repos", fmt.Sprintf("/Repos/%s", user.UserName))
 			d.Set("external_id", user.ExternalID)
+			d.Set("application_id", user.ApplicationID)
 			splits := strings.Split(user.UserName, "@")
 			norm := nonAlphanumeric.ReplaceAllLiteralString(splits[0], "_")
 			norm = strings.ToLower(norm)


### PR DESCRIPTION
- return `application_id` from `databricks_current_user` if that user is a Service Principal
- add `databricks_service_principal` data source (maybe could enhance later with a display name lookup, but for now, you need the application id)
- add tests for data source
- update documentation

Hopefully this isn't too shabby... first time writing anything in Go.