### PR TITLE
Release v0.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 ## 0.5.6
 
 * Added `databricks_views` data resource, making `databricks_tables` return only managed or external tables in Unity Catalog ([#1274](https://github.com/databrickslabs/terraform-provider-databricks/issues/1274)).
+* Added default timeout of 20m to `databricks_mount` ([#1280](https://github.com/databrickslabs/terraform-provider-databricks/pull/1280)).
+* Made `common.DataResource` deterministic ([#1279](https://github.com/databrickslabs/terraform-provider-databricks/pull/1279)).
+* Fixed exporting text-only widgets ([#1278](https://github.com/databrickslabs/terraform-provider-databricks/pull/1278)).
+* Updated devcontainer to support ARM ([#1256](https://github.com/databrickslabs/terraform-provider-databricks/pull/1256)).
+* Various documentation fixes ([#1285](https://github.com/databrickslabs/terraform-provider-databricks/pull/1285), [#1282](https://github.com/databrickslabs/terraform-provider-databricks/pull/1282), [#1281](https://github.com/databrickslabs/terraform-provider-databricks/pull/1281), [#1276](https://github.com/databrickslabs/terraform-provider-databricks/pull/1276)).
+
+Updated dependency versions:
+
+* Bump github.com/hashicorp/hcl/v2 from 2.11.1 to 2.12.0
+* Bump github.com/Azure/go-autorest/autorest from 0.11.26 to 0.11.27
 
 ## 0.5.5
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.5.5"
+      version = "0.5.6"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -338,7 +338,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.5.5"
+      version = "0.5.6"
     }
   }
 }


### PR DESCRIPTION
# Version changelog

## 0.5.6

* Added `databricks_views` data resource, making `databricks_tables` return only managed or external tables in Unity Catalog ([#1274](https://github.com/databrickslabs/terraform-provider-databricks/issues/1274)).
* Added default timeout of 20m to `databricks_mount` ([#1280](https://github.com/databrickslabs/terraform-provider-databricks/pull/1280)).
* Made `common.DataResource` deterministic ([#1279](https://github.com/databrickslabs/terraform-provider-databricks/pull/1279)).
* Fixed exporting text-only widgets ([#1278](https://github.com/databrickslabs/terraform-provider-databricks/pull/1278)).
* Updated devcontainer to support ARM ([#1256](https://github.com/databrickslabs/terraform-provider-databricks/pull/1256)).
* Various documentation fixes ([#1285](https://github.com/databrickslabs/terraform-provider-databricks/pull/1285), [#1282](https://github.com/databrickslabs/terraform-provider-databricks/pull/1282), [#1281](https://github.com/databrickslabs/terraform-provider-databricks/pull/1281), [#1276](https://github.com/databrickslabs/terraform-provider-databricks/pull/1276)).

Updated dependency versions:

* Bump github.com/hashicorp/hcl/v2 from 2.11.1 to 2.12.0
* Bump github.com/Azure/go-autorest/autorest from 0.11.26 to 0.11.27

Test run: AWS
---
 * [x] access.TestAccIPACL (2.36s)
 * [x] access/acceptance.TestAccTableACL (540.34s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateClusterWithLibraries (354.91s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateSingleNodeCluster (62.74s)
 * [x] clusters/acceptance.TestAccListClustersIntegration (70.52s)
 * [x] commands/acceptance.TestAccContext (13.93s)
 * [x] jobs/acceptance.TestAccJobResource (4.16s)
 * [x] libraries/acceptance.TestAccLibraryCreate (59.90s)
 * [x] mlflow/acceptance.TestAccMLflowExperiment (5.00s)
 * [x] mlflow/acceptance.TestAccMLflowModel (2.92s)
 * [x] permissions.TestAccessControlChangeString (0.00s)
 * [x] permissions.TestAccessControlString (0.00s)
 * [x] permissions.TestAccessControlToAccessControlChange (0.00s)
 * [x] permissions/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (34.81s)
 * [x] permissions/acceptance.TestAccDatabricksReposPermissionsResourceFullLifecycle (36.94s)
 * [x] permissions/acceptance.TestAccPermissionsClusterPolicy (13.36s)
 * [x] permissions/acceptance.TestAccPermissionsClusters (78.65s)
 * [x] permissions/acceptance.TestAccPermissionsInstancePool (14.10s)
 * [x] permissions/acceptance.TestAccPermissionsJobs (13.63s)
 * [x] permissions/acceptance.TestAccPermissionsNotebooks (16.38s)
 * [x] permissions/acceptance.TestAccPermissionsTokens (13.06s)
 * [x] policies/acceptance.TestAccClusterPolicyResourceFullLifecycle (4.75s)
 * [x] pools.TestAccInstancePools (2.25s)
 * [x] scim.TestAccCreateUser (7.66s)
 * [x] scim.TestAccFilterGroup (1.29s)
 * [x] scim.TestAccGroup (18.83s)
 * [x] scim.TestAccReadUser (1.45s)
 * [x] scim/acceptance.TestAccForceUserImport (13.27s)
 * [x] scim/acceptance.TestAccGroupMemberResource (21.15s)
 * [x] scim/acceptance.TestAccGroupResource (8.60s)
 * [x] scim/acceptance.TestAccGroupResource_verify_entitlements (12.25s)
 * [x] scim/acceptance.TestAccGroupsExternalIdAndScimProvisioning (12.91s)
 * [x] scim/acceptance.TestAccServicePrincipalResourceOnAws (7.39s)
 * [x] scim/acceptance.TestAccUserResource (9.87s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipals (1.78s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipalsGroup (0.83s)
 * [x] secrets/acceptance.TestAccSecretAclResource (11.11s)
 * [x] secrets/acceptance.TestAccSecretAclResourceDefaultPrincipal (4.64s)
 * [x] secrets/acceptance.TestAccSecretResource (3.91s)
 * [x] secrets/acceptance.TestAccSecretScopeResource (5.22s)
 * [x] storage.TestAccCreateFile (8.29s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (4.79s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (2.51s)
 * [x] storage/acceptance.TestAccInvalidSecretScopeFails (2.63s)
 * [x] storage/acceptance.TestAccSourceOnInvalidMountFails (31.80s)
 * [x] tokens.TestAccCreateToken (0.45s)
 * [x] tokens.TestAccCreateToken_NoExpiration (0.29s)
 * [x] tokens/acceptance.TestAccTokenResource (3.53s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (4.77s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (4.38s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (2.57s)

Test run: Azure
---
 * [x] access.TestAccIPACL (3.96s)
 * [x] access/acceptance.TestAccTableACL (441.57s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateClusterWithLibraries (222.36s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateSingleNodeCluster (41.87s)
 * [x] clusters/acceptance.TestAccListClustersIntegration (40.40s)
 * [x] commands/acceptance.TestAccContext (23.19s)
 * [x] jobs/acceptance.TestAccJobResource (3.23s)
 * [x] libraries/acceptance.TestAccLibraryCreate (54.56s)
 * [x] mlflow/acceptance.TestAccMLflowExperiment (4.58s)
 * [x] mlflow/acceptance.TestAccMLflowModel (2.58s)
 * [x] permissions.TestAccessControlChangeString (0.00s)
 * [x] permissions.TestAccessControlString (0.00s)
 * [x] permissions.TestAccessControlToAccessControlChange (0.00s)
 * [x] permissions/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (9.91s)
 * [x] permissions/acceptance.TestAccDatabricksReposPermissionsResourceFullLifecycle (10.65s)
 * [x] permissions/acceptance.TestAccPermissionsClusterPolicy (3.42s)
 * [x] permissions/acceptance.TestAccPermissionsClusters (57.16s)
 * [x] permissions/acceptance.TestAccPermissionsInstancePool (3.33s)
 * [x] permissions/acceptance.TestAccPermissionsJobs (4.09s)
 * [x] permissions/acceptance.TestAccPermissionsNotebooks (4.31s)
 * [x] permissions/acceptance.TestAccPermissionsTokens (3.02s)
 * [x] policies/acceptance.TestAccClusterPolicyResourceFullLifecycle (4.10s)
 * [x] pools.TestAccInstancePools (0.92s)
 * [x] scim.TestAccCreateUser (2.03s)
 * [x] scim.TestAccFilterGroup (0.32s)
 * [x] scim.TestAccGroup (4.28s)
 * [x] scim.TestAccReadUser (0.28s)
 * [x] scim.TestAccServicePrincipalOnAzure (1.91s)
 * [x] scim/acceptance.TestAccForceUserImport (4.99s)
 * [x] scim/acceptance.TestAccGroupDataSplitMembers (6.29s)
 * [x] scim/acceptance.TestAccGroupMemberResource (5.77s)
 * [x] scim/acceptance.TestAccGroupResource (4.00s)
 * [x] scim/acceptance.TestAccGroupResource_verify_entitlements (5.30s)
 * [x] scim/acceptance.TestAccGroupsExternalIdAndScimProvisioning (4.94s)
 * [x] scim/acceptance.TestAccServicePrincipalResourceOnAzure (3.63s)
 * [x] scim/acceptance.TestAccUserResource (6.38s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipals (0.85s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipalsGroup (1.18s)
 * [x] secrets/acceptance.TestAccSecretAclResource (4.96s)
 * [x] secrets/acceptance.TestAccSecretAclResourceDefaultPrincipal (4.17s)
 * [x] secrets/acceptance.TestAccSecretResource (4.52s)
 * [x] secrets/acceptance.TestAccSecretScopeResource (5.78s)
 * [x] storage.TestAccCreateFile (2.00s)
 * [x] storage/acceptance.TestAccAzureBlobMountGeneric (141.58s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (4.53s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (2.17s)
 * [x] storage/acceptance.TestAccInvalidSecretScopeFails (3.57s)
 * [x] storage/acceptance.TestAccSourceOnInvalidMountFails (35.66s)
 * [x] tokens.TestAccCreateToken (0.54s)
 * [x] tokens.TestAccCreateToken_NoExpiration (0.52s)
 * [x] tokens/acceptance.TestAccTokenResource (3.51s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (3.06s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (4.33s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (6.09s)