### PR TITLE
Restrict KMS policy to caller AWS account

### DIFF
--- a/docs/resources/mws_customer_managed_keys.md
+++ b/docs/resources/mws_customer_managed_keys.md
@@ -27,6 +27,8 @@ variable "databricks_account_id" {
   description = "Account Id that could be found in the bottom left corner of https://accounts.cloud.databricks.com/"
 }
 
+data "aws_caller_identity" "current" {}
+
 data "aws_iam_policy_document" "databricks_managed_services_cmk" {
   version = "2012-10-17"
   statement {
@@ -34,7 +36,7 @@ data "aws_iam_policy_document" "databricks_managed_services_cmk" {
     effect = "Allow"
     principals {
       type        = "AWS"
-      identifiers = ["*"]
+      identifiers = [data.aws_caller_identity.current.account_id]
     }
     actions   = ["kms:*"]
     resources = ["*"]

--- a/docs/resources/mws_customer_managed_keys.md
+++ b/docs/resources/mws_customer_managed_keys.md
@@ -94,7 +94,7 @@ data "aws_iam_policy_document" "databricks_storage_cmk" {
     effect = "Allow"
     principals {
       type        = "AWS"
-      identifiers = ["*"]
+      identifiers = [data.aws_caller_identity.current.account_id]
     }
     actions   = ["kms:*"]
     resources = ["*"]


### PR DESCRIPTION
Current KMS policy is too large allowing all actions by any AWS account. Restrict it to the caller AWS account.