### PR TITLE
Fix updating `databricks_service_principal` on Azure

### DIFF
--- a/common/version.go
+++ b/common/version.go
@@ -3,7 +3,7 @@ package common
 import "context"
 
 var (
-	version = "0.5.7"
+	version = "0.5.8"
 	// ResourceName is resource name without databricks_ prefix
 	ResourceName contextKey = 1
 	// Provider is the current instance of provider

--- a/scim/resource_service_principal.go
+++ b/scim/resource_service_principal.go
@@ -125,11 +125,16 @@ func ResourceServicePrincipal() *schema.Resource {
 			return sp.Entitlements.readIntoData(d)
 		},
 		Update: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {
+			var applicationId string
+			if c.IsAzure() {
+				applicationId = d.Get("application_id").(string)
+			}
 			return NewServicePrincipalsAPI(ctx, c).Update(d.Id(), User{
-				DisplayName:  d.Get("display_name").(string),
-				Active:       d.Get("active").(bool),
-				Entitlements: readEntitlementsFromData(d),
-				ExternalID:   d.Get("external_id").(string),
+				DisplayName:   d.Get("display_name").(string),
+				Active:        d.Get("active").(bool),
+				Entitlements:  readEntitlementsFromData(d),
+				ExternalID:    d.Get("external_id").(string),
+				ApplicationID: applicationId,
 			})
 		},
 		Delete: func(ctx context.Context, d *schema.ResourceData, c *common.DatabricksClient) error {

--- a/scripts/nightly/main.tf
+++ b/scripts/nightly/main.tf
@@ -15,7 +15,7 @@ output "tags" {
 }
 
 data "external" "env" {
-  program = ["python", "-c", "import sys,os,json;json.dump(dict(os.environ), sys.stdout)"]
+  program = ["python3", "-c", "import sys,os,json;json.dump(dict(os.environ), sys.stdout)"]
 }
 
 data "external" "me" {


### PR DESCRIPTION
* propagate `application_id` on SCIM PUT call for SPN on Azure
* behavior should not affect AWS

Fix #1319