### PR TITLE
Added `delta_sharing_*` support to `databricks_metastore`

### DIFF
--- a/catalog/resource_metastore.go
+++ b/catalog/resource_metastore.go
@@ -33,7 +33,7 @@ type MetastoreInfo struct {
 	UpdatedAt                                   int64   `json:"updated_at,omitempty" tf:"computed"`
 	UpdatedBy                                   string  `json:"updated_by,omitempty" tf:"computed"`
 	DeltaSharingEnabled                         bool    `json:"delta_sharing_enabled,omitempty"`
-	DeltaSharingRecipientTokenLifetimeInSeconds int64   `json:"delta_sharing_recipient_token_lifetime_in_seconds,omitempty" tf:"default:7776000"`
+	DeltaSharingRecipientTokenLifetimeInSeconds int64   `json:"delta_sharing_recipient_token_lifetime_in_seconds,omitempty"`
 	DeltaSharingOrganizationName                string  `json:"delta_sharing_organization_name,omitempty"`
 }
 
@@ -94,12 +94,7 @@ func ResourceMetastore() *schema.Resource {
 		patch := map[string]interface{}{}
 		for _, field := range updatable {
 			old, new := d.GetChange(field)
-			//Int fields old will always be 0 and for this payload
-			//we need to send 0 in the request for infinite lifetime
-			defaultLifetimeIntField := field == "delta_sharing_recipient_token_lifetime_in_seconds" &&
-				old == 0 && new == 0
-
-			if old == new && !defaultLifetimeIntField {
+			if old == new {
 				continue
 			}
 			if field == "name" && old == "" {

--- a/catalog/resource_metastore.go
+++ b/catalog/resource_metastore.go
@@ -33,7 +33,7 @@ type MetastoreInfo struct {
 	UpdatedAt                                   int64   `json:"updated_at,omitempty" tf:"computed"`
 	UpdatedBy                                   string  `json:"updated_by,omitempty" tf:"computed"`
 	DeltaSharingEnabled                         bool    `json:"delta_sharing_enabled,omitempty"`
-	DeltaSharingRecipientTokenLifetimeInSeconds int32   `json:"delta_sharing_recipient_token_lifetime_in_seconds,omitempty" tf:"default:3600"`
+	DeltaSharingRecipientTokenLifetimeInSeconds int64   `json:"delta_sharing_recipient_token_lifetime_in_seconds,omitempty" tf:"default:7776000"`
 	DeltaSharingOrganizationName                string  `json:"delta_sharing_organization_name,omitempty"`
 }
 

--- a/catalog/resource_metastore_test.go
+++ b/catalog/resource_metastore_test.go
@@ -30,7 +30,6 @@ func TestCreateMetastore(t *testing.T) {
 				Response: MetastoreInfo{
 					StorageRoot: "s3://b/abc",
 					Name:        "a",
-					//DeltaSharingRecipientTokenLifetimeInSeconds: 0,
 				},
 			},
 			{

--- a/catalog/resource_metastore_test.go
+++ b/catalog/resource_metastore_test.go
@@ -30,13 +30,16 @@ func TestCreateMetastore(t *testing.T) {
 				Response: MetastoreInfo{
 					StorageRoot: "s3://b/abc",
 					Name:        "a",
+					//DeltaSharingRecipientTokenLifetimeInSeconds: 0,
 				},
 			},
 			{
 				Method:   "PATCH",
 				Resource: "/api/2.0/unity-catalog/metastores/abc",
 				ExpectedRequest: map[string]interface{}{
-					"owner": "administrators",
+					"owner":                 "administrators",
+					"delta_sharing_enabled": true,
+					"delta_sharing_recipient_token_lifetime_in_seconds": 0,
 				},
 			},
 		},
@@ -46,6 +49,8 @@ func TestCreateMetastore(t *testing.T) {
 		name = "a"
 		storage_root = "s3://b"
 		owner = "administrators"
+		delta_sharing_enabled = true
+		delta_sharing_recipient_token_lifetime_in_seconds = 0
 		`,
 	}.ApplyNoError(t)
 }

--- a/catalog/resource_metastore_test.go
+++ b/catalog/resource_metastore_test.go
@@ -97,3 +97,36 @@ func TestForceDeleteMetastore(t *testing.T) {
 		`,
 	}.ApplyNoError(t)
 }
+
+func TestUpdateMetastore_NoChanges(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/unity-catalog/metastores/abc",
+				Response: MetastoreInfo{
+					StorageRoot: "s3://b/abc",
+					Name:        "a",
+				},
+			},
+		},
+		Resource:    ResourceMetastore(),
+		ID:          "abc",
+		Update:      true,
+		RequiresNew: true,
+		InstanceState: map[string]string{
+			"name":                  "abc",
+			"storage_root":          "s3:/a",
+			"owner":                 "admin",
+			"delta_sharing_enabled": "true",
+			"delta_sharing_recipient_token_lifetime_in_seconds": "1002",
+		},
+		HCL: `
+		name = "abc"
+		storage_root = "s3:/a"
+		owner = "admin"
+        delta_sharing_enabled = true
+		delta_sharing_recipient_token_lifetime_in_seconds = 1002
+		`,
+	}.ApplyNoError(t)
+}

