### PR TITLE
Added `network_id` to `network` block in `databricks_mws_workspaces` for GCP

### DIFF
--- a/mws/resource_workspace.go
+++ b/mws/resource_workspace.go
@@ -66,6 +66,7 @@ type GCPCommonNetworkConfig struct {
 }
 
 type GCPNetwork struct {
+	NetworkID               string                   `json:"network_id,omitempty"`
 	GCPManagedNetworkConfig *GCPManagedNetworkConfig `json:"gcp_managed_network_config"`
 	GCPCommonNetworkConfig  *GCPCommonNetworkConfig  `json:"gcp_common_network_config"`
 }

--- a/mws/resource_workspace_test.go
+++ b/mws/resource_workspace_test.go
@@ -129,6 +129,7 @@ func TestResourceWorkspaceCreateGcp(t *testing.T) {
 					},
 					"location": "bcd",
 					"network": map[string]interface{}{
+						"network_id": "net_id_a",
 						"gcp_common_network_config": map[string]interface{}{
 							"gke_cluster_master_ip_range": "e",
 							"gke_connectivity_type":       "d",
@@ -173,6 +174,7 @@ func TestResourceWorkspaceCreateGcp(t *testing.T) {
 			}
 		}
 		network {
+			network_id = "net_id_a"
 			gcp_managed_network_config {
 				subnet_cidr = "a"
 				gke_cluster_pod_ip_range = "b"


### PR DESCRIPTION
In GCP to use customer-manager VPC, the `network_id` is specified inside the `network` object, not at the top-level workspace object.

This allows the `network_id` to be specified at the correct place.