### PR TITLE
Refactor `databricks_permissions` to common.Resource

### DIFF
--- a/access/resource_ipaccesslist_test.go
+++ b/access/resource_ipaccesslist_test.go
@@ -313,13 +313,13 @@ func TestIPACLDelete(t *testing.T) {
 }
 
 func TestIPACLDelete_Error(t *testing.T) {
-	d, err := qa.ResourceFixture{
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   http.MethodDelete,
 				Resource: "/api/2.0/ip-access-lists/" + TestingID,
 				Response: common.APIErrorBody{
-					ErrorCode: "FEATURE_DISABLE",
+					ErrorCode: "FEATURE_DISABLED",
 					Message:   "IP access list is not available in the pricing tier of this workspace",
 				},
 				Status: 404,
@@ -327,11 +327,9 @@ func TestIPACLDelete_Error(t *testing.T) {
 		},
 		Resource: ResourceIPAccessList(),
 		Delete:   true,
+		Removed:  true,
 		ID:       TestingID,
-	}.Apply(t)
-	assert.Error(t, err)
-	qa.AssertErrorStartsWith(t, err, "IP access list is not available in ")
-	assert.Equal(t, TestingID, d.Id())
+	}.ApplyNoError(t)
 }
 
 func TestListIpAccessLists(t *testing.T) {

--- a/access/resource_ipaccesslist_test.go
+++ b/access/resource_ipaccesslist_test.go
@@ -319,17 +319,17 @@ func TestIPACLDelete_Error(t *testing.T) {
 				Method:   http.MethodDelete,
 				Resource: "/api/2.0/ip-access-lists/" + TestingID,
 				Response: common.APIErrorBody{
-					ErrorCode: "FEATURE_DISABLED",
-					Message:   "IP access list is not available in the pricing tier of this workspace",
+					ErrorCode: "INVALID_STATE",
+					Message:   "Something went wrong",
 				},
-				Status: 404,
+				Status: 400,
 			},
 		},
 		Resource: ResourceIPAccessList(),
 		Delete:   true,
 		Removed:  true,
 		ID:       TestingID,
-	}.ApplyNoError(t)
+	}.ExpectError(t, "Something went wrong")
 }
 
 func TestListIpAccessLists(t *testing.T) {

--- a/permissions/resource_permissions.go
+++ b/permissions/resource_permissions.go
@@ -208,7 +208,7 @@ func (a PermissionsAPI) Read(objectID string) (objectACL ObjectACL, err error) {
 	// platform propagates INVALID_STATE error for auto-purged clusters in 
 	// the permissions api. this adds "a logical fix" also here, not to introduce
 	// cross-package dependency on "clusters".
-	if ok && strings.Contains(apiErr.Message, "Cannot access cluster") {
+	if ok && strings.Contains(apiErr.Message, "Cannot access cluster") && apiErr.StatusCode == 400 {
 		apiErr.StatusCode = 404
 		err = apiErr
 		return

--- a/permissions/resource_permissions.go
+++ b/permissions/resource_permissions.go
@@ -292,11 +292,7 @@ func (oa *ObjectACL) ToPermissionsEntity(d *schema.ResourceData, me string) (Per
 			return entity, nil
 		}
 		identifier := path.Base(oa.ObjectID)
-		err := d.Set(mapping.field, identifier)
-		if err != nil {
-			return entity, err
-		}
-		return entity, nil
+		return entity, d.Set(mapping.field, identifier)
 	}
 	return entity, fmt.Errorf("unknown object type %s", oa.ObjectType)
 }

--- a/permissions/resource_permissions.go
+++ b/permissions/resource_permissions.go
@@ -346,37 +346,7 @@ func ResourcePermissions() *schema.Resource {
 		}
 		return s
 	})
