### PR TITLE
Update devcontainer to support ARM

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:20.04
 
 ARG TERRAFORM_VERSION=0.14.8
+ARG TARGETARCH
 
 # Configure apt, install packages and tools
 RUN \
@@ -18,7 +19,7 @@ RUN \
 # Install terraform 
 RUN \
     mkdir -p /tmp/docker-downloads \
-    && curl -sSL -o /tmp/docker-downloads/terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+    && curl -sSL -o /tmp/docker-downloads/terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${TARGETARCH}.zip \
     && unzip /tmp/docker-downloads/terraform.zip \
     && mv terraform /usr/local/bin \
     && terraform -install-autocomplete
@@ -33,7 +34,7 @@ RUN \
 
 # GoLang
 RUN \
-    wget -c https://dl.google.com/go/go1.15.2.linux-amd64.tar.gz -O - | tar -xz -C /usr/local \
+    wget -c https://dl.google.com/go/go1.18.1.linux-${TARGETARCH}.tar.gz -O - | tar -xz -C /usr/local \
     && export PATH=$PATH:/usr/local/go/bin \
     && echo 'export PATH="/root/go/bin:/usr/local/go/bin:$PATH"' >> /root/.bashrc \
     && ln -s /usr/local/go/bin/go /bin/go
@@ -43,16 +44,15 @@ ENV GO111MODULE=on
 # Install Go tools
 RUN \
     # --> Delve for debugging
-    go get github.com/go-delve/delve/cmd/dlv \
+    go install -v github.com/go-delve/delve/cmd/dlv@latest \
     # --> Go language server
-    && go get -v golang.org/x/tools/gopls \
+    && go install -v golang.org/x/tools/gopls@latest \
     # --> Goimports
-    && go get golang.org/x/tools/cmd/goimports \
-    # --> Gotestsum
-    && go get gotest.tools/gotestsum \
-    # --> Go symbols and outline for go to symbol support and test support 
-    && go get github.com/acroca/go-symbols@v0.1.1 && go get github.com/ramya-rao-a/go-outline@7182a932836a71948db4a81991a494751eccfe77 \
-    # --> Static checker
-    && go install honnef.co/go/tools/cmd/staticcheck \
-
-USER developer
+    && go install -v golang.org/x/tools/cmd/goimports@latest \
+    # # --> Gotestsum
+    && go install -v gotest.tools/gotestsum@latest \
+    # # --> Go symbols and outline for go to symbol support and test support 
+    && go install github.com/acroca/go-symbols@v0.1.1 \
+    && go install github.com/ramya-rao-a/go-outline@7182a932836a71948db4a81991a494751eccfe77 \
+    # # --> Static checker
+    && go install honnef.co/go/tools/cmd/staticcheck@latest

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,9 @@
-FROM ubuntu:20.04
+ARG VARIANT=1.16-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/go:${VARIANT}
 
-ARG TERRAFORM_VERSION=0.14.8
+ARG TERRAFORM_VERSION=1.0.0
 ARG TARGETARCH
+ARG USERNAME=vscode
 
 # Configure apt, install packages and tools
 RUN \
@@ -24,35 +26,15 @@ RUN \
     && mv terraform /usr/local/bin \
     && terraform -install-autocomplete
 
-# Save command line history 
-RUN \
-    echo "export HISTFILE=/root/commandhistory/.bash_history" >> "/root/.bashrc" \
-    && echo "export PROMPT_COMMAND='history -a'" >> "/root/.bashrc" \
-    && mkdir -p /root/commandhistory \
-    && touch /root/commandhistory/.bash_history \
-    && echo "source /usr/share/bash-completion/bash_completion" >> "/root/.bashrc"
-
-# GoLang
-RUN \
-    wget -c https://dl.google.com/go/go1.18.1.linux-${TARGETARCH}.tar.gz -O - | tar -xz -C /usr/local \
-    && export PATH=$PATH:/usr/local/go/bin \
-    && echo 'export PATH="/root/go/bin:/usr/local/go/bin:$PATH"' >> /root/.bashrc \
-    && ln -s /usr/local/go/bin/go /bin/go
-
-ENV GO111MODULE=on
+USER $USERNAME
 
 # Install Go tools
 RUN \
-    # --> Delve for debugging
-    go install -v github.com/go-delve/delve/cmd/dlv@latest \
-    # --> Go language server
-    && go install -v golang.org/x/tools/gopls@latest \
     # --> Goimports
-    && go install -v golang.org/x/tools/cmd/goimports@latest \
+    go install -v golang.org/x/tools/cmd/goimports@latest \
     # # --> Gotestsum
     && go install -v gotest.tools/gotestsum@latest \
     # # --> Go symbols and outline for go to symbol support and test support 
     && go install github.com/acroca/go-symbols@v0.1.1 \
-    && go install github.com/ramya-rao-a/go-outline@7182a932836a71948db4a81991a494751eccfe77 \
     # # --> Static checker
-    && go install honnef.co/go/tools/cmd/staticcheck@latest
+    && go install honnef.co/go/tools/cmd/staticcheck@v0.2.2

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,16 +2,20 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/master/containers/go
 {
 	"name": "databricks-terraform",
-	"dockerFile": "Dockerfile",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			// Update the VARIANT arg to pick a version of Go: 1, 1.18, 1.17
+			// Append -bullseye or -buster to pin to an OS version.
+			// Use -bullseye variants on local arm64/Apple Silicon.
+			"VARIANT": "1.16-bullseye",
+			// Options
+			"NODE_VERSION": "none"
+		}
+	},
 	"mounts": [
-		// Mount go mod cache
-		"source=databricks-terraform-gomodcache,target=/go/pkg,type=volume",
-		// Keep command history 
-		"source=databricks-terraform-bashhistory,target=/commandhistory,type=volume",
 		// Mount docker socket for docker builds
-		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
-		// Mount home directory conveniently
-		"source=${localEnv:HOME},target=/home/me,type=bind,consistency=cached"
+		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
 	],
 	"runArgs": [
 		// Uncomment the next line to use a non-root user. On Linux, this will prevent
@@ -44,7 +48,6 @@
 			"usePlaceholders": true, // add parameter placeholders when completing a function
 			// Experimental settings
 			"completeUnimported": true, // autocomplete unimported packages
-			"watchFileChanges": true, // watch file changes outside of the editor
 			"deepCompletion": true, // enable deep completion
 		},
 		"files.eol": "\n", // formatting only supports LF line endings	
@@ -59,5 +62,6 @@
 		"mauve.terraform",
 		"hashicorp.terraform",
 		"ms-vsliveshare.vsliveshare"
-	]
+	],
+	"remoteUser": "vscode"
 }


### PR DESCRIPTION
this will enable M1 Mac users to develop in dev containers.

Also had to update the version go go to 1.18.1 to make it work.