### PR TITLE
Adding service principals to group documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -262,6 +262,8 @@ resides. Alternatively, you can provide this value as an environment variable `A
 
 There are `ARM_*` environment variables provide a way to share authentication configuration using the `databricks` provider alongside the [`azurerm` provider](https://registry.terraform.io/providers/hashicorp/azurerm/latest).
 
+When a workspace is created using a service principal account, that service principal account is automatically added to the workspace as a member of the admins group. To add a new service principal account to an existing workspace, create a [databricks_service_principal](service_principal.md).
+
 ## Miscellaneous configuration parameters
 
 This section covers configuration parameters not related to authentication.  They could be used when debugging problems, or do an additional tuning of provider's behaviour:

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -3,7 +3,7 @@ subcategory: "Security"
 ---
 # databricks_group Resource
 
-This resource allows you to manage [groups in Databricks Workspace](https://docs.databricks.com/administration-guide/users-groups/groups.html) or [Account Console](https://accounts.cloud.databricks.com/) (for AWS deployments). You can also [associate](group_member.md) Databricks users to groups. This is useful if you are using an application to sync users & groups with SCIM API.
+This resource allows you to manage [groups in Databricks Workspace](https://docs.databricks.com/administration-guide/users-groups/groups.html) or [Account Console](https://accounts.cloud.databricks.com/) (for AWS deployments). You can also [associate](group_member.md) Databricks users and [service principals](service_principal.md) to groups. This is useful if you are using an application to sync users & groups with SCIM API.
 
 Recommended to use along with Identity Provider SCIM provisioning to populate users into those groups:
 

--- a/docs/resources/group_member.md
+++ b/docs/resources/group_member.md
@@ -38,7 +38,7 @@ resource "databricks_group_member" "bb" {
 The following arguments are supported:
 
 * `group_id` - (Required) This is the id of the [group](group.md) resource.
-* `member_id` - (Required) This is the id of the [group](group.md) or [user](user.md).
+* `member_id` - (Required) This is the id of the [group](group.md), [service principal](service_principal.md), or [user](user.md).
 
 ## Attribute Reference
 
@@ -59,6 +59,7 @@ The following resources are often used in the same context:
 * [databricks_group](../data-sources/group.md) data to retrieve information about [databricks_group](group.md) members, entitlements and instance profiles.
 * [databricks_group_instance_profile](group_instance_profile.md) to attach [databricks_instance_profile](instance_profile.md) (AWS) to [databricks_group](group.md).
 * [databricks_ip_access_list](ip_access_list.md) to allow access from [predefined IP ranges](https://docs.databricks.com/security/network/ip-access-list.html).
+* [databricks_service_principal](service_principal.md) to grant access to a workspace to an automation tool or application.
 * [databricks_user](user.md) to [manage users](https://docs.databricks.com/administration-guide/users-groups/users.html), that could be added to [databricks_group](group.md) within the workspace.
 * [databricks_user](../data-sources/user.md) data to retrieves information about [databricks_user](user.md).
 * [databricks_user_instance_profile](user_instance_profile.md) to attach [databricks_instance_profile](instance_profile.md) (AWS) to [databricks_user](user.md).


### PR DESCRIPTION
Adding reference to service principals in the documentation for groups, as well as making it clearer that the example in the "authenticating with service principals" does not demonstrate how a service principal is added to an existing workspace.  