-	readContext := func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-		id := d.Id()
-		objectACL, err := NewPermissionsAPI(ctx, m).Read(id)
-		if common.IsMissing(err) {
-			log.Printf("[INFO] %s is removed on backend", d.Id())
-			d.SetId("")
-			return nil
-		}
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		me, err := scim.NewUsersAPI(ctx, m).Me()
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		entity, err := objectACL.ToPermissionsEntity(d, me.UserName)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		if len(entity.AccessControlList) == 0 {
-			// empty "modifiable" access control list is the same as resource absence
-			d.SetId("")
-			return nil
-		}
-		err = common.StructToData(entity, s, d)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		return nil
-	}
-	return &schema.Resource{
+	return common.Resource{
 		Schema: s,
 		CustomizeDiff: func(ctx context.Context, diff *schema.ResourceDiff, c interface{}) error {
 			client := c.(*common.DatabricksClient)
@@ -407,53 +377,58 @@ func ResourcePermissions() *schema.Resource {
 			}
 			return nil
 		},
-		ReadContext: readContext,
-		CreateContext: func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+		Read: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			id := d.Id()
+			objectACL, err := NewPermissionsAPI(ctx, c).Read(id)
+			if err != nil {
+				return err
+			}
+			me, err := scim.NewUsersAPI(ctx, c).Me()
+			if err != nil {
+				return err
+			}
+			entity, err := objectACL.ToPermissionsEntity(d, me.UserName)
+			if err != nil {
+				return err
+			}
+			if len(entity.AccessControlList) == 0 {
+				// empty "modifiable" access control list is the same as resource absence
+				d.SetId("")
+				return nil
+			}
+			return common.StructToData(entity, s, d)
+		},
+		Create: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			var entity PermissionsEntity
 			common.DataToStructPointer(d, s, &entity)
 			for _, mapping := range permissionsResourceIDFields() {
 				if v, ok := d.GetOk(mapping.field); ok {
-					id, err := mapping.idRetriever(ctx, m.(*common.DatabricksClient), v.(string))
+					id, err := mapping.idRetriever(ctx, c, v.(string))
 					if err != nil {
-						return diag.FromErr(err)
+						return err
 					}
 					objectID := fmt.Sprintf("/%s/%s", mapping.resourceType, id)
-					err = NewPermissionsAPI(ctx, m).Update(objectID, AccessControlChangeList{
+					err = NewPermissionsAPI(ctx, c).Update(objectID, AccessControlChangeList{
 						AccessControlList: entity.AccessControlList,
 					})
 					if err != nil {
-						return diag.FromErr(err)
+						return err
 					}
 					d.SetId(objectID)
-					return readContext(ctx, d, m)
+					return nil
 				}
 			}
-			return diag.Errorf("At least one type of resource identifiers must be set")
+			return errors.New("At least one type of resource identifiers must be set")
 		},
-		UpdateContext: func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
 			var entity PermissionsEntity
 			common.DataToStructPointer(d, s, &entity)
-			err := NewPermissionsAPI(ctx, m).Update(d.Id(), AccessControlChangeList{
+			return NewPermissionsAPI(ctx, c).Update(d.Id(), AccessControlChangeList{
 				AccessControlList: entity.AccessControlList,
 			})
-			if err != nil {
-				return diag.FromErr(err)
-			}
-			return readContext(ctx, d, m)
 		},
-		DeleteContext: func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-			err := NewPermissionsAPI(ctx, m).Delete(d.Id())
-			if common.IsMissing(err) {
-				log.Printf("[INFO] %s is already removed on backend", d.Id())
-				return nil
-			}
-			if err != nil {
-				return diag.FromErr(err)
-			}
-			return nil
+		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			return NewPermissionsAPI(ctx, c).Delete(d.Id())
 		},
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
-	}
+	}.ToResource()
 }

