### PR TITLE
Release v0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Version changelog
 
+## 0.5.5
+
+* Added configuration generators for `databricks_sql_*` resources in _experimental_ [Resource Exporter](https://asciinema.org/a/Rv8ZFJQpfrfp6ggWddjtyXaOy) ([#1199](https://github.com/databrickslabs/terraform-provider-databricks/pull/1199)).
+* Added `google_credentials` provider agument that has the same semantics as [`credentials` argument](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#credentials) in official [`google` provider](https://registry.terraform.io/providers/hashicorp/google/latest/docs) ([#1214](https://github.com/databrickslabs/terraform-provider-databricks/pull/1214)).
+* Fixed `databricks_grants` on UC external location empty list error ([#1202](https://github.com/databrickslabs/terraform-provider-databricks/issues/1202)).
+* Fixed errors in `databricks_permissions` resource for auto-purged `databricks_cluster` ([#1252](https://github.com/databrickslabs/terraform-provider-databricks/commit/dac42524f5037c796187c77ba49367b964b03e9f)). 
+* Various documentation fixes ([#1231](https://github.com/databrickslabs/terraform-provider-databricks/pull/1231), [#1239](https://github.com/databrickslabs/terraform-provider-databricks/pull/1239), [#1254](https://github.com/databrickslabs/terraform-provider-databricks/pull/1254), [#1240](https://github.com/databrickslabs/terraform-provider-databricks/commit/2dabfc90592d79249bd177bb975a84e0b98504f7)).
+
+Updated dependency versions:
+
+* Bump google.golang.org/api from 0.71.0 to 0.75.0
+* Bump github.com/golang-jwt/jwt/v4 from 4.3.0 to 4.4.1
+* Bump github.com/stretchr/testify from 1.7.0 to 1.7.1
+* Bump github.com/hashicorp/go-retryablehttp from 0.7.0 to 0.7.1
+* Bump github.com/hashicorp/terraform-plugin-sdk/v2 from 2.11.0 to 2.14.0
+* Bump github.com/Azure/go-autorest/autorest from 0.11.24 to 0.11.26
+
 ## 0.5.4
 
 * Completely removed custom client-side validation in `databricks_service_principal` ([#1193](https://github.com/databrickslabs/terraform-provider-databricks/issues/1193)).

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.5.4"
+      version = "0.5.5"
     }
   }
 }

--- a/common/version.go
+++ b/common/version.go
@@ -3,7 +3,7 @@ package common
 import "context"
 
 var (
-	version = "0.5.4"
+	version = "0.5.5"
 	// ResourceName is resource name without databricks_ prefix
 	ResourceName contextKey = 1
 	// Provider is the current instance of provider

--- a/docs/index.md
+++ b/docs/index.md
@@ -338,7 +338,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.5.4"
+      version = "0.5.5"
     }
   }
 }

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -5,7 +5,7 @@ subcategory: "Compute"
 
 This resource allows you to manage [Databricks Clusters](https://docs.databricks.com/clusters/index.html).
 
--> **Note** In case of [`Cannot access cluster ####-######-####### that was terminated or unpinned more than 30 days ago`](https://github.com/databrickslabs/terraform-provider-databricks/issues/1197#issuecomment-1069386670) errors, please upgrade to v0.5.4 or later. If for some reason you cannot upgrade the version of provider, then the other viable option to unblock the apply pipeline is [`terraform state rm path.to.databricks_cluster.resource`](https://www.terraform.io/cli/commands/state/rm) command.
+-> **Note** In case of [`Cannot access cluster ####-######-####### that was terminated or unpinned more than 30 days ago`](https://github.com/databrickslabs/terraform-provider-databricks/issues/1197#issuecomment-1069386670) errors, please upgrade to v0.5.5 or later. If for some reason you cannot upgrade the version of provider, then the other viable option to unblock the apply pipeline is [`terraform state rm path.to.databricks_cluster.resource`](https://www.terraform.io/cli/commands/state/rm) command.
 
 ```hcl
 data "databricks_node_type" "smallest" {


### PR DESCRIPTION
# Version changelog

## 0.5.5

* Added configuration generators for `databricks_sql_*` resources in _experimental_ [Resource Exporter](https://asciinema.org/a/Rv8ZFJQpfrfp6ggWddjtyXaOy) ([#1199](https://github.com/databrickslabs/terraform-provider-databricks/pull/1199)).
* Added `google_credentials` provider agument that has the same semantics as [`credentials` argument](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#credentials) in official [`google` provider](https://registry.terraform.io/providers/hashicorp/google/latest/docs) ([#1214](https://github.com/databrickslabs/terraform-provider-databricks/pull/1214)).
* Fixed `databricks_grants` on UC external location empty list error ([#1202](https://github.com/databrickslabs/terraform-provider-databricks/issues/1202)).
* Fixed errors in `databricks_permissions` resource for auto-purged `databricks_cluster` ([#1252](https://github.com/databrickslabs/terraform-provider-databricks/commit/dac42524f5037c796187c77ba49367b964b03e9f)). 
* Various documentation fixes ([#1231](https://github.com/databrickslabs/terraform-provider-databricks/pull/1231), [#1239](https://github.com/databrickslabs/terraform-provider-databricks/pull/1239), [#1254](https://github.com/databrickslabs/terraform-provider-databricks/pull/1254), [#1240](https://github.com/databrickslabs/terraform-provider-databricks/commit/2dabfc90592d79249bd177bb975a84e0b98504f7)).

Updated dependency versions:

* Bump google.golang.org/api from 0.71.0 to 0.75.0
* Bump github.com/golang-jwt/jwt/v4 from 4.3.0 to 4.4.1
* Bump github.com/stretchr/testify from 1.7.0 to 1.7.1
* Bump github.com/hashicorp/go-retryablehttp from 0.7.0 to 0.7.1
* Bump github.com/hashicorp/terraform-plugin-sdk/v2 from 2.11.0 to 2.14.0
* Bump github.com/Azure/go-autorest/autorest from 0.11.24 to 0.11.26

Test run: AWS
---
 * [x] access.TestAccIPACL (2.36s)
 * [x] access/acceptance.TestAccTableACL (540.34s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateClusterWithLibraries (354.91s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateSingleNodeCluster (62.74s)
 * [x] clusters/acceptance.TestAccListClustersIntegration (70.52s)
 * [x] commands/acceptance.TestAccContext (13.93s)
 * [x] jobs/acceptance.TestAccJobResource (4.16s)
 * [x] libraries/acceptance.TestAccLibraryCreate (59.90s)
 * [x] mlflow/acceptance.TestAccMLflowExperiment (5.00s)
 * [x] mlflow/acceptance.TestAccMLflowModel (2.92s)
 * [x] permissions.TestAccessControlChangeString (0.00s)
 * [x] permissions.TestAccessControlString (0.00s)
 * [x] permissions.TestAccessControlToAccessControlChange (0.00s)
 * [x] permissions/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (34.81s)
 * [x] permissions/acceptance.TestAccDatabricksReposPermissionsResourceFullLifecycle (36.94s)
 * [x] permissions/acceptance.TestAccPermissionsClusterPolicy (13.36s)
 * [x] permissions/acceptance.TestAccPermissionsClusters (78.65s)
 * [x] permissions/acceptance.TestAccPermissionsInstancePool (14.10s)
 * [x] permissions/acceptance.TestAccPermissionsJobs (13.63s)
 * [x] permissions/acceptance.TestAccPermissionsNotebooks (16.38s)
 * [x] permissions/acceptance.TestAccPermissionsTokens (13.06s)
 * [x] policies/acceptance.TestAccClusterPolicyResourceFullLifecycle (4.75s)
 * [x] pools.TestAccInstancePools (2.25s)
 * [x] scim.TestAccCreateUser (7.66s)
 * [x] scim.TestAccFilterGroup (1.29s)
 * [x] scim.TestAccGroup (18.83s)
 * [x] scim.TestAccReadUser (1.45s)
 * [x] scim/acceptance.TestAccForceUserImport (13.27s)
 * [x] scim/acceptance.TestAccGroupMemberResource (21.15s)
 * [x] scim/acceptance.TestAccGroupResource (8.60s)
 * [x] scim/acceptance.TestAccGroupResource_verify_entitlements (12.25s)
 * [x] scim/acceptance.TestAccGroupsExternalIdAndScimProvisioning (12.91s)
 * [x] scim/acceptance.TestAccServicePrincipalResourceOnAws (7.39s)
 * [x] scim/acceptance.TestAccUserResource (9.87s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipals (1.78s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipalsGroup (0.83s)
 * [x] secrets/acceptance.TestAccSecretAclResource (11.11s)
 * [x] secrets/acceptance.TestAccSecretAclResourceDefaultPrincipal (4.64s)
 * [x] secrets/acceptance.TestAccSecretResource (3.91s)
 * [x] secrets/acceptance.TestAccSecretScopeResource (5.22s)
 * [x] storage.TestAccCreateFile (8.29s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (4.79s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (2.51s)
 * [x] storage/acceptance.TestAccInvalidSecretScopeFails (2.63s)
 * [x] storage/acceptance.TestAccSourceOnInvalidMountFails (31.80s)
 * [x] tokens.TestAccCreateToken (0.45s)
 * [x] tokens.TestAccCreateToken_NoExpiration (0.29s)
 * [x] tokens/acceptance.TestAccTokenResource (3.53s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (4.77s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (4.38s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (2.57s)


Test run: Azure
---
 * [x] access.TestAccIPACL (3.96s)
 * [x] access/acceptance.TestAccTableACL (441.57s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateClusterWithLibraries (222.36s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateSingleNodeCluster (41.87s)
 * [x] clusters/acceptance.TestAccListClustersIntegration (40.40s)
 * [x] commands/acceptance.TestAccContext (23.19s)
 * [x] jobs/acceptance.TestAccJobResource (3.23s)
 * [x] libraries/acceptance.TestAccLibraryCreate (54.56s)
 * [x] mlflow/acceptance.TestAccMLflowExperiment (4.58s)
 * [x] mlflow/acceptance.TestAccMLflowModel (2.58s)
 * [x] permissions.TestAccessControlChangeString (0.00s)
 * [x] permissions.TestAccessControlString (0.00s)
 * [x] permissions.TestAccessControlToAccessControlChange (0.00s)
 * [x] permissions/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (9.91s)
 * [x] permissions/acceptance.TestAccDatabricksReposPermissionsResourceFullLifecycle (10.65s)
 * [x] permissions/acceptance.TestAccPermissionsClusterPolicy (3.42s)
 * [x] permissions/acceptance.TestAccPermissionsClusters (57.16s)
 * [x] permissions/acceptance.TestAccPermissionsInstancePool (3.33s)
 * [x] permissions/acceptance.TestAccPermissionsJobs (4.09s)
 * [x] permissions/acceptance.TestAccPermissionsNotebooks (4.31s)
 * [x] permissions/acceptance.TestAccPermissionsTokens (3.02s)
 * [x] policies/acceptance.TestAccClusterPolicyResourceFullLifecycle (4.10s)
 * [x] pools.TestAccInstancePools (0.92s)
 * [x] scim.TestAccCreateUser (2.03s)
 * [x] scim.TestAccFilterGroup (0.32s)
 * [x] scim.TestAccGroup (4.28s)
 * [x] scim.TestAccReadUser (0.28s)
 * [x] scim.TestAccServicePrincipalOnAzure (1.91s)
 * [x] scim/acceptance.TestAccForceUserImport (4.99s)
 * [x] scim/acceptance.TestAccGroupDataSplitMembers (6.29s)
 * [x] scim/acceptance.TestAccGroupMemberResource (5.77s)
 * [x] scim/acceptance.TestAccGroupResource (4.00s)
 * [x] scim/acceptance.TestAccGroupResource_verify_entitlements (5.30s)
 * [x] scim/acceptance.TestAccGroupsExternalIdAndScimProvisioning (4.94s)
 * [x] scim/acceptance.TestAccServicePrincipalResourceOnAzure (3.63s)
 * [x] scim/acceptance.TestAccUserResource (6.38s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipals (0.85s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipalsGroup (1.18s)
 * [x] secrets/acceptance.TestAccSecretAclResource (4.96s)
 * [x] secrets/acceptance.TestAccSecretAclResourceDefaultPrincipal (4.17s)
 * [x] secrets/acceptance.TestAccSecretResource (4.52s)
 * [x] secrets/acceptance.TestAccSecretScopeResource (5.78s)
 * [x] storage.TestAccCreateFile (2.00s)
 * [x] storage/acceptance.TestAccAzureBlobMountGeneric (141.58s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (4.53s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (2.17s)
 * [x] storage/acceptance.TestAccInvalidSecretScopeFails (3.57s)
 * [x] storage/acceptance.TestAccSourceOnInvalidMountFails (35.66s)
 * [x] tokens.TestAccCreateToken (0.54s)
 * [x] tokens.TestAccCreateToken_NoExpiration (0.52s)
 * [x] tokens/acceptance.TestAccTokenResource (3.51s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (3.06s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (4.33s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (6.09s)

Test run: gcp-accounts
---

 * [x] mws.TestGcpaAccWorkspace (44.78s)

mws
---

 * [x] mws.TestMwsAccCreds (7.64s)
 * [x] mws.TestMwsAccCustomerManagedKeys (7.05s)
 * [x] mws.TestMwsAccLogDelivery (16.72s)
 * [x] mws.TestMwsAccPAS (5.25s)
 * [x] mws.TestMwsAccStorageConfigurations (3.92s)
 * [x] mws.TestMwsAccVPCEndpointIntegration (123.66s)
 * [x] mws.TestMwsAccWorkspace (1.81s)
 * [x] mws/acceptance.TestMwsAccCredentials (9.23s)
 * [x] mws/acceptance.TestMwsAccCustomerManagedKeys (11.77s)
 * [x] mws/acceptance.TestMwsAccLogDelivery (20.16s)
 * [x] mws/acceptance.TestMwsAccNetworks (7.76s)
 * [x] mws/acceptance.TestMwsAccPrivateAccessSettings (13.24s)
 * [x] mws/acceptance.TestMwsAccStorageConfigurations (7.48s)
 * [x] mws/acceptance.TestMwsAccVpcEndpoint (124.50s)
 * [x] mws/acceptance.TestMwsAccWorkspaces (120.34s)
