### PR TITLE
Release v0.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 * Added `external_id` and `force` attributes to `databricks_service_principal` resource ([#1293](https://github.com/databrickslabs/terraform-provider-databricks/pull/1293)).
 * Added documentation for `datarbicks_git_credential` resource ([#1295](https://github.com/databrickslabs/terraform-provider-databricks/pull/1295)).
+* Added documentation for `git_source` in `databricks_job` ([#1297](https://github.com/databrickslabs/terraform-provider-databricks/pull/1297)).
+* Fix `job_cluster`.`num_workers` in `databricks_job` ([#1284](https://github.com/databrickslabs/terraform-provider-databricks/pull/1284)).
+* Various documentation improvements ([#1292](https://github.com/databrickslabs/terraform-provider-databricks/pull/1292)), ([#1296](https://github.com/databrickslabs/terraform-provider-databricks/pull/1296)), ([#1298](https://github.com/databrickslabs/terraform-provider-databricks/pull/1298)).
+
+Updated dependency versions:
+
+* Bump google.golang.org/api from 0.75.0 to 0.77.0
+* Removed github.com/pkg/errors dependency
 
 ## 0.5.6
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.5.6"
+      version = "0.5.7"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -340,7 +340,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.5.6"
+      version = "0.5.7"
     }
   }
 }


### PR DESCRIPTION
# Version changelog

## 0.5.7

* Added `external_id` and `force` attributes to `databricks_service_principal` resource ([#1293](https://github.com/databrickslabs/terraform-provider-databricks/pull/1293)).
* Added documentation for `datarbicks_git_credential` resource ([#1295](https://github.com/databrickslabs/terraform-provider-databricks/pull/1295)).
* Added documentation for `git_source` in `databricks_job` ([#1297](https://github.com/databrickslabs/terraform-provider-databricks/pull/1297)).
* Fix `job_cluster`.`num_workers` in `databricks_job` ([#1284](https://github.com/databrickslabs/terraform-provider-databricks/pull/1284)).
* Various documentation improvements ([#1292](https://github.com/databrickslabs/terraform-provider-databricks/pull/1292)), ([#1296](https://github.com/databrickslabs/terraform-provider-databricks/pull/1296)), ([#1298](https://github.com/databrickslabs/terraform-provider-databricks/pull/1298)).

Updated dependency versions:

* Bump google.golang.org/api from 0.75.0 to 0.77.0
* Removed github.com/pkg/errors dependency

Test run: Azure
---
 * [x] access.TestAccIPACL (4.37s)
 * [x] access/acceptance.TestAccTableACL (551.38s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateClusterWithLibraries (243.49s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateSingleNodeCluster (58.80s)
 * [x] clusters/acceptance.TestAccListClustersIntegration (105.10s)
 * [x] commands/acceptance.TestAccContext (25.18s)
 * [x] jobs/acceptance.TestAccJobResource (3.75s)
 * [x] libraries/acceptance.TestAccLibraryCreate (40.63s)
 * [x] mlflow/acceptance.TestAccMLflowExperiment (5.15s)
 * [x] mlflow/acceptance.TestAccMLflowModel (3.01s)
 * [x] permissions.TestAccessControlChangeString (0.00s)
 * [x] permissions.TestAccessControlString (0.00s)
 * [x] permissions.TestAccessControlToAccessControlChange (0.00s)
 * [x] permissions/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (12.93s)
 * [x] permissions/acceptance.TestAccDatabricksReposPermissionsResourceFullLifecycle (13.52s)
 * [x] permissions/acceptance.TestAccPermissionsClusterPolicy (3.34s)
 * [x] permissions/acceptance.TestAccPermissionsClusters (57.50s)
 * [x] permissions/acceptance.TestAccPermissionsInstancePool (3.35s)
 * [x] permissions/acceptance.TestAccPermissionsJobs (4.45s)
 * [x] permissions/acceptance.TestAccPermissionsNotebooks (4.19s)
 * [x] permissions/acceptance.TestAccPermissionsTokens (3.28s)
 * [x] policies/acceptance.TestAccClusterPolicyResourceFullLifecycle (5.28s)
 * [x] pools.TestAccInstancePools (1.09s)
 * [x] repos/acceptance.TestAccGitCredentials (3.88s)
 * [x] scim.TestAccCreateUser (2.06s)
 * [x] scim.TestAccFilterGroup (0.28s)
 * [x] scim.TestAccGroup (4.12s)
 * [x] scim.TestAccReadUser (0.42s)
 * [x] scim.TestAccServicePrincipalOnAzure (1.63s)
 * [x] scim/acceptance.TestAccForceUserImport (5.49s)
 * [x] scim/acceptance.TestAccGroupDataSplitMembers (7.13s)
 * [x] scim/acceptance.TestAccGroupMemberResource (5.74s)
 * [x] scim/acceptance.TestAccGroupResource (5.88s)
 * [x] scim/acceptance.TestAccGroupResource_verify_entitlements (6.19s)
 * [x] scim/acceptance.TestAccGroupsExternalIdAndScimProvisioning (6.97s)
 * [x] scim/acceptance.TestAccServicePrincipalResourceOnAzure (3.82s)
 * [x] scim/acceptance.TestAccUserResource (7.65s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipals (0.99s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipalsGroup (0.70s)
 * [x] secrets/acceptance.TestAccSecretAclResource (5.36s)
 * [x] secrets/acceptance.TestAccSecretAclResourceDefaultPrincipal (4.99s)
 * [x] secrets/acceptance.TestAccSecretResource (5.33s)
 * [x] secrets/acceptance.TestAccSecretScopeResource (6.29s)
 * [x] storage.TestAccCreateFile (2.02s)
 * [x] storage/acceptance.TestAccAzureBlobMountGeneric (142.16s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (5.27s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (2.43s)
 * [x] storage/acceptance.TestAccInvalidSecretScopeFails (4.22s)
 * [x] storage/acceptance.TestAccSourceOnInvalidMountFails (35.75s)
 * [x] tokens.TestAccCreateToken (0.53s)
 * [x] tokens.TestAccCreateToken_NoExpiration (0.45s)
 * [x] tokens/acceptance.TestAccTokenResource (4.44s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (2.94s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (4.65s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (2.36s)

Test run: AWS
---
 * [x] access.TestAccIPACL (4.80s)
 * [x] access/acceptance.TestAccTableACL (542.39s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateClusterWithLibraries (426.76s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateSingleNodeCluster (62.55s)
 * [x] clusters/acceptance.TestAccListClustersIntegration (112.68s)
 * [x] commands/acceptance.TestAccContext (13.63s)
 * [x] jobs/acceptance.TestAccJobResource (4.04s)
 * [x] libraries/acceptance.TestAccLibraryCreate (116.96s)
 * [x] mlflow/acceptance.TestAccMLflowExperiment (5.78s)
 * [x] mlflow/acceptance.TestAccMLflowModel (2.81s)
 * [x] permissions.TestAccessControlChangeString (0.00s)
 * [x] permissions.TestAccessControlString (0.00s)
 * [x] permissions.TestAccessControlToAccessControlChange (0.00s)
 * [x] permissions/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (36.55s)
 * [x] permissions/acceptance.TestAccDatabricksReposPermissionsResourceFullLifecycle (37.96s)
 * [x] permissions/acceptance.TestAccPermissionsClusterPolicy (14.69s)
 * [x] permissions/acceptance.TestAccPermissionsClusters (108.61s)
 * [x] permissions/acceptance.TestAccPermissionsInstancePool (14.63s)
 * [x] permissions/acceptance.TestAccPermissionsJobs (15.18s)
 * [x] permissions/acceptance.TestAccPermissionsNotebooks (15.24s)
 * [x] permissions/acceptance.TestAccPermissionsTokens (13.32s)
 * [x] policies/acceptance.TestAccClusterPolicyResourceFullLifecycle (4.69s)
 * [x] pools.TestAccInstancePools (2.16s)
 * [x] repos/acceptance.TestAccGitCredentials (3.63s)
 * [x] scim.TestAccCreateUser (8.00s)
 * [x] scim.TestAccFilterGroup (1.40s)
 * [x] scim.TestAccGroup (20.21s)
 * [x] scim.TestAccReadUser (1.51s)
 * [x] scim/acceptance.TestAccForceUserImport (11.46s)
 * [x] scim/acceptance.TestAccGroupMemberResource (22.70s)
 * [x] scim/acceptance.TestAccGroupResource (10.99s)
 * [x] scim/acceptance.TestAccGroupResource_verify_entitlements (10.68s)
 * [x] scim/acceptance.TestAccGroupsExternalIdAndScimProvisioning (18.78s)
 * [x] scim/acceptance.TestAccServicePrincipalResourceOnAws (7.50s)
 * [x] scim/acceptance.TestAccUserResource (10.12s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipals (1.74s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipalsGroup (0.75s)
 * [x] secrets/acceptance.TestAccSecretAclResource (11.07s)
 * [x] secrets/acceptance.TestAccSecretAclResourceDefaultPrincipal (4.64s)
 * [x] secrets/acceptance.TestAccSecretResource (4.55s)
 * [x] secrets/acceptance.TestAccSecretScopeResource (5.46s)
 * [x] storage.TestAccCreateFile (7.88s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (5.68s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (2.61s)
 * [x] storage/acceptance.TestAccInvalidSecretScopeFails (3.27s)
 * [x] storage/acceptance.TestAccSourceOnInvalidMountFails (31.96s)
 * [x] tokens.TestAccCreateToken (0.45s)
 * [x] tokens.TestAccCreateToken_NoExpiration (0.44s)
 * [x] tokens/acceptance.TestAccTokenResource (4.00s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (4.76s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (4.35s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (2.20s)