--- a/catalog/resource_metastore_test.go
+++ b/catalog/resource_metastore_test.go
@@ -37,7 +37,6 @@ func TestCreateMetastore(t *testing.T) {
 				Resource: "/api/2.0/unity-catalog/metastores/abc",
 				ExpectedRequest: map[string]interface{}{
 					"owner": "administrators",
-					"delta_sharing_recipient_token_lifetime_in_seconds": 7776000,
 				},
 			},
 		},

--- a/catalog/resource_metastore_test.go
+++ b/catalog/resource_metastore_test.go
@@ -36,6 +36,47 @@ func TestCreateMetastore(t *testing.T) {
 				Method:   "PATCH",
 				Resource: "/api/2.0/unity-catalog/metastores/abc",
 				ExpectedRequest: map[string]interface{}{
+					"owner": "administrators",
+					"delta_sharing_recipient_token_lifetime_in_seconds": 7776000,
+				},
+			},
+		},
+		Resource: ResourceMetastore(),
+		Create:   true,
+		HCL: `
+		name = "a"
+		storage_root = "s3://b"
+		owner = "administrators"
+		`,
+	}.ApplyNoError(t)
+}
+
+func TestCreateMetastore_DeltaSharing(t *testing.T) {
+	qa.ResourceFixture{
+		Fixtures: []qa.HTTPFixture{
+			{
+				Method:   "POST",
+				Resource: "/api/2.0/unity-catalog/metastores",
+				ExpectedRequest: MetastoreInfo{
+					StorageRoot: "s3://b",
+					Name:        "a",
+				},
+				Response: MetastoreInfo{
+					MetastoreID: "abc",
+				},
+			},
+			{
+				Method:   "GET",
+				Resource: "/api/2.0/unity-catalog/metastores/abc",
+				Response: MetastoreInfo{
+					StorageRoot: "s3://b/abc",
+					Name:        "a",
+				},
+			},
+			{
+				Method:   "PATCH",
+				Resource: "/api/2.0/unity-catalog/metastores/abc",
+				ExpectedRequest: map[string]interface{}{
 					"owner":                 "administrators",
 					"delta_sharing_enabled": true,
 					"delta_sharing_recipient_token_lifetime_in_seconds": 0,

--- a/catalog/resource_metastore_test.go
+++ b/catalog/resource_metastore_test.go
@@ -125,7 +125,7 @@ func TestUpdateMetastore_NoChanges(t *testing.T) {
 		name = "abc"
 		storage_root = "s3:/a"
 		owner = "admin"
-        delta_sharing_enabled = true
+		delta_sharing_enabled = true
 		delta_sharing_recipient_token_lifetime_in_seconds = 1002
 		`,
 	}.ApplyNoError(t)

--- a/docs/resources/metastore.md
+++ b/docs/resources/metastore.md
@@ -53,7 +53,7 @@ The following arguments are required:
 * `storage_root` - Path on cloud storage account, where managed [databricks_table](table.md) are stored. Change forces creation of a new resource.
 * `owner` - (Optional) Username/groupname of Metastore owner.
 * `delta_sharing_enabled` - (Optional) Required along with `delta_sharing_recipient_token_lifetime_in_seconds`. Used to enable delta sharing on the metastore.
-* `delta_sharing_recipient_token_lifetime_in_seconds` - (Optional) Required along with `delta_sharing_enabled`. Used to set expiration duratrion in seconds on recipient data access tokens. Set to 0 for unlimited duration. The default value is 3600 seconds.
+* `delta_sharing_recipient_token_lifetime_in_seconds` - (Optional) Required along with `delta_sharing_enabled`. Used to set expiration duratrion in seconds on recipient data access tokens. Set to 0 for unlimited duration. The default value is 7776000 seconds (90 days).
 * `delta_sharing_organization_name` - (Optional) The organization name of a Delta Sharing entity. This field is used for Databricks to Databricks sharing. Once this is set it cannot be removed and can only be modified to another valid value. To delete this value please taint and recreate the resource.
 * `force_destroy` - (Optional) Destroy metastore regardless of its contents.
 

--- a/docs/resources/metastore.md
+++ b/docs/resources/metastore.md
@@ -53,7 +53,7 @@ The following arguments are required:
 * `storage_root` - Path on cloud storage account, where managed [databricks_table](table.md) are stored. Change forces creation of a new resource.
 * `owner` - (Optional) Username/groupname of Metastore owner.
 * `delta_sharing_enabled` - (Optional) Required along with `delta_sharing_recipient_token_lifetime_in_seconds`. Used to enable delta sharing on the metastore.
-* `delta_sharing_recipient_token_lifetime_in_seconds` - (Optional) Required along with `delta_sharing_enabled`. Used to set expiration duratrion in seconds on recipient data access tokens. Set to 0 for unlimited duration. The default value is 7776000 seconds (90 days).
+* `delta_sharing_recipient_token_lifetime_in_seconds` - (Optional) Required along with `delta_sharing_enabled`. Used to set expiration duration in seconds on recipient data access tokens. Set to 0 for unlimited duration.
 * `delta_sharing_organization_name` - (Optional) The organization name of a Delta Sharing entity. This field is used for Databricks to Databricks sharing. Once this is set it cannot be removed and can only be modified to another valid value. To delete this value please taint and recreate the resource.
 * `force_destroy` - (Optional) Destroy metastore regardless of its contents.
 

--- a/docs/resources/metastore.md
+++ b/docs/resources/metastore.md
@@ -54,6 +54,7 @@ The following arguments are required:
 * `owner` - (Optional) Username/groupname of Metastore owner.
 * `delta_sharing_enabled` - (Optional) Required along with `delta_sharing_recipient_token_lifetime_in_seconds`. Used to enable delta sharing on the metastore.
 * `delta_sharing_recipient_token_lifetime_in_seconds` - (Optional) Required along with `delta_sharing_enabled`. Used to set expiration duratrion in seconds on recipient data access tokens. Set to 0 for unlimited duration. The default value is 3600 seconds.
+* `delta_sharing_organization_name` - (Optional) The organization name of a Delta Sharing entity. This field is used for Databricks to Databricks sharing. Once this is set it cannot be removed and can only be modified to another valid value. To delete this value please taint and recreate the resource.
 * `force_destroy` - (Optional) Destroy metastore regardless of its contents.
 
 ## Import

--- a/docs/resources/metastore.md
+++ b/docs/resources/metastore.md
@@ -52,6 +52,8 @@ The following arguments are required:
 * `name` - Name of metastore.
 * `storage_root` - Path on cloud storage account, where managed [databricks_table](table.md) are stored. Change forces creation of a new resource.
 * `owner` - (Optional) Username/groupname of Metastore owner.
+* `delta_sharing_enabled` - (Optional) Required along with `delta_sharing_recipient_token_lifetime_in_seconds`. Used to enable delta sharing on the metastore.
+* `delta_sharing_recipient_token_lifetime_in_seconds` - (Optional) Required along with `delta_sharing_enabled`. Used to set expiration duratrion in seconds on recipient data access tokens. Set to 0 for unlimited duration.
 * `force_destroy` - (Optional) Destroy metastore regardless of its contents.
 
 ## Import

--- a/docs/resources/metastore.md
+++ b/docs/resources/metastore.md
@@ -53,7 +53,7 @@ The following arguments are required:
 * `storage_root` - Path on cloud storage account, where managed [databricks_table](table.md) are stored. Change forces creation of a new resource.
 * `owner` - (Optional) Username/groupname of Metastore owner.
 * `delta_sharing_enabled` - (Optional) Required along with `delta_sharing_recipient_token_lifetime_in_seconds`. Used to enable delta sharing on the metastore.
-* `delta_sharing_recipient_token_lifetime_in_seconds` - (Optional) Required along with `delta_sharing_enabled`. Used to set expiration duratrion in seconds on recipient data access tokens. Set to 0 for unlimited duration.
+* `delta_sharing_recipient_token_lifetime_in_seconds` - (Optional) Required along with `delta_sharing_enabled`. Used to set expiration duratrion in seconds on recipient data access tokens. Set to 0 for unlimited duration. The default value is 3600 seconds.
 * `force_destroy` - (Optional) Destroy metastore regardless of its contents.
 
 ## Import


### PR DESCRIPTION
added the following fields:

Optional non computed fields:
1.  `delta_sharing_enabled`
2. `delta_sharing_recipient_token_lifetime_in_seconds`

Added computed fields:
1. `region`
2. `cloud`
3. `global_metastore_id`

also added docs