### PR TITLE
Added `databricks_git_credentials` pat discovery from common environment variables

### DIFF
--- a/docs/resources/git_credential.md
+++ b/docs/resources/git_credential.md
@@ -23,7 +23,7 @@ resource "databricks_git_credential" "ado" {
 
 The following arguments are supported:
 
-* `personal_access_token` - (Required) The personal access token used to authenticate to the corresponding Git provider.
+* `personal_access_token` - (Required) The personal access token used to authenticate to the corresponding Git provider. If value is not provided, it's sourced from the first environment variable of [`GITHUB_TOKEN`](https://registry.terraform.io/providers/integrations/github/latest/docs#oauth--personal-access-token), [`GITLAB_TOKEN`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs#required), or [`AZDO_PERSONAL_ACCESS_TOKEN`](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs#argument-reference), that has a non-empty value.
 * `git_username` - (Required) user name at Git provider.
 * `git_provider` -  (Required) case insensitive name of the Git provider.  Following values are supported right now (could be a subject for a change, consult [Git Credentials API documentation](https://docs.databricks.com/dev-tools/api/latest/gitcredentials.html)): `gitHub`, `gitHubEnterprise`, `bitbucketCloud`, `bitbucketServer`, `azureDevOpsServices`, `gitLab`, `gitLabEnterpriseEdition`, `awsCodeCommit`.
 * `force` - (Optional) specify if settings need to be enforced - right now, Databricks allows only single Git credential, so if it's already configured, the apply operation will fail.

--- a/repos/resource_git_credential.go
+++ b/repos/resource_git_credential.go
@@ -71,6 +71,11 @@ func ResourceGitCredential() *schema.Resource {
 			Type:     schema.TypeBool,
 			Optional: true,
 		}
+		s["personal_access_token"].DefaultFunc = schema.MultiEnvDefaultFunc([]string{
+			"GITHUB_TOKEN",               // https://registry.terraform.io/providers/integrations/github/latest/docs
+			"GITLAB_TOKEN",               // https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs
+			"AZDO_PERSONAL_ACCESS_TOKEN", // https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs
+		}, nil)
 		return s
 	})
 


### PR DESCRIPTION
If `personal_access_token` is not provided, it's sourced from the first environment variable of [`GITHUB_TOKEN`](https://registry.terraform.io/providers/integrations/github/latest/docs#oauth--personal-access-token), [`GITLAB_TOKEN`](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs#required), or [`AZDO_PERSONAL_ACCESS_TOKEN`](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs#argument-reference), that has a non-empty value.

Fixes #1352