### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Version changelog
 
+## 0.6.0
+
+* Added `delta_sharing_*` support to `databricks_metastore` ([#1334](https://github.com/databrickslabs/terraform-provider-databricks/pull/1334)).
+* Added `databricks_git_credentials` pat discovery from common environment variables ([#1353](https://github.com/databrickslabs/terraform-provider-databricks/pull/1353)).
+* Added `databricks_permissions` for `databricks_pipeline` ([#1361](https://github.com/databrickslabs/terraform-provider-databricks/pull/1361)).
+* Added `network_id` to `network` block in `databricks_mws_workspaces` for GCP ([#1360](https://github.com/databrickslabs/terraform-provider-databricks/pull/1360)).
+* Added `azure_managed_identity` block to `databricks_storage_credential` and `databricks_metastore_data_access` resources ([#1354](https://github.com/databrickslabs/terraform-provider-databricks/pull/1354)).
+* Update docs regarding importing of `databricks_sql_*` resources ([#1349](https://github.com/databrickslabs/terraform-provider-databricks/pull/1349)).
+* Apply ownership for UC objects during creation ([#1338](https://github.com/databrickslabs/terraform-provider-databricks/pull/1338)).
+* Re-create purged cluster for `databricks_mount` for Google Storage ([#1333](https://github.com/databrickslabs/terraform-provider-databricks/pull/1333)).
+* Various documentation fixes ([#1350](https://github.com/databrickslabs/terraform-provider-databricks/pull/1350)).
+
+Updated dependency versions:
+
+* Bump google.golang.org/api from 0.80.0 to 0.81.0
+* Bump gopkg.in/ini.v1 from 1.66.4 to 1.66.6
+* Bump google.golang.org/api from 0.81.0 to 0.82.0
+* Bump github.com/stretchr/testify from 1.7.1 to 1.7.2
+* Bump github.com/hashicorp/terraform-plugin-sdk/v2 from 2.16.0 to 2.17.0
+
 ## 0.5.9
 
 * Added warning section for debug mode ([#1325](https://github.com/databrickslabs/terraform-provider-databricks/pull/1325)).

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.5.9"
+      version = "0.6.0"
     }
   }
 }

--- a/common/version.go
+++ b/common/version.go
@@ -3,7 +3,7 @@ package common
 import "context"
 
 var (
-	version = "0.5.9"
+	version = "0.6.0"
 	// ResourceName is resource name without databricks_ prefix
 	ResourceName contextKey = 1
 	// Provider is the current instance of provider

--- a/docs/guides/aws-workspace.md
+++ b/docs/guides/aws-workspace.md
@@ -259,10 +259,10 @@ Code that creates workspaces and code that [manages workspaces](workspace-manage
 
 ```hcl
 resource "databricks_mws_workspaces" "this" {
-  provider        = databricks.mws
-  account_id      = var.databricks_account_id
-  aws_region      = var.region
-  workspace_name  = local.prefix
+  provider       = databricks.mws
+  account_id     = var.databricks_account_id
+  aws_region     = var.region
+  workspace_name = local.prefix
 
   credentials_id           = databricks_mws_credentials.this.credentials_id
   storage_configuration_id = databricks_mws_storage_configurations.this.storage_configuration_id

--- a/docs/index.md
+++ b/docs/index.md
@@ -342,7 +342,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.5.9"
+      version = "0.6.0"
     }
   }
 }

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -48,11 +48,11 @@ Creating group in AWS Databricks account:
 ```hcl
 // initialize provider at account-level
 provider "databricks" {
-  alias    = "mws"
-  host     = "https://accounts.cloud.databricks.com"
+  alias      = "mws"
+  host       = "https://accounts.cloud.databricks.com"
   account_id = "00000000-0000-0000-0000-000000000000"
-  username = var.databricks_account_username
-  password = var.databricks_account_password
+  username   = var.databricks_account_username
+  password   = var.databricks_account_password
 }
 
 resource "databricks_group" "this" {

--- a/docs/resources/metastore_data_access.md
+++ b/docs/resources/metastore_data_access.md
@@ -69,7 +69,7 @@ resource "databricks_metastore_data_access" "this" {
   metastore_id = databricks_metastore.this.id
   name         = "mi_dac"
   azure_managed_identity {
-    access_connector_id   = var.access_connector_id
+    access_connector_id = var.access_connector_id
   }
   is_default = true
 }

--- a/docs/resources/mws_workspaces.md
+++ b/docs/resources/mws_workspaces.md
@@ -65,10 +65,10 @@ resource "databricks_mws_networks" "this" {
 
 // create workspace in given VPC with DBFS on root bucket
 resource "databricks_mws_workspaces" "this" {
-  provider        = databricks.mws
-  account_id      = var.databricks_account_id
-  workspace_name  = var.prefix
-  aws_region      = var.region
+  provider       = databricks.mws
+  account_id     = var.databricks_account_id
+  workspace_name = var.prefix
+  aws_region     = var.region
 
   credentials_id           = databricks_mws_credentials.this.credentials_id
   storage_configuration_id = databricks_mws_storage_configurations.this.storage_configuration_id
@@ -177,10 +177,10 @@ resource "databricks_mws_storage_configurations" "this" {
 }
 
 resource "databricks_mws_workspaces" "this" {
-  provider        = databricks.mws
-  account_id      = var.databricks_account_id
-  workspace_name  = local.prefix
-  aws_region      = "us-east-1"
+  provider       = databricks.mws
+  account_id     = var.databricks_account_id
+  workspace_name = local.prefix
+  aws_region     = "us-east-1"
 
   credentials_id           = databricks_mws_credentials.this.credentials_id
   storage_configuration_id = databricks_mws_storage_configurations.this.storage_configuration_id

--- a/docs/resources/service_principal.md
+++ b/docs/resources/service_principal.md
@@ -48,11 +48,11 @@ Creating service principal in AWS Databricks account:
 ```hcl
 // initialize provider at account-level
 provider "databricks" {
-  alias    = "mws"
-  host     = "https://accounts.cloud.databricks.com"
+  alias      = "mws"
+  host       = "https://accounts.cloud.databricks.com"
   account_id = "00000000-0000-0000-0000-000000000000"
-  username = var.databricks_account_username
-  password = var.databricks_account_password
+  username   = var.databricks_account_username
+  password   = var.databricks_account_password
 }
 
 resource "databricks_service_principal" "sp" {

--- a/docs/resources/storage_credential.md
+++ b/docs/resources/storage_credential.md
@@ -47,7 +47,7 @@ resource "databricks_storage_credential" "external_sp" {
 resource "databricks_storage_credential" "external_mi" {
   name = "mi_credential"
   azure_managed_identity {
-    access_connector_id   = var.access_connector_id
+    access_connector_id = var.access_connector_id
   }
   comment = "Managed identity credential managed by TF"
 }

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -48,11 +48,11 @@ Creating user in AWS Databricks account:
 ```hcl
 // initialize provider at account-level
 provider "databricks" {
-  alias    = "mws"
-  host     = "https://accounts.cloud.databricks.com"
+  alias      = "mws"
+  host       = "https://accounts.cloud.databricks.com"
   account_id = "00000000-0000-0000-0000-000000000000"
-  username = var.databricks_account_username
-  password = var.databricks_account_password
+  username   = var.databricks_account_username
+  password   = var.databricks_account_password
 }
 
 resource "databricks_user" "account_user" {


### PR DESCRIPTION
* Added `delta_sharing_*` support to `databricks_metastore` ([#1334](https://github.com/databrickslabs/terraform-provider-databricks/pull/1334)).
* Added `databricks_git_credentials` pat discovery from common environment variables ([#1353](https://github.com/databrickslabs/terraform-provider-databricks/pull/1353)).
* Added `databricks_permissions` for `databricks_pipeline` ([#1361](https://github.com/databrickslabs/terraform-provider-databricks/pull/1361)).
* Added `network_id` to `network` block in `databricks_mws_workspaces` for GCP ([#1360](https://github.com/databrickslabs/terraform-provider-databricks/pull/1360)).
* Added `azure_managed_identity` block to `databricks_storage_credential` and `databricks_metastore_data_access` resources ([#1354](https://github.com/databrickslabs/terraform-provider-databricks/pull/1354)).
* Update docs regarding importing of `databricks_sql_*` resources ([#1349](https://github.com/databrickslabs/terraform-provider-databricks/pull/1349)).
* Apply ownership for UC objects during creation ([#1338](https://github.com/databrickslabs/terraform-provider-databricks/pull/1338)).
* Re-create purged cluster for `databricks_mount` for Google Storage ([#1333](https://github.com/databrickslabs/terraform-provider-databricks/pull/1333)).
* Various documentation fixes ([#1350](https://github.com/databrickslabs/terraform-provider-databricks/pull/1350)).

Updated dependency versions:

* Bump google.golang.org/api from 0.80.0 to 0.81.0
* Bump gopkg.in/ini.v1 from 1.66.4 to 1.66.6
* Bump google.golang.org/api from 0.81.0 to 0.82.0
* Bump github.com/stretchr/testify from 1.7.1 to 1.7.2
* Bump github.com/hashicorp/terraform-plugin-sdk/v2 from 2.16.0 to 2.17.0

Test run: gcp-accounts
---

 * [x] mws.TestGcpaAccWorkspace (36.67s)

Test run: Azure
---

 * [x] access.TestAccIPACL (5.16s)
 * [x] access/acceptance.TestAccTableACL (496.78s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateClusterWithLibraries (254.85s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateSingleNodeCluster (68.41s)
 * [x] clusters/acceptance.TestAccListClustersIntegration (105.01s)
 * [x] commands/acceptance.TestAccContext (26.62s)
 * [x] jobs/acceptance.TestAccJobResource (3.83s)
 * [x] libraries/acceptance.TestAccLibraryCreate (54.61s)
 * [x] mlflow/acceptance.TestAccMLflowExperiment (4.91s)
 * [x] mlflow/acceptance.TestAccMLflowModel (2.78s)
 * [x] permissions.TestAccessControlChangeString (0.00s)
 * [x] permissions.TestAccessControlString (0.00s)
 * [x] permissions.TestAccessControlToAccessControlChange (0.00s)
 * [x] permissions/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (11.10s)
 * [x] permissions/acceptance.TestAccDatabricksReposPermissionsResourceFullLifecycle (11.09s)
 * [x] permissions/acceptance.TestAccPermissionsClusterPolicy (3.52s)
 * [x] permissions/acceptance.TestAccPermissionsClusters (63.61s)
 * [x] permissions/acceptance.TestAccPermissionsInstancePool (4.37s)
 * [x] permissions/acceptance.TestAccPermissionsJobs (4.47s)
 * [x] permissions/acceptance.TestAccPermissionsNotebooks (4.47s)
 * [x] permissions/acceptance.TestAccPermissionsTokens (3.13s)
 * [x] policies/acceptance.TestAccClusterPolicyResourceFullLifecycle (4.36s)
 * [x] pools.TestAccInstancePools (1.11s)
 * [x] repos/acceptance.TestAccGitCredentials (3.11s)
 * [x] scim.TestAccCreateUser (2.36s)
 * [x] scim.TestAccFilterGroup (0.44s)
 * [x] scim.TestAccGroup (4.47s)
 * [x] scim.TestAccReadUser (0.32s)
 * [x] scim.TestAccServicePrincipalOnAzure (2.07s)
 * [x] scim/acceptance.TestAccForceUserImport (4.68s)
 * [x] scim/acceptance.TestAccGroupDataSplitMembers (7.17s)
 * [x] scim/acceptance.TestAccGroupMemberResource (6.54s)
 * [x] scim/acceptance.TestAccGroupResource (4.44s)
 * [x] scim/acceptance.TestAccGroupResource_verify_entitlements (5.14s)
 * [x] scim/acceptance.TestAccGroupsExternalIdAndScimProvisioning (5.91s)
 * [x] scim/acceptance.TestAccServicePrincipalResourceOnAzure (4.37s)
 * [x] scim/acceptance.TestAccUserResource (6.82s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipals (0.97s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipalsGroup (0.71s)
 * [x] secrets/acceptance.TestAccSecretAclResource (6.96s)
 * [x] secrets/acceptance.TestAccSecretAclResourceDefaultPrincipal (4.31s)
 * [x] secrets/acceptance.TestAccSecretResource (4.78s)
 * [x] secrets/acceptance.TestAccSecretScopeResource (5.20s)
 * [x] storage.TestAccCreateFile (2.44s)
 * [x] storage/acceptance.TestAccAzureBlobMountGeneric (140.91s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (4.83s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (2.61s)
 * [x] storage/acceptance.TestAccInvalidSecretScopeFails (4.62s)
 * [x] storage/acceptance.TestAccSourceOnInvalidMountFails (36.41s)
 * [x] tokens.TestAccCreateToken (0.53s)
 * [x] tokens.TestAccCreateToken_NoExpiration (0.44s)
 * [x] tokens/acceptance.TestAccTokenResource (4.24s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (2.89s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (4.35s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (2.13s)

Test run: AWS
---

 * [x] access.TestAccIPACL (5.50s)
 * [x] access/acceptance.TestAccTableACL (542.97s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateClusterWithLibraries (528.48s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateSingleNodeCluster (73.23s)
 * [x] clusters/acceptance.TestAccListClustersIntegration (197.61s)
 * [x] commands/acceptance.TestAccContext (15.66s)
 * [x] jobs/acceptance.TestAccJobResource (4.04s)
 * [x] libraries/acceptance.TestAccLibraryCreate (153.07s)
 * [x] mlflow/acceptance.TestAccMLflowExperiment (6.54s)
 * [x] mlflow/acceptance.TestAccMLflowModel (3.21s)
 * [x] permissions.TestAccessControlChangeString (0.00s)
 * [x] permissions.TestAccessControlString (0.00s)
 * [x] permissions.TestAccessControlToAccessControlChange (0.00s)
 * [x] permissions/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (37.69s)
 * [x] permissions/acceptance.TestAccDatabricksReposPermissionsResourceFullLifecycle (31.81s)
 * [x] permissions/acceptance.TestAccPermissionsClusterPolicy (13.69s)
 * [x] permissions/acceptance.TestAccPermissionsClusters (108.87s)
 * [x] permissions/acceptance.TestAccPermissionsInstancePool (14.76s)
 * [x] permissions/acceptance.TestAccPermissionsJobs (15.11s)
 * [x] permissions/acceptance.TestAccPermissionsNotebooks (15.96s)
 * [x] permissions/acceptance.TestAccPermissionsTokens (13.33s)
 * [x] policies/acceptance.TestAccClusterPolicyResourceFullLifecycle (4.43s)
 * [x] pools.TestAccInstancePools (2.19s)
 * [x] repos/acceptance.TestAccGitCredentials (3.34s)
 * [x] scim.TestAccCreateUser (7.48s)
 * [x] scim.TestAccFilterGroup (1.46s)
 * [x] scim.TestAccGroup (20.00s)
 * [x] scim.TestAccReadUser (1.60s)
 * [x] scim/acceptance.TestAccForceUserImport (12.06s)
 * [x] scim/acceptance.TestAccGroupMemberResource (22.94s)
 * [x] scim/acceptance.TestAccGroupResource (10.96s)
 * [x] scim/acceptance.TestAccGroupResource_verify_entitlements (10.57s)
 * [x] scim/acceptance.TestAccGroupsExternalIdAndScimProvisioning (13.83s)
 * [x] scim/acceptance.TestAccServicePrincipalResourceOnAws (7.87s)
 * [x] scim/acceptance.TestAccUserResource (11.32s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipals (1.71s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipalsGroup (0.85s)
 * [x] secrets/acceptance.TestAccSecretAclResource (10.86s)
 * [x] secrets/acceptance.TestAccSecretAclResourceDefaultPrincipal (5.34s)
 * [x] secrets/acceptance.TestAccSecretResource (4.22s)
 * [x] secrets/acceptance.TestAccSecretScopeResource (5.23s)
 * [x] storage.TestAccCreateFile (6.51s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (6.72s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (2.74s)
 * [x] storage/acceptance.TestAccInvalidSecretScopeFails (3.23s)
 * [x] storage/acceptance.TestAccSourceOnInvalidMountFails (31.98s)
 * [x] tokens.TestAccCreateToken (0.49s)
 * [x] tokens.TestAccCreateToken_NoExpiration (0.30s)
 * [x] tokens/acceptance.TestAccTokenResource (4.29s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (4.99s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (4.57s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (2.44s)