### PR TITLE
Ignore new lint error & update formatting

### DIFF
--- a/catalog/data_views_test.go
+++ b/catalog/data_views_test.go
@@ -16,15 +16,15 @@ func TestViewsData(t *testing.T) {
 					Tables: []TableInfo{
 						{
 							CatalogName: "a",
-							SchemaName: "b",
-							Name: "c",
-							TableType: "MANAGED",
+							SchemaName:  "b",
+							Name:        "c",
+							TableType:   "MANAGED",
 						},
 						{
 							CatalogName: "a",
-							SchemaName: "b",
-							Name: "d",
-							TableType: "VIEW",
+							SchemaName:  "b",
+							Name:        "d",
+							TableType:   "VIEW",
 						},
 					},
 				},

--- a/catalog/resource_grants.go
+++ b/catalog/resource_grants.go
@@ -157,29 +157,29 @@ func (sm securableMapping) validate(d attributeGetter, pl PermissionsList) error
 var mapping = securableMapping{
 	// add other securable mappings once needed
 	"table": {
-		"MODIFY":         true,
-		"SELECT":         true,
+		"MODIFY": true,
+		"SELECT": true,
 	},
 	"view": {
-		"SELECT":         true,
+		"SELECT": true,
 	},
 	"catalog": {
-		"CREATE":         true,
-		"USAGE":          true,
+		"CREATE": true,
+		"USAGE":  true,
 	},
 	"schema": {
-		"CREATE":         true,
-		"USAGE":          true,
+		"CREATE": true,
+		"USAGE":  true,
 	},
 	"storage_credential": {
-		"CREATE_TABLE":   true,
-		"READ_FILES":     true,
-		"WRITE_FILES":    true,
+		"CREATE_TABLE": true,
+		"READ_FILES":   true,
+		"WRITE_FILES":  true,
 	},
 	"external_location": {
-		"CREATE_TABLE":   true,
-		"READ_FILES":     true,
-		"WRITE_FILES":    true,
+		"CREATE_TABLE": true,
+		"READ_FILES":   true,
+		"WRITE_FILES":  true,
 	},
 }
 

--- a/common/resource_test.go
+++ b/common/resource_test.go
@@ -45,7 +45,7 @@ func TestHTTP404TriggersResourceRemovalForReadAndDelete(t *testing.T) {
 	}
 	r := Resource{
 		Create: nope,
-		Read: nope,
+		Read:   nope,
 		Update: nope,
 		Delete: nope,
 		Schema: map[string]*schema.Schema{
@@ -59,7 +59,7 @@ func TestHTTP404TriggersResourceRemovalForReadAndDelete(t *testing.T) {
 	client := &DatabricksClient{}
 	ctx := context.Background()
 	d := r.TestResourceData()
-	
+
 	// Create propagates 404 error
 	diags := r.CreateContext(ctx, d, client)
 	assert.True(t, diags.HasError())

--- a/permissions/resource_permissions.go
+++ b/permissions/resource_permissions.go
@@ -205,7 +205,7 @@ func (a PermissionsAPI) Read(objectID string) (objectACL ObjectACL, err error) {
 	err = a.client.Get(a.context, urlPathForObjectID(objectID), nil, &objectACL)
 	apiErr, ok := err.(common.APIError)
 	// https://github.com/databrickslabs/terraform-provider-databricks/issues/1227
-	// platform propagates INVALID_STATE error for auto-purged clusters in 
+	// platform propagates INVALID_STATE error for auto-purged clusters in
 	// the permissions api. this adds "a logical fix" also here, not to introduce
 	// cross-package dependency on "clusters".
 	if ok && strings.Contains(apiErr.Message, "Cannot access cluster") && apiErr.StatusCode == 400 {

--- a/permissions/resource_permissions_test.go
+++ b/permissions/resource_permissions_test.go
@@ -799,7 +799,7 @@ func TestResourcePermissionsCreate_PathIdRetriever_Error(t *testing.T) {
 			qa.HTTPFailures[0],
 		},
 		Resource: ResourcePermissions(),
-		Create: true,
+		Create:   true,
 		HCL: `notebook_path = "/foo/bar"
 
 		access_control {
@@ -816,7 +816,7 @@ func TestResourcePermissionsCreate_ActualUpdate_Error(t *testing.T) {
 			qa.HTTPFailures[0],
 		},
 		Resource: ResourcePermissions(),
-		Create: true,
+		Create:   true,
 		HCL: `cluster_id = "abc"
 
 		access_control {

--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,0 +1,1 @@
+checks = ["inherit", "-SA1019"]

--- a/storage/resource_mount.go
+++ b/storage/resource_mount.go
@@ -66,7 +66,7 @@ func ResourceMount() *schema.Resource {
 	r.DeleteContext = mountCallback(mountDelete).preProcess(r)
 	r.Importer = nil
 	r.Timeouts = &schema.ResourceTimeout{
-		Default: schema.DefaultTimeout(20*time.Minute),
+		Default: schema.DefaultTimeout(20 * time.Minute),
 	}
 	return r
 }


### PR DESCRIPTION
Lint error on Go 1.18:

```
provider/generate_test.go:250:18: strings.Title has been deprecated since Go 1.18 and an alternative has been available since Go 1.0: The rule Title uses for word boundaries does not handle Unicode punctuation properly. Use golang.org/x/text/cases instead.  (SA1019)
qa/testing.go:458:17: strings.Title has been deprecated since Go 1.18 and an alternative has been available since Go 1.0: The rule Title uses for word boundaries does not handle Unicode punctuation properly. Use golang.org/x/text/cases instead.  (SA1019)
```