### PR TITLE
Fix the guide for Unity catalog on Azure to correct ADLS path

### DIFF
--- a/docs/guides/unity-catalog-azure.md
+++ b/docs/guides/unity-catalog-azure.md
@@ -139,8 +139,8 @@ A [databricks_metastore](../resources/metastore.md) is the top level container f
 resource "databricks_metastore" "this" {
   name = "primary"
   storage_root = format("abfss://%s@%s.dfs.core.windows.net/",
-    azurerm_storage_account.unity_catalog.name,
-  azurerm_storage_container.unity_catalog.name)
+    azurerm_storage_container.unity_catalog.name,
+    azurerm_storage_account.unity_catalog.name)
   force_destroy = true
 }
 


### PR DESCRIPTION
Document fix - Correct the [guide for Unity catalog on Azure](https://github.com/databrickslabs/terraform-provider-databricks/blob/master/docs/guides/unity-catalog-azure.md#create-a-unity-catalog-metastore-and-link-it-to-workspaces) to use correct abfss URI for the default ADLS container. 
Correcting to `abfss://<storage_container_name>@<storage_account_name>.dfs.core.windows.net/...`

Closes #1230 