### PR TITLE
Add `GoogleCredentials` config that takes JSON key

### DIFF
--- a/common/client.go
+++ b/common/client.go
@@ -53,6 +53,7 @@ type DatabricksClient struct {
 	ConfigFile string `name:"config_file" env:"DATABRICKS_CONFIG_FILE"`
 
 	GoogleServiceAccount string `name:"google_service_account" env:"DATABRICKS_GOOGLE_SERVICE_ACCOUNT" auth:"google"`
+	GoogleCredentials    string `name:"google_credentials" env:"GOOGLE_CREDENTIALS" auth:"google,sensitive"`
 
 	AzureResourceID    string `name:"azure_workspace_resource_id" env:"DATABRICKS_AZURE_RESOURCE_ID" auth:"azure"`
 	AzureUseMSI        bool   `name:"azure_use_msi" env:"ARM_USE_MSI" auth:"azure"`
@@ -246,6 +247,7 @@ func (c *DatabricksClient) Authenticate(ctx context.Context) error {
 		{c.configureWithAzureClientSecret, "azure-client-secret"},
 		{c.configureWithAzureManagedIdentity, "azure-msi"},
 		{c.configureWithAzureCLI, "azure-cli"},
+		{c.configureWithGoogleCrendentials, "google-creds"},
 		{c.configureWithGoogleForAccountsAPI, "google-accounts"},
 		{c.configureWithGoogleForWorkspace, "google-workspace"},
 		{c.configureWithDatabricksCfg, "databricks-cli"},
@@ -262,6 +264,7 @@ func (c *DatabricksClient) Authenticate(ctx context.Context) error {
 			return c.niceAuthError(fmt.Sprintf("cannot configure %s auth: %s", auth.name, err))
 		}
 		if authorizer == nil {
+			// try the next method.
 			continue
 		}
 		// even though this may complain about clear text logging, passwords are replaced with `***`
@@ -493,6 +496,7 @@ func (c *DatabricksClient) ClientForHost(ctx context.Context, url string) (*Data
 		Password:             c.Password,
 		Token:                c.Token,
 		GoogleServiceAccount: c.GoogleServiceAccount,
+		GoogleCredentials:    c.GoogleCredentials,
 		AzurermEnvironment:   c.AzurermEnvironment,
 		InsecureSkipVerify:   c.InsecureSkipVerify,
 		HTTPTimeoutSeconds:   c.HTTPTimeoutSeconds,

--- a/common/client_test.go
+++ b/common/client_test.go
@@ -154,7 +154,7 @@ func TestDatabricksClient_FormatURL(t *testing.T) {
 
 func TestClientAttributes(t *testing.T) {
 	ca := ClientAttributes()
-	assert.Len(t, ca, 20)
+	assert.Len(t, ca, 21)
 }
 
 func TestDatabricksClient_Authenticate(t *testing.T) {

--- a/common/gcp.go
+++ b/common/gcp.go
@@ -3,11 +3,61 @@ package common
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"net/http"
+	"os"
 
 	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/idtoken"
 	"google.golang.org/api/impersonate"
+	"google.golang.org/api/option"
 )
+
+// Configures an authorizer that uses credentials sourced from JSON or file.
+// This auth mode does NOT use impersonation and it does NOT use Application
+// Default Credentials (ADC).
+func (c *DatabricksClient) configureWithGoogleCrendentials(
+	ctx context.Context) (func(r *http.Request) error, error) {
+	if c.GoogleCredentials == "" || !c.IsGcp() || c.Host == "" {
+		return nil, nil
+	}
+	json, err := readCredentials(c.GoogleCredentials)
+	if err != nil {
+		err = fmt.Errorf("could not read GoogleCredentials. "+
+			"Make sure the file exists, or the JSON content is valid: %w", err)
+		return nil, err
+	}
+	// Obtain token source for creating OIDC token.
+	audience := c.Host
+	oidcSource, err := idtoken.NewTokenSource(ctx, audience, option.WithCredentialsJSON([]byte(json)))
+	if err != nil {
+		return nil, fmt.Errorf("could not obtain OIDC token from JSON: %w", err)
+	}
+	// Obtain token source for creating Google Cloud Platform token.
+	creds, err := google.CredentialsFromJSON(ctx, []byte(json),
+		"https://www.googleapis.com/auth/cloud-platform",
+		"https://www.googleapis.com/auth/compute")
+	if err != nil {
+		return nil, fmt.Errorf("could not obtain OAuth2 token from JSON: %w", err)
+	}
+	return newOidcAuthorizerForAccountsAPI(oidcSource, creds.TokenSource), nil
+}
+
+// Reads credentials as JSON. Credentials can be either a path to JSON file,
+// or actual JSON string.
+func readCredentials(credentials string) (string, error) {
+	// Try to read credentials as file path.
+	if _, err := os.Stat(credentials); err == nil {
+		jsonContents, err := ioutil.ReadFile(credentials)
+		if err != nil {
+			return string(jsonContents), err
+		}
+		return string(jsonContents), nil
+	}
+	// Assume that credential is actually JSON string.
+	return credentials, nil
+}
 
 func (c *DatabricksClient) getGoogleOIDCSource(ctx context.Context) (oauth2.TokenSource, error) {
 	// source for generateIdToken

--- a/common/gcp_test.go
+++ b/common/gcp_test.go
@@ -2,7 +2,9 @@ package common
 
 import (
 	"context"
+	"io/ioutil"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,6 +12,21 @@ import (
 	"golang.org/x/oauth2"
 	"google.golang.org/api/option"
 )
+
+// Fake credentials for testing only. Private key was generated using:
+// $ openssl genrsa -out name_of_private_key.pem 512
+const fakeCredentialsJson = `{
+	"type": "service_account",
+	"project_id": "fake-project-id",
+	"private_key_id": "123456789",
+	"private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIBOwIBAAJBAO3U0tUlSLIX06qGqalP+MUScgnmB9scOZ/fZNOykU+QLufdgqDe\nA59CfpytNg/zts8BsRgSTRiLs+6jLhjK6LkCAwEAAQJBALDuGibNROaQyTvcUI2P\n2/8oOMRaZ8++kLP56jV/a5DmwIYt5t5c35/LUWR2GA/7nvQvOJ1XZ6U+uyciOKGg\nJ7ECIQD5k+N8jIMJiobULRLAJgEWQat158sWQ3G23NakdJEWlQIhAPPzjhV+iuJ9\nu4SMOP0BLGgbjWQtna75/cOC916EmLSVAiBrBY7MTti2E7ADdhyPRvy6VYi386Cz\nuFIf7w0f0liRDQIgWD/XOndYjq6lU0HWq8/s3Ix7Da5iyJWu8zdBfXPCOjECIQC1\nusZas9Gcfu4oc3g29c0aQ5IozUTnJhAPjljxj3PmZg==\n-----END RSA PRIVATE KEY-----",
+	"client_email": "fake-sa2@example.com",
+	"client_id": "987654321",
+	"auth_uri": "https://accounts.example.com/o/oauth2/auth",
+	"token_uri": "http://127.0.0.1/token",
+	"auth_provider_x509_cert_url": "http://127.0.0.1/oauth2/v1/certs",
+	"client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/my-sa2%40example.com"
+  }`
 
 func TestGoogleOIDC(t *testing.T) {
 	defer CleanupEnvironment()()
@@ -24,6 +41,70 @@ func TestGoogleOIDC(t *testing.T) {
 
 	_, err := client.getGoogleOIDCSource(context.Background())
 	require.NoError(t, err)
+}
+
+func TestConfigureWithGoogleCredentialsUsingInvalidJson(t *testing.T) {
+	defer CleanupEnvironment()()
+	client := &DatabricksClient{
+		Host:                 "https://accounts.gcp.databricks.com/",
+		GoogleServiceAccount: "my-sa2@fake-project-id.iam.gserviceaccount.com",
+		GoogleCredentials:    fakeCredentialsJson,
+	}
+	client.configureHTTPCLient()
+
+	_, err := client.configureWithGoogleCrendentials(context.Background())
+	assert.ErrorContains(t, err,
+		"could not obtain OIDC token from JSON: oauth2: cannot fetch token")
+	// TODO: To get better test coverage, start a local OAuth2 server to support
+	// exercising a full token fetching flow.
+}
+
+func TestConfigureWithGoogleCredentialsUsingInvalidCredsFile(t *testing.T) {
+	defer CleanupEnvironment()()
+
+	// Write fakeCredentialsJson to a temp file to pass to GoogleCredentials.
+	credsPath := filepath.Join(t.TempDir(), "creds.json")
+	err := ioutil.WriteFile(credsPath, []byte(fakeCredentialsJson), 0600)
+	assert.Nil(t, err, "Failed writing input JSON file.")
+
+	client := &DatabricksClient{
+		Host:                 "https://accounts.gcp.databricks.com/",
+		GoogleServiceAccount: "my-sa2@fake-project-id.iam.gserviceaccount.com",
+		GoogleCredentials:    credsPath,
+	}
+	client.configureHTTPCLient()
+
+	_, err = client.configureWithGoogleCrendentials(context.Background())
+	assert.ErrorContains(t, err,
+		"could not obtain OIDC token from JSON: oauth2: cannot fetch token")
+}
+
+func TestConfigureWithGoogleCredentialsNoCredsFile(t *testing.T) {
+	defer CleanupEnvironment()()
+	client := &DatabricksClient{
+		Host:                 "https://accounts.gcp.databricks.com/",
+		GoogleServiceAccount: "my-sa2@fake-project-id.iam.gserviceaccount.com",
+		GoogleCredentials:    "/tmp/this/path/does/not/exist/creds.json",
+	}
+	client.configureHTTPCLient()
+
+	_, err := client.configureWithGoogleCrendentials(context.Background())
+	assert.ErrorContains(t, err,
+		"could not obtain OIDC token from JSON: invalid character")
+}
+
+func TestConfigureWithGoogleCredentialsEmptyHost(t *testing.T) {
+	defer CleanupEnvironment()()
+	client := &DatabricksClient{
+		Host:                 "",
+		GoogleServiceAccount: "my-sa2@fake-project-id.iam.gserviceaccount.com",
+		GoogleCredentials:    fakeCredentialsJson,
+	}
+	client.configureHTTPCLient()
+
+	ret, err := client.configureWithGoogleCrendentials(context.Background())
+	assert.Nil(t, ret)
+	assert.Nil(t, err)
 }
 
 func TestConfigureWithGoogleForAccountsAPI(t *testing.T) {


### PR DESCRIPTION
Adding support for GoogleCredentials field in provider configuration. GoogleCredentials can take either a path to .json file, or JSON content itself. This works the same way as [`credentials`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#credentials) field in Google Terraform (Hashicorp).

It does not use impersonation flow. In this case, we only need the credentials of the service account that has permission to create Databricks workspace (i.e. SA2, not SA1).

Tested locally from a fresh environment. gcloud was not configured. It could create workspace and resources (notebook, clusters, ..) correctly.

CC: @nfx 