--- a/permissions/resource_permissions_test.go
+++ b/permissions/resource_permissions_test.go
@@ -201,8 +201,8 @@ func TestResourcePermissionsRead_some_error(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestResourcePermissionsRead_ErrorOnScimMe(t *testing.T) {
-	_, err := qa.ResourceFixture{
+func TestResourcePermissionsCustomizeDiff_ErrorOnScimMe(t *testing.T) {
+	qa.ResourceFixture{
 		Fixtures: []qa.HTTPFixture{
 			{
 				Method:   http.MethodGet,
@@ -245,8 +245,89 @@ func TestResourcePermissionsRead_ErrorOnScimMe(t *testing.T) {
 		Resource: ResourcePermissions(),
 		Read:     true,
 		ID:       "/clusters/abc",
-	}.Apply(t)
-	assert.Error(t, err)
+	}.ExpectError(t, "Internal error happened")
+}
+
+func TestResourcePermissionsRead_ErrorOnScimMe(t *testing.T) {
+	qa.HTTPFixturesApply(t, []qa.HTTPFixture{
+		{
+			Method:   http.MethodGet,
+			Resource: "/api/2.0/permissions/clusters/abc",
+			Response: ObjectACL{
+				ObjectID:   "/clusters/abc",
+				ObjectType: "clusters",
+				AccessControlList: []AccessControl{
+					{
+						UserName: TestingUser,
+						AllPermissions: []Permission{
+							{
+								PermissionLevel: "CAN_READ",
+								Inherited:       false,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Method:   http.MethodGet,
+			Resource: "/api/2.0/preview/scim/v2/Me",
+			Response: common.APIErrorBody{
+				ErrorCode: "INVALID_REQUEST",
+				Message:   "Internal error happened",
+			},
+			Status: 400,
+		},
+	}, func(ctx context.Context, client *common.DatabricksClient) {
+		r := ResourcePermissions()
+		d := r.TestResourceData()
+		d.SetId("/clusters/abc")
+		diags := r.ReadContext(ctx, d, client)
+		assert.True(t, diags.HasError())
+		assert.Equal(t, "Internal error happened", diags[0].Summary)
+	})
+}
+
+func TestResourcePermissionsRead_ToPermissionsEntity_Error(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			me,
+			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.0/permissions/clusters/abc",
+				Response: ObjectACL{
+					ObjectType: "teapot",
+				},
+			},
+		},
+		Resource: ResourcePermissions(),
+		Read:     true,
+		New:      true,
+		ID:       "/clusters/abc",
+	}.ExpectError(t, "unknown object type teapot")
+}
+
+func TestResourcePermissionsRead_EmptyListResultsInRemoval(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			me,
+			{
+				Method:   http.MethodGet,
+				Resource: "/api/2.0/permissions/clusters/abc",
+				Response: ObjectACL{
+					ObjectID:   "/clusters/abc",
+					ObjectType: "cluster",
+				},
+			},
+		},
+		Resource: ResourcePermissions(),
+		Read:     true,
+		Removed:  true,
+		InstanceState: map[string]string{
+			"cluster_id": "abc",
+		},
+		ID: "/clusters/abc",
+	}.ApplyNoError(t)
 }
 
 func TestResourcePermissionsDelete(t *testing.T) {
@@ -710,6 +791,40 @@ func TestResourcePermissionsCreate_error(t *testing.T) {
 			assert.Equal(t, "INVALID_REQUEST", e.ErrorCode)
 		}
 	}
+}
+
+func TestResourcePermissionsCreate_PathIdRetriever_Error(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			me,
+			qa.HTTPFailures[0],
+		},
+		Resource: ResourcePermissions(),
+		Create: true,
+		HCL: `notebook_path = "/foo/bar"
+
+		access_control {
+			user_name = "ben"
+			permission_level = "CAN_RUN"
+		}`,
+	}.ExpectError(t, "Cannot load path /foo/bar: I'm a teapot")
+}
+
+func TestResourcePermissionsCreate_ActualUpdate_Error(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			me,
+			qa.HTTPFailures[0],
+		},
+		Resource: ResourcePermissions(),
+		Create: true,
+		HCL: `cluster_id = "abc"
+
+		access_control {
+			user_name = "ben"
+			permission_level = "CAN_MANAGE"
+		}`,
+	}.ExpectError(t, "I'm a teapot")
 }
 
 func TestResourcePermissionsUpdate(t *testing.T) {


### PR DESCRIPTION
This guarantees panic recovery and common error messages across all resources