### PR TITLE
Release v0.5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,22 @@
 
 ## 0.5.9
 
-* Add ability to specify tags for jobs ([#1337](https://github.com/databrickslabs/terraform-provider-databricks/pull/1337))
+* Added warning section for debug mode ([#1325](https://github.com/databrickslabs/terraform-provider-databricks/pull/1325)).
+* Added ability to specify tags for `databricks_job` ([#1337](https://github.com/databrickslabs/terraform-provider-databricks/pull/1337)).
+* Upgraded AWS provider for AWS guides. Added examples for account-level identities ([#1332](https://github.com/databrickslabs/terraform-provider-databricks/pull/1332)).
+* Updated docs to use `application_id` as privilege for `databricks_service_principal` ([#1336](https://github.com/databrickslabs/terraform-provider-databricks/pull/1336)).
+* Added `databricks_service_principal_role` resource ([#1340](https://github.com/databrickslabs/terraform-provider-databricks/pull/1340)).
+* Fixed itegration testing image ([#1342](https://github.com/databrickslabs/terraform-provider-databricks/pull/1342), [#1343](https://github.com/databrickslabs/terraform-provider-databricks/pull/1343)).
+* Added `skip_validation` for `databricks_external_location` ([#1330](https://github.com/databrickslabs/terraform-provider-databricks/pull/1330)).
+* Added `alert_on_last_attempt` to `databricks_job` ([#1341](https://github.com/databrickslabs/terraform-provider-databricks/pull/1341)).
+* Skip `make test` on doc-only changes ([#1339](https://github.com/databrickslabs/terraform-provider-databricks/pull/1339)).
+* Improve common package test coverage ([#1344](https://github.com/databrickslabs/terraform-provider-databricks/pull/1344)).
+* Re-create purged cluster for `databricks_mount` for AWS S3 ([#1345](https://github.com/databrickslabs/terraform-provider-databricks/pull/1345)).
+
+Updated dependency versions:
+
+* Bump google.golang.org/api from 0.79.0 to 0.80.0
+* Bump github.com/Azure/go-autorest/autorest/adal from 0.9.19 to 0.9.20
 
 ## 0.5.8
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.5.8"
+      version = "0.5.9"
     }
   }
 }

--- a/common/version.go
+++ b/common/version.go
@@ -3,7 +3,7 @@ package common
 import "context"
 
 var (
-	version = "0.5.8"
+	version = "0.5.9"
 	// ResourceName is resource name without databricks_ prefix
 	ResourceName contextKey = 1
 	// Provider is the current instance of provider

--- a/docs/index.md
+++ b/docs/index.md
@@ -342,7 +342,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.5.8"
+      version = "0.5.9"
     }
   }
 }


### PR DESCRIPTION
## 0.5.9

* Added warning section for debug mode ([#1325](https://github.com/databrickslabs/terraform-provider-databricks/pull/1325)).
* Added ability to specify tags for `databricks_job` ([#1337](https://github.com/databrickslabs/terraform-provider-databricks/pull/1337)).
* Upgraded AWS provider for AWS guides. Added examples for account-level identities ([#1332](https://github.com/databrickslabs/terraform-provider-databricks/pull/1332)).
* Updated docs to use `application_id` as privilege for `databricks_service_principal` ([#1336](https://github.com/databrickslabs/terraform-provider-databricks/pull/1336)).
* Added `databricks_service_principal_role` resource ([#1340](https://github.com/databrickslabs/terraform-provider-databricks/pull/1340)).
* Fixed itegration testing image ([#1342](https://github.com/databrickslabs/terraform-provider-databricks/pull/1342), [#1343](https://github.com/databrickslabs/terraform-provider-databricks/pull/1343)).
* Added `skip_validation` for `databricks_external_location` ([#1330](https://github.com/databrickslabs/terraform-provider-databricks/pull/1330)).
* Added `alert_on_last_attempt` to `databricks_job` ([#1341](https://github.com/databrickslabs/terraform-provider-databricks/pull/1341)).
* Skip `make test` on doc-only changes ([#1339](https://github.com/databrickslabs/terraform-provider-databricks/pull/1339)).
* Improve common package test coverage ([#1344](https://github.com/databrickslabs/terraform-provider-databricks/pull/1344)).
* Re-create purged cluster for `databricks_mount` for AWS S3 ([#1345](https://github.com/databrickslabs/terraform-provider-databricks/pull/1345)).

Updated dependency versions:

* Bump google.golang.org/api from 0.79.0 to 0.80.0
* Bump github.com/Azure/go-autorest/autorest/adal from 0.9.19 to 0.9.20

Test run: Azure
---

 * [x] access.TestAccIPACL (4.72s)
 * [x] access/acceptance.TestAccTableACL (517.67s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateClusterWithLibraries (254.61s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateSingleNodeCluster (58.41s)
 * [x] clusters/acceptance.TestAccListClustersIntegration (115.00s)
 * [x] commands/acceptance.TestAccContext (31.67s)
 * [x] jobs/acceptance.TestAccJobResource (3.39s)
 * [x] libraries/acceptance.TestAccLibraryCreate (54.66s)
 * [x] mlflow/acceptance.TestAccMLflowExperiment (6.14s)
 * [x] mlflow/acceptance.TestAccMLflowModel (2.87s)
 * [x] permissions.TestAccessControlChangeString (0.00s)
 * [x] permissions.TestAccessControlString (0.00s)
 * [x] permissions.TestAccessControlToAccessControlChange (0.00s)
 * [x] permissions/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (12.10s)
 * [x] permissions/acceptance.TestAccDatabricksReposPermissionsResourceFullLifecycle (10.87s)
 * [x] permissions/acceptance.TestAccPermissionsClusterPolicy (3.49s)
 * [x] permissions/acceptance.TestAccPermissionsClusters (57.82s)
 * [x] permissions/acceptance.TestAccPermissionsInstancePool (3.62s)
 * [x] permissions/acceptance.TestAccPermissionsJobs (4.27s)
 * [x] permissions/acceptance.TestAccPermissionsNotebooks (4.26s)
 * [x] permissions/acceptance.TestAccPermissionsTokens (3.38s)
 * [x] policies/acceptance.TestAccClusterPolicyResourceFullLifecycle (4.82s)
 * [x] pools.TestAccInstancePools (1.00s)
 * [x] repos/acceptance.TestAccGitCredentials (2.97s)
 * [x] scim.TestAccCreateUser (2.51s)
 * [x] scim.TestAccFilterGroup (0.29s)
 * [x] scim.TestAccGroup (4.49s)
 * [x] scim.TestAccReadUser (0.32s)
 * [x] scim.TestAccServicePrincipalOnAzure (1.90s)
 * [x] scim/acceptance.TestAccForceUserImport (5.98s)
 * [x] scim/acceptance.TestAccGroupDataSplitMembers (7.70s)
 * [x] scim/acceptance.TestAccGroupMemberResource (5.84s)
 * [x] scim/acceptance.TestAccGroupResource (4.88s)
 * [x] scim/acceptance.TestAccGroupResource_verify_entitlements (4.79s)
 * [x] scim/acceptance.TestAccGroupsExternalIdAndScimProvisioning (5.51s)
 * [x] scim/acceptance.TestAccServicePrincipalResourceOnAzure (3.61s)
 * [x] scim/acceptance.TestAccUserResource (7.11s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipals (0.80s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipalsGroup (1.07s)
 * [x] secrets/acceptance.TestAccSecretAclResource (5.26s)
 * [x] secrets/acceptance.TestAccSecretAclResourceDefaultPrincipal (5.12s)
 * [x] secrets/acceptance.TestAccSecretResource (5.08s)
 * [x] secrets/acceptance.TestAccSecretScopeResource (7.34s)
 * [x] storage.TestAccCreateFile (2.33s)
 * [x] storage/acceptance.TestAccAzureBlobMountGeneric (143.52s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (4.93s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (2.54s)
 * [x] storage/acceptance.TestAccInvalidSecretScopeFails (3.97s)
 * [x] storage/acceptance.TestAccSourceOnInvalidMountFails (35.77s)
 * [x] tokens.TestAccCreateToken (0.49s)
 * [x] tokens.TestAccCreateToken_NoExpiration (0.38s)
 * [x] tokens/acceptance.TestAccTokenResource (4.21s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (2.79s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (4.78s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (2.50s)

Test run: AWS
---
 * [x] access.TestAccIPACL (2.52s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateClusterWithLibraries (446.79s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateSingleNodeCluster (65.48s)
 * [x] clusters/acceptance.TestAccListClustersIntegration (72.58s)
 * [x] commands/acceptance.TestAccContext (15.88s)
 * [x] jobs/acceptance.TestAccJobResource (4.23s)
 * [x] libraries/acceptance.TestAccLibraryCreate (76.38s)
 * [x] mlflow/acceptance.TestAccMLflowExperiment (5.72s)
 * [x] mlflow/acceptance.TestAccMLflowModel (2.91s)
 * [x] permissions.TestAccessControlChangeString (0.00s)
 * [x] permissions.TestAccessControlString (0.00s)
 * [x] permissions.TestAccessControlToAccessControlChange (0.00s)
 * [x] permissions/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (32.82s)
 * [x] permissions/acceptance.TestAccDatabricksReposPermissionsResourceFullLifecycle (30.90s)
 * [x] permissions/acceptance.TestAccPermissionsClusterPolicy (14.20s)
 * [x] permissions/acceptance.TestAccPermissionsClusters (79.17s)
 * [x] permissions/acceptance.TestAccPermissionsInstancePool (14.72s)
 * [x] permissions/acceptance.TestAccPermissionsJobs (15.01s)
 * [x] permissions/acceptance.TestAccPermissionsNotebooks (16.46s)
 * [x] permissions/acceptance.TestAccPermissionsTokens (13.92s)
 * [x] policies/acceptance.TestAccClusterPolicyResourceFullLifecycle (4.30s)
 * [x] pools.TestAccInstancePools (2.37s)
 * [x] repos/acceptance.TestAccGitCredentials (2.96s)
 * [x] scim.TestAccCreateUser (7.32s)
 * [x] scim.TestAccFilterGroup (1.33s)
 * [x] scim.TestAccGroup (19.54s)
 * [x] scim.TestAccReadUser (1.49s)
 * [x] scim/acceptance.TestAccForceUserImport (12.85s)
 * [x] scim/acceptance.TestAccGroupMemberResource (20.80s)
 * [x] scim/acceptance.TestAccGroupResource (9.30s)
 * [x] scim/acceptance.TestAccGroupResource_verify_entitlements (10.28s)
 * [x] scim/acceptance.TestAccGroupsExternalIdAndScimProvisioning (13.30s)
 * [x] scim/acceptance.TestAccServicePrincipalResourceOnAws (7.81s)
 * [x] scim/acceptance.TestAccUserResource (9.84s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipals (1.59s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipalsGroup (0.78s)
 * [x] secrets/acceptance.TestAccSecretAclResource (11.54s)
 * [x] secrets/acceptance.TestAccSecretAclResourceDefaultPrincipal (5.10s)
 * [x] secrets/acceptance.TestAccSecretResource (4.96s)
 * [x] secrets/acceptance.TestAccSecretScopeResource (6.25s)
 * [x] storage.TestAccCreateFile (7.91s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (4.95s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (2.51s)
 * [x] storage/acceptance.TestAccInvalidSecretScopeFails (3.25s)
 * [x] storage/acceptance.TestAccSourceOnInvalidMountFails (31.73s)
 * [x] tokens.TestAccCreateToken (0.58s)
 * [x] tokens.TestAccCreateToken_NoExpiration (0.30s)
 * [x] tokens/acceptance.TestAccTokenResource (3.74s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (4.77s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (4.68s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (2.82s)