### PR TITLE
Request to add warning in `databricks_permissions.token_usage`

### DIFF
--- a/docs/resources/permissions.md
+++ b/docs/resources/permissions.md
@@ -496,6 +496,7 @@ resource "databricks_permissions" "password_usage" {
 ## Token usage
 
 -> **Note** It is required to have at least 1 personal access token in the workspace before you can manage tokens permissions.
+
 !> **Warning** After applying the changes, any users who previously had either `Can Use` or `Can Manage` permission but no longer have either permission are denied access to token-based authentication and their active tokens are immediately deleted (revoked). Deleted tokens cannot be retrieved.
 
 Only [possible permission](https://docs.databricks.com/administration-guide/access-control/tokens.html) to assign to non-admin group is `CAN_USE`, where _admins_ `CAN_MANAGE` all tokens:

--- a/docs/resources/permissions.md
+++ b/docs/resources/permissions.md
@@ -496,6 +496,7 @@ resource "databricks_permissions" "password_usage" {
 ## Token usage
 
 -> **Note** It is required to have at least 1 personal access token in the workspace before you can manage tokens permissions.
+!> **Warning** After applying the changes, any users who previously had either `Can Use` or `Can Manage` permission but no longer have either permission are denied access to token-based authentication and their active tokens are immediately deleted (revoked). Deleted tokens cannot be retrieved.
 
 Only [possible permission](https://docs.databricks.com/administration-guide/access-control/tokens.html) to assign to non-admin group is `CAN_USE`, where _admins_ `CAN_MANAGE` all tokens:
 


### PR DESCRIPTION
In the admin guide, we have a warning that revoking token usage permission will delete the active tokens. Since users following only Terraform registry docs are not aware of this behavior and causing confusion. We can include a warning in Terraform docs to make it very clear or we can ignore this PR considering we already have a link to the admin guide. 

https://docs.databricks.com/administration-guide/access-control/tokens.html#manage-token-permissions-using-the-admin-console:~:text=save%20your%20changes.-,Warning,-After%20saving%20your

`After saving your changes, any users who previously had either Can Use or Can Manage permission but no longer have either permission are denied access to token-based authentication and their active tokens are immediately deleted (revoked). Deleted tokens cannot be retrieved.`