### PR TITLE
Add ability to specify tags for jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version changelog
 
+## 0.5.9
+
+* Add ability to specify tags for jobs ([#1337](https://github.com/databrickslabs/terraform-provider-databricks/pull/1337))
+
 ## 0.5.8
 
 * Update `aws_iam_policy_document` in `databricks_mws_customer_managed_keys` docs to restrict KMS policy to caller AWS account ([#1309](https://github.com/databrickslabs/terraform-provider-databricks/pull/1309)).

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -124,6 +124,7 @@ The following arguments are required:
 * `max_concurrent_runs` - (Optional) (Integer) An optional maximum allowed number of concurrent runs of the job. Defaults to *1*.
 * `email_notifications` - (Optional) (List) An optional set of email addresses notified when runs of this job begin and complete and when this job is deleted. The default behavior is to not send any emails. This field is a block and is documented below.
 * `schedule` - (Optional) (List) An optional periodic schedule for this job. The default behavior is that the job runs when triggered by clicking Run Now in the Jobs UI or sending an API request to runNow. This field is a block and is documented below.
+* `tags` - (Optional) (Map) An optional map of the tags associated with the job. Specified tags will be used as cluster tags for job clusters.
 
 ### job_cluster Configuration Block
 [Shared job cluster](https://docs.databricks.com/jobs.html#use-shared-job-clusters) specification. Allows multiple tasks in the same job run to reuse the cluster. 

--- a/jobs/resource_job.go
+++ b/jobs/resource_job.go
@@ -146,6 +146,7 @@ type JobSettings struct {
 	Schedule           *CronSchedule       `json:"schedule,omitempty"`
 	MaxConcurrentRuns  int32               `json:"max_concurrent_runs,omitempty"`
 	EmailNotifications *EmailNotifications `json:"email_notifications,omitempty" tf:"suppress_diff"`
+	Tags               map[string]string   `json:"tags,omitempty"`
 }
 
 func (js *JobSettings) isMultiTask() bool {


### PR DESCRIPTION
Jobs API now allows to specify tags that will be used as cluster tags for created jobs clusters