### PR TITLE
Release v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Version changelog
 
+## 0.6.2
+
+* Add a warning in `databricks_permissions` token usage docs ([#1380](https://github.com/databrickslabs/terraform-provider-databricks/pull/1380)).
+
+Updated dependency versions:
+
+* Bump google.golang.org/api from 0.83.0 to 0.84.0
+* Bump github.com/stretchr/testify from 1.7.2 to 1.7.3
+
 ## 0.6.1
 
 * Added `databricks_service_principal` and `databricks_service_principals` data resources ([#1370](https://github.com/databrickslabs/terraform-provider-databricks/pull/1370)).

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.6.1"
+      version = "0.6.2"
     }
   }
 }

--- a/common/version.go
+++ b/common/version.go
@@ -3,7 +3,7 @@ package common
 import "context"
 
 var (
-	version = "0.6.1"
+	version = "0.6.2"
 	// ResourceName is resource name without databricks_ prefix
 	ResourceName contextKey = 1
 	// Provider is the current instance of provider

--- a/docs/index.md
+++ b/docs/index.md
@@ -342,7 +342,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databrickslabs/databricks"
-      version = "0.6.1"
+      version = "0.6.2"
     }
   }
 }

--- a/scripts/upgrade-namespace.py
+++ b/scripts/upgrade-namespace.py
@@ -1,0 +1,26 @@
+import glob, re, sys
+
+old_provider = "databrickslabs/databricks"
+new_provider = "databricks/databricks"
+
+files_to_fix = []
+regex = re.compile(r"source\s+=\s+\"{}\"".format(old_provider))
+
+for terraform_configuration_file in glob.glob('**/**.tf', recursive=True):
+    contents = open(terraform_configuration_file, 'r').read()
+    if not regex.findall(contents):
+        continue
+    print(f'[+] File {terraform_configuration_file} matches.')
+    files_to_fix.append((terraform_configuration_file, contents))
+
+if not len(files_to_fix):
+    print("NOTHING: Didn't find any mentions of the databricks provider.")
+    sys.exit(1)
+
+if 'yes' == input(f'Type yes to confirm fix of {len(files_to_fix)} files: ').lower():
+    for terraform_configuration_file, contents in files_to_fix:
+        with open(terraform_configuration_file, 'w') as f:
+            new_contents = regex.sub(f'source = "{new_provider}"', contents)
+            f.write(new_contents)
+    print(f'SUCCESS: Fixed {len(files_to_fix)} files!')
+else: print("ABORT: Didn't receive 'yes'.")

--- a/scripts/versions-lock.hcl
+++ b/scripts/versions-lock.hcl
@@ -1,0 +1,571 @@
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.3.0"
+  constraints = "0.3.0"
+  hashes = [
+    "h1:GszteoOV01k3QzX1ptTJre7SQkgmiWKeLgxqXY976Ic=",
+    "zh:0a109aaa15d8e0980ead8c9f347ef4f29c0c7a7a8adde955b0130b25dd0cbb20",
+    "zh:32640cc6bd811e33f2d80e403731de6e941590af0f85e14f1eb4e28405cfa652",
+    "zh:3ee64f1c57745f4ae1bdd97ea000d8138b823b602136a510f609f053f029f072",
+    "zh:44977a050e8dfa7702e5cfa938c843623b46bdaddc11ac2a792c93c8cc97a21f",
+    "zh:641eeaeb070625622060441e1170ea250a0f13e1341d56f83d8aaa29439d0be6",
+    "zh:d43968c464d4e83f228ff5455b027e19dc2b5dde5de13719f25f514123f224f6",
+    "zh:f8f1789909479d683975a182b9e9376b0f0d20fbb2ff6b9711d6d0dc5206abef",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.3.1"
+  constraints = "0.3.1"
+  hashes = [
+    "h1:xuWKdKeNoAGtRf2w4LppLT7CBthQsYNqMEFowmLB2uE=",
+    "zh:4c73cc97a25b4d581f73a8ffb00aceec157404fa5e32ce5338a2a591d0b8e3a4",
+    "zh:673453cc059362898a177359520061a754638f93e4053588b370a77ccc707702",
+    "zh:90ba141c029f24ef5225ad99c8b5c648d7ba7282a94988da8256fcfb2b845c5c",
+    "zh:92d9e7a8eb33bc7a6fb623c23cd09e25f230aaa387986828b61e607bc0915dd8",
+    "zh:aee7a11fce9c2f3993fbddaef20b2995e14c8461a97d61a4518955d449c7398f",
+    "zh:cf78298b202a907f0f3af9f32d457e6af00c68c85a668bf1d5ab5f18ba85c881",
+    "zh:d715a3b61c447c92672bb81169d9b11059c54c59800418fde702a0a73da7c126",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.3.2"
+  constraints = "0.3.2"
+  hashes = [
+    "h1:0fq5LNYA9T1ywb5riB+PEoA1RBcUje0s7dvcsPbdXgE=",
+    "zh:3b4bca446a30db7b444466d152ccc3843b153d85105870e44ee460898b0ce39c",
+    "zh:524c113f9e1ee5b378daad80e7911d72428a90836e5bfdd47371bb592333d65c",
+    "zh:5fd15b0a6b829dc641aa867119b21b261c8f30806fc892e787aacb8bd5d4044f",
+    "zh:697a4dbbd5770bcf6e0fa719fe6027ee7df57be50f55a87c9561d3dc8963c773",
+    "zh:89c4640607808df8177a8741cb65527a97b301b02f3b9e8894d7817529a1bfb7",
+    "zh:c2c01208b5997e2fdc105ffaf92e047ca34c57a2e17241320eb82d629380f732",
+    "zh:d2ca19f1a5a1ff19ab9d28ef7c25d80093fbd92df2152a0a86475e9353f51c41",
+    "zh:fbb64f3951cfda61c3582b44d583e69872ffa7e9afa22cf1f4013fa7e257c8a1",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.3.3"
+  constraints = "0.3.3"
+  hashes = [
+    "h1:MbaB1P5xaJZAcr001zVsEg0AyF6yeGt05U66GtBFgv0=",
+    "zh:0d2e4a8175e804573f4b2adb779f4142a0607d3451bb0e51fbaa488a24ab9db6",
+    "zh:4a23b8a265473c511265029a6f2252c5f6f5d24bdafd684f1dcee3050bea8a03",
+    "zh:5c71d527fe6f7ef556106ff662ba12f948fea91755972cae89b88d90dccf46a1",
+    "zh:a20c841743880b1638a1a536d5bdaf657df9ba85e548a7f428cb4187365a5786",
+    "zh:a69fcde6f786dc6bf74fb786077c337b8933789b7bb862fdb244a459684a69f6",
+    "zh:ab5dcdabb67aefb611cbc27e8ba594dbcb013bf26fb243c0f987907cb1ac1676",
+    "zh:ac39957f4b839b93b12cab627aa0e8778f35ebc4360b8c66aa536b828c9259f7",
+    "zh:f9ffafe79bb7f5261598c40b302d01e8da57be79abb59d7882eecbd237842e09",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.3.4"
+  constraints = "0.3.4"
+  hashes = [
+    "h1:CGkDWzhY1LweF36dFGFyOldEliexHpUijLGeJtr1ldY=",
+    "zh:37036494400e3c7c1a3b2df4fc64dad3be7c9ced8908d7874cdbbedd971f4855",
+    "zh:3ade139753c188e5f91682982d9da0b62fde9c4d723413315766333599e3c73b",
+    "zh:415cd29f7c6bc8c1d16b9a5554062f869b0425b475b2e352ce24e587350cef03",
+    "zh:7a012b284a7687016e222e65f02baf870cc16010dab8643279d6a32ebf77ba01",
+    "zh:81e569adb99b1a04fd0553b9e1e51c3c5de9894523a445135530ed0b26faacb9",
+    "zh:8ce679852eb22f41a5b958df2f3a0f32aef288760f19383dc7837dbc406799d5",
+    "zh:ba86c99b99de49bc04b27abe35cc6f959fbf15602ce5c02ff134347f6819f820",
+    "zh:db1e6876ebed3c7ed2c3e6609508c34e71789531ebcc35b1d9417c792fdddf24",
+    "zh:fcce1964a0efe110f986315ed1bbce1ee54af86db5d1b67c423619c5758d9627",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.3.5"
+  constraints = "0.3.5"
+  hashes = [
+    "h1:xTJXsxBgotYIqy+jYMBUI/jdQd256bROd7J7GdUe9Yo=",
+    "zh:0a74e3e6666206c63e6bc45de46d79848e8b530072a3a0d11f01a16445d82e9f",
+    "zh:0b50cb2074363fc41642c3caededefc840bb63b1db28310b406376102582a652",
+    "zh:256e3b4a3af52852bad55af085efe95ea0ae9fd5383def4a475c12bfe97f93e6",
+    "zh:48a86ca88df1e79518cf2fcd831f7cab25eb4524c5b108471b6d8f634333df8e",
+    "zh:6bdf337c9e950fb9be7c5c907c8c20c340b64abb6426e7f4fe21d39842db7296",
+    "zh:80b7983152b95c0a02438f418cf77dc384c08ea0fe89bdb9ca3a440db97fe805",
+    "zh:8515aa8c7595307c24257fffffa623a7a32ff8930c6405530b8caa28de0db25f",
+    "zh:c221cd2b62b6ac00159cf741f5994c09b455e6ed4ec72fdec8961f66f3c1a4d9",
+    "zh:e4e8aeaac861c462f6daf9c54274796b2f47c9b23effa25e6222e370be0c926f",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.3.6"
+  constraints = "0.3.6"
+  hashes = [
+    "h1:QxmFwhSOJUv3rJ49bkHuOc605nZJb3vSYjjXouhB+Eo=",
+    "zh:15a6fb168d5931a7d9e5a346b078c2875adb4d64798f3a4d10d6479a5bb3fa74",
+    "zh:2844625b8901dcf5668e34b73efe1e8f2d979eff5cc92289d19618a0ac9963f6",
+    "zh:3e9d0fa1592a7f834b549cb756215ab4d7e068f1e74ba2415d7c961662f3eb2b",
+    "zh:68dff7ca906f0b0e354c0e2224716ea049819ba746acd3cc532e4d98a09c2318",
+    "zh:87b60325211ec33bd38da39ba5bd0e2d7249eeb0eb21f4f7ed2aadd02a1d93b6",
+    "zh:a39d4f673fdbc6137b9317aaea02e19f3d143b7ae1c4fbe03678e147c6f036fe",
+    "zh:ba37f892b0ba03f42d1763687a310d443c998e69d887d73937608382ce25a384",
+    "zh:d28f892ee04bf80fc45b193444a9d37f16548956fccf7fbd020a58eec44d22d7",
+    "zh:fa098b728c1c20737216a7594d84f5a4c581b1937b82d78371f12827dd5de5ba",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.3.7"
+  constraints = "0.3.7"
+  hashes = [
+    "h1:7wImwe2TlbYOJDBpNFqKer+RIX4JyquWz30S4VcG1mM=",
+    "zh:1590ab45a63d29bd59aecc4f802a09e6ea17a4e9f0b3f984cc407a786b258083",
+    "zh:3413a9e5cf5315c3ceb640deefcb820f0b0f6b11686098b73dd6f6e0dd50c493",
+    "zh:4bb1305244c3fee56cbd869f47495d27ff9a068fd786de6944721cd892050b36",
+    "zh:57101fdc2d494f45477c0211f01da29ef85b279260087eff978eb7096486e5d4",
+    "zh:6d30f25728a9376b6c8e71680d98a1b8a31b44d5c285e3e40813f5e1abaf4214",
+    "zh:6f149f7bb2617f15890b0e33e0d89565495613d84580638c35d50183904bc29e",
+    "zh:ebba6394e337850d7f7db8b755241340a2a06866c70438713234b5ad7d2e25a9",
+    "zh:ef2819d68ad5cebc0a8d94d90a160d5794c724eaa671c961a21cfcd22574fdf0",
+    "zh:fd2b875e9949371a0fb33c98565d352806ef8b448c8f0198acdae2e541712d5f",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.3.8"
+  constraints = "0.3.8"
+  hashes = [
+    "h1:HioKP8jUHriV17itbuppiQ00w1lucyc03LunmlUR3R8=",
+    "zh:3d3f1958cfa8cc2b424b79f763ce0208324b377db81bd21f12d84d1142814302",
+    "zh:53144d5c67055f705a6f8a3617794d7db21a9bff4920c5bd758e79c4f12e3583",
+    "zh:60c1a65ed02f5c121f256f41e930cd951d5cd761622c03f0720cd547ff2a458f",
+    "zh:8818da2f778dc1c46f6eb944c021f7137dad57b0b3f1221faa6e465b3f399712",
+    "zh:8a6e1c944142ddedeedac5a64d4e8dc2ac3b3f2b95b3115045742d6a7595f9b7",
+    "zh:8fb7bef84dd8808d681b2ad9053dd979980af4329a10c88b480582bf6ff55691",
+    "zh:a623503c6377d9ad13c540a8e7aed27f2bca3ff282054e563b47b4b2acd9bf2d",
+    "zh:eb633dcbfc637bbed5f91311b860f833d9a01013687169a12a30d24e5499d9c3",
+    "zh:efc35c97377a796e2d61609ee29595ae6a3f8d39cebd3fdbeaa33d1e75f9ca59",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.3.9"
+  constraints = "0.3.9"
+  hashes = [
+    "h1:1RP1XkUS4R5TfOLda+em2tg3DdGUcRL9pkbQHt/J/Q8=",
+    "zh:42eb3fa0e1e002fa86a4a7353507581b01f2cfe368a14d26a0c7d9fe48cad77c",
+    "zh:482d7ea1c3912aedb14ef0ac7376399560ed8906c2def73d0b62a422cdc84915",
+    "zh:4b987a1fdbcefd1056ecbc98bf1751538ea1ca22e2172f924f5e5d2ec4694f8b",
+    "zh:7fa07d34cd84ad7784ca46e01fd836bda2ea91887a24bf294392967093a56429",
+    "zh:83098c9de2f669d41ef3459a7529a6fbc455bb07c35968c8d2d3dd7ba63a6575",
+    "zh:b558db0fed328d48977edba457b9ddc22e6b00cdcfc9b72efcf5f6c0b9af3111",
+    "zh:c1ea963b99db21ee9f11f127d2a96d06d76543014bae8d315b7b3a378da321a9",
+    "zh:f884fae38a2f118ba50f531bc78004e327b9991c277b92fe473c86368a1e7d51",
+    "zh:fb1021304bc0004b6ab5a2e6d5e01e0efc3f6278645528e0ec12dd671464a0a7",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.3.10"
+  constraints = "0.3.10"
+  hashes = [
+    "h1:u/RRXN0G5gkb3A41b3lEj/OytyVmqecmINQzhvOHeHs=",
+    "zh:002ecdbf4bdffc36cefe9299aaaf3c209ab2093a61f522347fe3a34ef9def5a3",
+    "zh:1bf683cb6efdfae289bed84d071af6c77f8497d723ee6254aba8722e4574a87d",
+    "zh:24247a8ae1855cd26470c2ecb362d503f293e4ade2a8b743abb34b49c9c4dae4",
+    "zh:39d09541981ef278c813b958a91fe191d361c73aedbdb533d6b86aeccce45e45",
+    "zh:3fada6aa9d86a3a3415e3f6a6475fd7f6f53d564c5614f7c5e82f9d7104a192f",
+    "zh:58fb40c5be7539f7eed86458915ea920a5fa6ccfb424678804cad9e461e83dea",
+    "zh:bcdaef7d181890b1b953ac510b53a71c2084b3bf221dee1f40afdb13b12a5a63",
+    "zh:bf61fa45d0b813dce7d155617dfdd49f3640bcd44a8e9bc93740833a84f2734c",
+    "zh:d1f0e66e9c05dfed041dc53c5d005f8132b69975bbab79336cdc9e04ba0ce7c8",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.3.11"
+  constraints = "0.3.11"
+  hashes = [
+    "h1:o8if96RKQkn4ei0/QXaMoHSFwgL0nsprkGV2dAGKOLA=",
+    "zh:565f5e9e691854a27205a8e56f2df5bc222455f3ecf00e1d71bc3ab526630784",
+    "zh:7cdec7f5a4509b25b32e47e01c9c5844c56fb4ccc98ea0f2dcb749d14ad21a90",
+    "zh:96378ef610c6403af79b310976465de648f1b1e20e08dba91a76653f17441255",
+    "zh:c5c62fb49720e711114ef2e0865ac83f758cedcd46c5385a7f531060c1bbe8bf",
+    "zh:cd5c180d51e33fdaefaf0f0ef411e3d918a339237c9ccbe36333a9af631cdbf6",
+    "zh:ece1042314d87e50a74881818feb09992a6a8f2118a5f741180adadf8b7905ce",
+    "zh:f2c57f881ecc34fba9ccad5eb071979f1801407f314077ed34e62d77fe41f29f",
+    "zh:f603d348f8d6b3ef0231e9ce69a678cc12546a6860a9417005b7d235e163cf8a",
+    "zh:fc1691cd0b076d1510905248aee6e980ba0e27d9c7db18f7e6b4981813b87f26",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.4.0"
+  constraints = "0.4.0"
+  hashes = [
+    "h1:QS7/qWOOJXY8wHuGUvs53EPLRSdNJ/MqUjHf9RFToAo=",
+    "zh:0340b2485a045605701756e2bd3dcab979be5733537401c96135d864cf1043c2",
+    "zh:0a635626ada977f182e9a6847d74671121ddd26f073d2283537f994eed5badc5",
+    "zh:283d87b16efeed1d3ab64bbf8a1aa0505b9098ff218024545586d2c900dae640",
+    "zh:3a842a577155678f49ada2e10b376ba494f9dd7cd54f12eb1c78abaf3a4bc9e6",
+    "zh:5c20eeaa1a7d6975647803575234e4868cdfa481c5567c0a435efa1f1dbb13c9",
+    "zh:6733bc6cd8488e216532874ab8d3993861bd46e21ca8cd35a4a1796e0804d485",
+    "zh:728c2bf415c795f00140652278c068ce4724279760c4856dce37d4dc35c3ee8c",
+    "zh:8564c02ea7d7ef893edb09ba6cdde127100d4cf85e46491fa1216c8078831044",
+    "zh:c227c6640dd99b326dc687f8811361118138c08329b98c5dffb23299d33f5769",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.4.1"
+  constraints = "0.4.1"
+  hashes = [
+    "h1:w7GdE+YXhbGmSIvqdGnSH0uSMYWNKIBA9A+I8iuciWg=",
+    "zh:2fd4e1bddf61bcabc51b3f9a7712c5f32560407d06477dcf4f28a096bf75c7b3",
+    "zh:314ede585f7ed1400149605e0718b6b45eadd2d4f197bcd99ce1a35b318e279a",
+    "zh:439fbeac5a9f0b47f890c33c20919480fe116bb4ae7163a027ccc4e062734eac",
+    "zh:48e790d6cb4af4f011020c316cf3b098a9aad00c8eed9e00a9709478daa6a242",
+    "zh:4fcbbdccd749df5458847bb0b689f0a4695e98eaed4940b7a8d5466985f56ea7",
+    "zh:78f7ec337e24f6e9824976d6d9980cb4a33efe6ae28355fc85896ca8a2ac5df3",
+    "zh:9de55c4fda8b134ba8d416eb2a2e8df319e439f81de8c9d595cb1553ed7693e4",
+    "zh:d2d690eef34f95c0b4976841eefdb0c5d8467e2b6ce6b75a42d97c31ccd60deb",
+    "zh:e28b326fb1fde7ed03df530c7fdf8f0676fa91cc4ef2cd3bc6d05cb64b0766c0",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.4.2"
+  constraints = "0.4.2"
+  hashes = [
+    "h1:qGouMcOCqnT9apkB+iRs3KMs7keze3uhsFZATkNB8Fk=",
+    "zh:10c528819cddca669946766010bb039d07801f4852019da7c534d1eb1d71cdae",
+    "zh:746a1dcf85edbac5db1cc0f72ae6c8ea7a4eed927253aa4501be36325fe206de",
+    "zh:77d92613cf28047aaee3aee1c570c2e525335317e5937982563a32b3824a1298",
+    "zh:7be070af36cf56f964c954be023077ec562480e36fed77ce9a6a1096e6765283",
+    "zh:90cc8a76a74c11d652fad8a7dea4f3fff3a2cecbe944f8363b3158169c3924d8",
+    "zh:9b81cee091131849ee5f57e871280afc609a4181004427ab6ec0b20631e03b5b",
+    "zh:d4a8b5c9f9f354c028b0c2b5b3e858315a82f90c05383a3ad949eaf46f536ada",
+    "zh:e31f6e098f3e4096ce73ed3b22b830ac8a46437048db9bd93e0b0c82d1061cfa",
+    "zh:e978c16c65d7a820ffd5b1659c779cb50d86d382e9fb106e5884588981f1f7d1",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.4.3"
+  constraints = "0.4.3"
+  hashes = [
+    "h1:SbH8FzW4Ak9DtjPfXLY1pYAUrtqYcvabcnmg2sPsqTM=",
+    "zh:004ff1ede711ff89ab254b7c3683553ae024e171627e4a6ce7b0233b3bb7f595",
+    "zh:01824bcee67f21db7a3b42a7ec8041b3b9444aa5c853af0855be642241cba75b",
+    "zh:3edb87c38895798f8c6f151f5eef81828c33c53bc77a26beab5a87d4739d4d5a",
+    "zh:4668f1c6c3412200afc4e7248b0a5b1686acc2a5517563346766dc7433aaf85c",
+    "zh:97b3ac0607744c9a74d9c5c8bb45d286a97cb948e06cd6292536148897c8ff09",
+    "zh:9ab91a74fc383cc623caa9af812bb84bad189487198a9077af792cc758b86b26",
+    "zh:9bde1466a3a514e2ab40f443a89e7c398df949832d03b872487370bbf155fd0d",
+    "zh:a570628467753dcec735d87c47d2affc62b0981be5f57ad64179626a6c2ab58c",
+    "zh:fa7a257319b2b26e97c5242a7e9917732f6826774e9da8c22a5ff4733ca6dd16",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.4.4"
+  constraints = "0.4.4"
+  hashes = [
+    "h1:lxMHDxDWTvu6Qh+jEGIAStoAXwzXwwiVc7XW2+08YU8=",
+    "zh:30575a20b0c7a5dae0452dac58b02647c23925f3fd10e038d6cf82ea86588e25",
+    "zh:33e97d9019d00011044b048ae6407a8f019306417781db7af0ba2ceb419651cb",
+    "zh:36c51261d187b58b24a67d8a4dafbb6421936dc465a5cec27f48f1a0a45ef6dc",
+    "zh:40cbbb87b057be4e6736c0b3dde17e24471f79a2580bb9c103384c0b58aa2610",
+    "zh:458a80c757439ecb7cdaeed3652c39c323d271c30670e28000446d5d0c783894",
+    "zh:9577855b122b6a4dff87a789e2ebd661ef40124bae11ebf1a323431d86b2cca4",
+    "zh:ae5a5877dfd2ab35f8835c34360ffa6f103a41f64823ad7e8c2e53e4e7eec263",
+    "zh:be1133b5590647f7d4903172d7cc8329794ca9ca5243918ed55c54d0999d6e60",
+    "zh:c7afaeed16e05c97377f12b3773c051638400b2d23b2121bac460e2a3d4761fb",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.4.5"
+  constraints = "0.4.5"
+  hashes = [
+    "h1:w3t6FuWmEuzDOEy/G1NYNvU+xG8TxHZpC3dcuNFTg2E=",
+    "zh:060fb8d8eecc0ef327c0652cc5c5ee08dd92fc06a94026049a4ea1ca663374fe",
+    "zh:42d7fec20bf3c2e995b1213b6b0b0f5fe1674f08367f30470ca4fa46e2b39cf5",
+    "zh:55ffa3c8ca36c962b0e248df8d9528c1240b881fac7b46dc5faeaf0ef9e09280",
+    "zh:6b6e7f4837b43240b271ec6987f700898c93ca60b35d5d134d6330fdb370ba4b",
+    "zh:89ff6d71bd0baf1147ef218d67fdb9f2c1036dca7a44c0b4d37982aa284e4fcc",
+    "zh:93e995693b25fcd802f5c26543a8bf6d2e19544d405baf6b44c790c049fa2a32",
+    "zh:972411b47d07053d124f544b57ff7deaabaea0a50a78c8023d354e5c3399b093",
+    "zh:c625064c2d407714e737f32fb81d82ce16c2944962830171f199cd49efffa92a",
+    "zh:fdd6d724b4982a3f8badaef055062c0896f669c99ebc9f5c4778a428e1cd1cb5",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.4.6"
+  constraints = "0.4.6"
+  hashes = [
+    "h1:7o5Ef/BEsYYxImKPA8eNniAgjTY+P8JRBEDkHwzUPqI=",
+    "zh:09ec5d7ae4cead1f3d6caca1f41ae72646e48cd32574f2e2a9f9f5b6247057e9",
+    "zh:1bc15d2802d577bf8a7fb7ec89da758b9dc2cdfbf2ebc2efe6d506cfd86c2a7a",
+    "zh:20b8c522ca7e756494c977f4fc02630200c6e0a22b0829bbcfdcce4f90d6effa",
+    "zh:21ddf7c44bf4443374490353bf13086993eeb32acb4e3f685107c21590f443a1",
+    "zh:4b125b1d6b26416168f74ae16c2e6bbdac63f320d6e8f33c967ae34a4c779ebf",
+    "zh:4d0136c44c2481169113094051bd1b3a5425aa4ed7fa1694c92bedfdf04d2cd1",
+    "zh:693a9c311b789613ad9f8bb652fa35748a487b2f48e44f23e7e8b1dad20a4b81",
+    "zh:ae9241794e3ee0458cb450d07e4a32acf780a51bc74bba73a39e1004f629215c",
+    "zh:d91f7f09c0faee8af952f40f76aa6ad838b0d1f870d893ba4a1e35f78335e09e",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.4.7"
+  constraints = "0.4.7"
+  hashes = [
+    "h1:wSVVSuDNmSr5C07sMubhcXPqP8Ncqsxn6Pp8uRr1290=",
+    "zh:0aa9306aa9dd49c51adfc77b35d0dec1c52ea426e90cd22890ded74d18c3694a",
+    "zh:2eacbca84ab079776a71a9a145b8d597dea03ef0f299b2d6a737c3f32f4893cc",
+    "zh:51e7eac47ee823ea691b5f284354b118b3aa83fa8d94ff02fed5ec69fc9239fc",
+    "zh:5507fb97eb4622144198eeebe5c6cbb223f9f8bf1bcbc8fa45e89cf1af28de02",
+    "zh:e04eaddddc06094d1515ec9c76165148a830f1d99b955dcd8c759ee637c364ec",
+    "zh:e6626edf17a8ed1173393fd05035a644094d87da4ba3f5ea1a410d0e1a9db1fa",
+    "zh:ee6e7af1ea2970c153495407ba102eaa1e40cc1c9e3dc10d2efa7e100a98ad92",
+    "zh:f8dd5c0d9f4018d703207eb6698d90fdff731c63f5cdbb442650299296a7c9ec",
+    "zh:fd289c0e565215ebc7c55d1ae4c60ed01fd3a960117afa8e54c3b2b7eed4b97c",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.4.8"
+  constraints = "0.4.8"
+  hashes = [
+    "h1:yGRgkLO2LWufK3PqTSGlwFiFuJiTV/jMLP+BrRg58Oo=",
+    "zh:02b0c2ac23167f80f0ea4559d51361a134a558f8b211e7539f68ca5299804996",
+    "zh:0e7cbe5f94406961bab2ed19c3a0fa2615c7e654705ed7b850f9df920dc18c36",
+    "zh:3bf8ca5c8677bf1dbf2dd2546df885201ac54554a1bd035945c6947831b6b3bd",
+    "zh:88af7c9e24cafc8b8cc7df524b5e357d96233a4fb68db3e3c309fb51f63ac98b",
+    "zh:c33a1e0e2dba495f5ff7b923478b6faf82edd825c2b5e37dbcca187e68621e00",
+    "zh:d0612d3f22cd7c60c6f0b83df5f8a97df781dcef56f720af0f1b4c70465db13c",
+    "zh:d635229c0ad68b5a9c5a98bdf8caee687137611874752779539cc00e60acad2e",
+    "zh:ede23a329a21608ace3bfe3fb27e9beaa67b31e964e1938f2f636da86f021322",
+    "zh:ee3e5631f52906a0fbedeed1e774979c4fce9b88a7001c15ab6d865fd6cceb67",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.4.9"
+  constraints = "0.4.9"
+  hashes = [
+    "h1:M/2zCLn03dE9LlZLAEX4YCrZsJCHOMGFfLdTu3UwkiE=",
+    "zh:095a042124c7d2aa8be2dd98bc35adf8da2eb20bdb3b1f4dbc5d2ff7f7e38807",
+    "zh:1228440c8762c38a4b6bd409dc65c7096d72846ad8f0b25724ee94c803f89168",
+    "zh:12614fa89089b768d13e828d99cd541eef6460de6af224ebec41ce60c7444319",
+    "zh:2f56b0cbc13ccb5194ae5a32072f926a1cb7b79273bdc42ee1f17754af732bc3",
+    "zh:56753b668335a0fe199a0a2aaba7c43e1ebd0a619e8b5ae13c1f2f258de3e3e3",
+    "zh:6e80c12abf393b18bd530390c689e4fe82146dcfb35128a32d952d66f3938903",
+    "zh:95e81ee4afabab5e4dc01452621d6ed98fb8e7b8ed3cb83b269fb6851dd074f1",
+    "zh:e16cbb318b9a4ef06ec86bb50f2311943fe0f80615d56deb63c9239a0ddf6a95",
+    "zh:f54191dd6d41af3aa66d3a0c4abb4b50a3111bb5899fb42609ae1484bd2f3163",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.5.0"
+  constraints = "0.5.0"
+  hashes = [
+    "h1:DYQBYQe0yz1ymXpcwYbN5fP8OUE4eMtRfS9JCtFbeew=",
+    "zh:03a78705088473f1e1ae66173c480b3f2d80260020b533746c03522cc4973ef2",
+    "zh:0e58647384fb91f59dcde06fe7c873119c673c83bbceb9933acc92cfe013fd51",
+    "zh:15862a7988dd5af414f25cca4919660ec3645be65a59e6fec0ef20ac7a1dbf4c",
+    "zh:1e37d4f250d5c4badabf324c074f29ecb9b8bbede7a6c842d8842cabc37d3708",
+    "zh:512fd9c1f5aa62254724170f23fd8ed49c163bb45d7c4b0549fb9a12072e8747",
+    "zh:9b546ece2acc1dea44b5fb1e0ad9a55163200eca82fe58215a9b0801708394f7",
+    "zh:bd95e2cc59e43658801eb7d8d6d601305a066576d3086ac2143c0166bdfc0874",
+    "zh:c7592b644bee3b7af6a7086144b644c71d1f890002055d1d4222ff992a35fe72",
+    "zh:ee9016af54663662e8c9ab4aee7b8d905ca5b5c6b26c728afd38f7a89fc23633",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.5.1"
+  constraints = "0.5.1"
+  hashes = [
+    "h1:Wwi+Mcove1IZ8mzMlhrHMuXs9zykefMV5K3g3fH2GC0=",
+    "zh:1b92029c48e12c209c72e674bb8e9788f4f03238b829ab84d61536c9100bd5cf",
+    "zh:695d0931535e85c2be3230cfe3422f96f57cdbaf4af6e784b134e44d0fb00e40",
+    "zh:7af5a49003d993329e54604f46fdb70b84aa4782d256316b4f1afb9452f18265",
+    "zh:b13409228be4119a0dbca9b95452b035fad5d05eda62caacb2eb472b31bd5639",
+    "zh:c29f2b2cc136fbd8dc088b7341774ae285b15b9aa21bf2cb105bab990ff89626",
+    "zh:cfad023abb68fb390678a21d2db1efa99d86c319eb7fdc1b99423d4b352d346b",
+    "zh:d7a29cbdae2e09498cfd0c00abd4a623dac5a67606083d980cef5731aa683375",
+    "zh:e84f267dd9e4f61dc77d76c07c236a839c7c615c1976a523071bcf19aa3fcd86",
+    "zh:f463ac8265eed21806a82c7bd5c96c9b7081a9eea96d05e4de2c08bfd1ec7a71",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.5.2"
+  constraints = "0.5.2"
+  hashes = [
+    "h1:xKHrXPbHL9qyOmdmYbNZ7lb6l7rBECykA7mkEXAjbEw=",
+    "zh:0dff78cac751121f3df33a73c05d83f31c3f4c284578eae0e8444a8735b1199f",
+    "zh:18c39dae220169cd204473e4582a2220e9dde0bb0d97f66bd04e74ad3ce73083",
+    "zh:94ff8356c292d4e1eda8a519180f80c6b51680709fbccab251053748bbe443ee",
+    "zh:a7eee848f581925fa3314983c63307cbb3aba5944c761c89f1cef812c527a016",
+    "zh:b383cc418782209a7260adee1caf6ef674d53bc673c54184778b0507ca3d48b2",
+    "zh:d159303221cbf2b1683840866541d40dcdc03d3eb9ed1fe4c45a773e359fdbf8",
+    "zh:dda4473d48b211d7d8a24dd6237d3c83372065da0684ae325d2859af333baf77",
+    "zh:f69fa1def83e658bcb5adc470ab11648278a2f5fb91b49dc74be9212c2169e31",
+    "zh:fc9f1d0273b7f1dd576e128b2b3b4f27339ce99331b4a8ed3e06ca8a240a1988",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.5.3"
+  constraints = "0.5.3"
+  hashes = [
+    "h1:K2gQhnHldxHy8EpDit1khkXomtaK7EkysUIxLEyulIw=",
+    "zh:13c1b114d017716ea660247fd19ae36794b27fb09925ce4e18c28c5545b605f2",
+    "zh:4e59ccae08aa04df92700fc3d4ff628685eebb6074418c29d19d9b0939ded566",
+    "zh:5c0f9af4fe5d1467c3f431d5459c20ce6c1652ca630293602a7550daa56ab064",
+    "zh:9080a4f4d634a93c462630b381b6014c4be4bc005163aa76e0b02da2682688c4",
+    "zh:9592d54a45123b41aad07df15363bd008fde59d127a0fb01520370d5c675904e",
+    "zh:d888eabb02f457ea838f2496e35c9a3cda873b08380a4dbc769e368db0a9c383",
+    "zh:ed9c38ba33dbf7da4776ab0b29349d5a59829c87e75bfdaeeea6ba19970c1ca7",
+    "zh:f293887ad6fe9c0632aacc13d21a2fdb78fe02205fc7bc042b5211b7678a6949",
+    "zh:fda8ca93cf12092712037a540cb56e8b560078bad08bb3c5a5768a5b116fd7c3",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.5.4"
+  constraints = "0.5.4"
+  hashes = [
+    "h1:SJ4ktD5afolZhJcPPazIRNIIbsEKc7lFr1P+iHA64LE=",
+    "zh:0aa63ae7dbb4345871b0f69e6ba0fc8cccda3c97f42cb8cba12e687bbfa599b1",
+    "zh:102bd4fe1b782fa5b285a809b87dfc1ae0f9f340fa4c4cf4086a90cb06ff7b1d",
+    "zh:193bca13101fe454f7205a9b12d3be3a76f388d05cf0fcc845b3863d840bf43d",
+    "zh:28b45229592482165639dce4265eee6549c0c546aceaef2ad2967ebfea38f650",
+    "zh:47727b0b2c3ba4c59227cab07aecfd30835f84ae1ae6595abce112aa0a1586b0",
+    "zh:757589f0fecbab46c58be9fa4d1448e717e18d211e19756e50576dc6b22f9b37",
+    "zh:8ade3c1249eba0e358708ef7f829b094fdc25a7f53af2488832b63cb4ff29691",
+    "zh:a49eb43cb2b286f2631b468bb9dedb03a77ebbf08346d19a325d5c76db388057",
+    "zh:ef002d55ae25870c7eb11111f9d5f36b6dce83ef6d9d0eb040682cb8154792b4",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.5.5"
+  constraints = "0.5.5"
+  hashes = [
+    "h1:NaI0GI7JxRsihI/LP9j077ZBjweq6ORxoEqftz78Aug=",
+    "zh:34fe845cde7316d5fca849b8545321e3887c1eb0c4c0eea9a44d213a174cacfc",
+    "zh:5cf2ba503cfcc17252960a8b62a4289217852d9f2f8ac0e48a21fcc4edafde58",
+    "zh:811787b04cde34d0ac30a67e568a84f9bd7533962a88642d2f9c580b43645605",
+    "zh:97111fa911083834f47b9375263f175eab3deff392671026cc528cdfb54a6279",
+    "zh:b09595def598e4bce2bf1728feb7f05b43cfaab0c16464cb5a9fe4fc6ec89b6b",
+    "zh:b3a6fc639c5096daeae81041588a3f6bd1ba938d4ff63839e2c28d6ea1964bb0",
+    "zh:e6d0e88652a2d24bdb93e03649373f3b05e18f83d1ce4ef335fc82770955be1f",
+    "zh:f0b2bd83f8d209c885758d4c829faa7f186dfc664536b3084b2ee234fe838eda",
+    "zh:f0f643d7d364723dadc51d4e942b925680ab89cb6fd8760b691ae75bda1d6c2a",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.5.6"
+  constraints = "0.5.6"
+  hashes = [
+    "h1:lkO102hKYqjqflelB0Rw+MDAQz6yxZGDi/92TimCsms=",
+    "zh:3fe9a4238f3559ddb2b1d9ef6570fc6d561f43cb1e313d242124f01c1fcfaba1",
+    "zh:66d1bd4fd095889ed75a919e35f93c8919eb34efbfe743377947af1b47fa13d3",
+    "zh:89b5ad891ab2f34575dc4b859f67165cf3bfaa824f7bfcfb99fa3bf70b496231",
+    "zh:b63be159b85cbfeb616fd797209cb64d2413fac88807348ed16e1203ed28e77c",
+    "zh:b70ff754ea9c39994dfdc212c5be85f5f34926ae1e56c1a517ec08592b217892",
+    "zh:dc1c7126d9448d0338902b495140633d0158a53774daf4f8f4866195a20b6786",
+    "zh:e6cc98f574d7d5c2485267c2eab0504904553347c579c928bec437fe54cfc2d5",
+    "zh:ee6dd76890187206a680393bb91fdfd2a2e59aa096280f68c787fe6aa68a80d1",
+    "zh:f4d3245e11ca0dc454f465b296f339300a25f7753924a57f620f7d774a4ede91",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.5.7"
+  constraints = "0.5.7"
+  hashes = [
+    "h1:0TM5ePZoe7VKxvWlo7434qI+kUvI1L+UfhAs1+RYkU0=",
+    "zh:448b4e92a8ea81177b98df499113c68058c3436b2dc855906d63eb0394927fa3",
+    "zh:4dab255585c757554965de16a1db319d1700f6bfc19e500a60069c94918ff76c",
+    "zh:560bc9c930828d4ef3ab1ecd804eac50cecce0bd797c26bca4a54a3815843977",
+    "zh:56a9947c6bb5b86b95f7bd69d87f36f52d72f33791c90ae9f00223b33d52297b",
+    "zh:7015698ceaad12d6c82b9cdd2d356147f722a98ab4a963c2d1a93037d68696f6",
+    "zh:89149ff6f99b129917c4ec1a61adcf76ab8f88d5f4aae57a5631b0c702ca8f2c",
+    "zh:bff771d30b52555aa23698c420e5fb0416a325e2690dd885a87f2f6404a42315",
+    "zh:c0988cab7ac37160cbc4902b6b8404c7abe7d05860cbd396dd51b9c4c471d264",
+    "zh:d03cb219e06f11149bc2e3b5ad95d695be81c7570ac9e9cdad22f912b20838bf",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.5.8"
+  constraints = "0.5.8"
+  hashes = [
+    "h1:xuQglSGpuKs0Fhy+uaDG4lNvmpsrx9vCveJHdeW85ok=",
+    "zh:24a3c50962995463c863850303b3fcebdb0a280997c876a401650104730512da",
+    "zh:58fdbf4fe30671fef2f1a4a5cbf875ec8fdd1f01c53b1d5e9858e3f2f1c2802c",
+    "zh:7baa0f0fc340d3b36cbe8f2dddfe1a95527f91afd30c38a9823aa08ccde037d9",
+    "zh:888f267d398970c40ea04f952e8880d07f8a9ca16b2f0c09595657d82d276511",
+    "zh:969d8e4f22a6e04993f299a836e9d89a8da825d4ef0b7feee7d811e05ef113c1",
+    "zh:997f023e4e25f3d302eae33c6e6fd328762a6f03d95073ffdd6be7fa778feb1b",
+    "zh:a6b5f1353acbe4deb3ac232fa1890e0171842b26efcb5e318b5a3123a17cacfb",
+    "zh:cc774f7168f2553ecb9676d6c35a09feb36a22be4de0fbd7174a1fdc448e8429",
+    "zh:d58cbd9c7e6c1c4824a08f37add766d13d224e53f75e95d3f6a26f2c85c4615b",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.5.9"
+  constraints = "0.5.9"
+  hashes = [
+    "h1:QxXTGolzcQIrR3CZcVObf3/8z8vlqW7qVigTm2oooIo=",
+    "zh:09ba55f52f2bbbb4f7d9ab3bcb81da32f49419c5c7d0d4a28093d7738a3c20b4",
+    "zh:0be3810511560f72d5ce3cbda5b6dabcc6f270cf62ffa9b685931b817863692c",
+    "zh:1a04539af311119a135cdfed22efa6ae6c469d2dd22ec7860af68aed2550ae55",
+    "zh:26554552c715840051ba03200fdf5ff02d7c06077c8e8690ac920737bbca603e",
+    "zh:2a5ad11b86152b5ab5cf3286f971107c5184356e22df22fff1a182e565f12031",
+    "zh:6d8bef52a013ae326831fb04b46cd45f8c0b6c181b2163581de622a7050e0323",
+    "zh:75a62e8ae2e40dcaa5f8d708760ab6eaa8f3eabc3092dbbf3d6765e8bdeb9787",
+    "zh:9c7eb1d2a0b531b95cd33639d63a4747d51f6a3030fc063f9cb74a7f3e8cd62a",
+    "zh:eb6e1dbe6f29264516412669189ebbe5cdb56d6b219feee3658cc0af4998482f",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.6.0"
+  constraints = "0.6.0"
+  hashes = [
+    "h1:IQ8FdJWgzcwD5dWESPcYDROYwN2qrjIYfVw85/Ne6oM=",
+    "zh:08e50dd1d9d439a1d908078defc43d622a7d2e94206135af10c25aacc504f221",
+    "zh:0d833596d4036ae4926142e19264274868ec6d66a43aa21b111ee6829682749e",
+    "zh:17787ae248f87562e84879a18039522021858656551e474efbdd213c8793c959",
+    "zh:232086c80fb84dd8de4bc9096a2fdf9c52c93fe7e74da0c0b1500ea2b13c35be",
+    "zh:44be90f0140dd8cdc863cee596bbaab2d6c6ebac4e7787f0941750f2436ab202",
+    "zh:5abd4d5939414e402cd78b4e0a00eae9fbbb994b0478f585c1ddbf2cf871da29",
+    "zh:7de311a4f447fce3f27e0983ead1e0a5d949e9819ced436455fe824f559c2293",
+    "zh:9e48b0817b579841bb41f439f3de71dd3a05e8c3802910ef5cc2152c9f90e894",
+    "zh:b69e05ce932a9ebc9c9514d98d4a018d5ba3a7f614005c68ac3fd30d5bfcf8c6",
+  ]
+}
+
+provider "registry.terraform.io/databrickslabs/databricks" {
+  version     = "0.6.1"
+  constraints = "0.6.1"
+  hashes = [
+    "h1:TNnUgumvZ9EOtE6ROPR+AU2PiMeByqzeM6o/hboVqfs=",
+    "zh:069be7739e03371e17ccc8a3ac9f0490e8c5d4dd07c8a205699c4e5badc4dac5",
+    "zh:126010525bc67472328bf2125d9a56c831e5fec8f1d366b3df7b6407f1e1af12",
+    "zh:1b2d37ab6aaede9bb2e3b1d8e5c873bac1541ee7e2ed73bf29ebc44a048df1ba",
+    "zh:1b8f01bcd16c45697ba6384d10d84855e33269e513a15a86e44dff5501d87845",
+    "zh:413098e4dc19879f1a4d2a956745acdbf4cd4036d01a48789a1979e58a7494e0",
+    "zh:74067627dde72b48f573e4507f7c51115fb5d8f1c20670e66644ac314e126c3f",
+    "zh:a4a82ff29543ea0a2b70831b290f4bd20eace206415953e3f5a2ce7ecabf5ebb",
+    "zh:d16382f233635e41fafc3c99c3aa12e3951902172e6630d57459ab566a0ef1c3",
+    "zh:dfcf7634a8ae54a67b98f8779a6404d68226b03a7ae9d377fde4eaf3b8dd3629",
+  ]
+}


### PR DESCRIPTION
* Add a warning in `databricks_permissions` token usage docs ([#1380](https://github.com/databrickslabs/terraform-provider-databricks/pull/1380)).

Updated dependency versions:

* Bump google.golang.org/api from 0.83.0 to 0.84.0
* Bump github.com/stretchr/testify from 1.7.2 to 1.7.3

Test run: Azure
---

 * [x] access.TestAccIPACL (4.12s)
 * [x] access/acceptance.TestAccTableACL (503.03s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateClusterWithLibraries (265.79s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateSingleNodeCluster (68.48s)
 * [x] clusters/acceptance.TestAccListClustersIntegration (104.84s)
 * [x] commands/acceptance.TestAccContext (31.17s)
 * [x] jobs/acceptance.TestAccJobResource (3.73s)
 * [x] libraries/acceptance.TestAccLibraryCreate (54.57s)
 * [x] mlflow/acceptance.TestAccMLflowExperiment (5.45s)
 * [x] mlflow/acceptance.TestAccMLflowModel (3.16s)
 * [x] permissions.TestAccessControlChangeString (0.00s)
 * [x] permissions.TestAccessControlString (0.00s)
 * [x] permissions.TestAccessControlToAccessControlChange (0.00s)
 * [x] permissions/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (11.73s)
 * [x] permissions/acceptance.TestAccDatabricksReposPermissionsResourceFullLifecycle (11.82s)
 * [x] permissions/acceptance.TestAccPermissionsClusterPolicy (3.67s)
 * [x] permissions/acceptance.TestAccPermissionsClusters (77.87s)
 * [x] permissions/acceptance.TestAccPermissionsInstancePool (4.57s)
 * [x] permissions/acceptance.TestAccPermissionsJobs (4.53s)
 * [x] permissions/acceptance.TestAccPermissionsNotebooks (4.43s)
 * [x] permissions/acceptance.TestAccPermissionsTokens (3.10s)
 * [x] policies/acceptance.TestAccClusterPolicyResourceFullLifecycle (5.88s)
 * [x] pools.TestAccInstancePools (1.05s)
 * [x] repos/acceptance.TestAccGitCredentials (3.20s)
 * [x] scim.TestAccCreateUser (2.60s)
 * [x] scim.TestAccFilterGroup (0.31s)
 * [x] scim.TestAccGroup (4.83s)
 * [x] scim.TestAccReadUser (0.33s)
 * [x] scim.TestAccServicePrincipalOnAzure (1.97s)
 * [x] scim/acceptance.TestAccForceUserImport (4.96s)
 * [x] scim/acceptance.TestAccGroupDataSplitMembers (8.22s)
 * [x] scim/acceptance.TestAccGroupMemberResource (6.53s)
 * [x] scim/acceptance.TestAccGroupResource (4.99s)
 * [x] scim/acceptance.TestAccGroupResource_verify_entitlements (5.73s)
 * [x] scim/acceptance.TestAccGroupsExternalIdAndScimProvisioning (6.54s)
 * [x] scim/acceptance.TestAccServicePrincipalResourceOnAzure (4.00s)
 * [x] scim/acceptance.TestAccUserResource (6.80s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipals (0.84s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipalsGroup (0.71s)
 * [x] secrets/acceptance.TestAccSecretAclResource (6.69s)
 * [x] secrets/acceptance.TestAccSecretAclResourceDefaultPrincipal (5.59s)
 * [x] secrets/acceptance.TestAccSecretResource (7.55s)
 * [x] secrets/acceptance.TestAccSecretScopeResource (5.51s)
 * [x] storage.TestAccCreateFile (2.47s)
 * [x] storage/acceptance.TestAccAzureBlobMountGeneric (163.17s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (6.91s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (3.58s)
 * [x] storage/acceptance.TestAccInvalidSecretScopeFails (5.39s)
 * [x] storage/acceptance.TestAccSourceOnInvalidMountFails (27.65s)
 * [x] tokens.TestAccCreateToken (0.70s)
 * [x] tokens.TestAccCreateToken_NoExpiration (0.39s)
 * [x] tokens/acceptance.TestAccTokenResource (4.86s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (3.24s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (5.39s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (3.56s)

Test run: AWS
---

 * [x] access.TestAccIPACL (5.69s)
 * [x] access/acceptance.TestAccTableACL (559.46s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateClusterWithLibraries (543.72s)
 * [x] clusters/acceptance.TestAccClusterResource_CreateSingleNodeCluster (65.05s)
 * [x] clusters/acceptance.TestAccListClustersIntegration (334.63s)
 * [x] commands/acceptance.TestAccContext (17.90s)
 * [x] jobs/acceptance.TestAccJobResource (4.20s)
 * [x] libraries/acceptance.TestAccLibraryCreate (244.00s)
 * [x] mlflow/acceptance.TestAccMLflowExperiment (6.19s)
 * [x] mlflow/acceptance.TestAccMLflowModel (2.62s)
 * [x] permissions.TestAccessControlChangeString (0.00s)
 * [x] permissions.TestAccessControlString (0.00s)
 * [x] permissions.TestAccessControlToAccessControlChange (0.00s)
 * [x] permissions/acceptance.TestAccDatabricksPermissionsResourceFullLifecycle (34.67s)
 * [x] permissions/acceptance.TestAccDatabricksReposPermissionsResourceFullLifecycle (29.67s)
 * [x] permissions/acceptance.TestAccPermissionsClusterPolicy (14.26s)
 * [x] permissions/acceptance.TestAccPermissionsClusters (146.82s)
 * [x] permissions/acceptance.TestAccPermissionsInstancePool (15.55s)
 * [x] permissions/acceptance.TestAccPermissionsJobs (14.64s)
 * [x] permissions/acceptance.TestAccPermissionsNotebooks (16.04s)
 * [x] permissions/acceptance.TestAccPermissionsTokens (13.56s)
 * [x] policies/acceptance.TestAccClusterPolicyResourceFullLifecycle (4.13s)
 * [x] pools.TestAccInstancePools (2.57s)
 * [x] repos/acceptance.TestAccGitCredentials (3.34s)
 * [x] scim.TestAccCreateUser (7.61s)
 * [x] scim.TestAccFilterGroup (1.38s)
 * [x] scim.TestAccGroup (20.39s)
 * [x] scim.TestAccReadUser (1.49s)
 * [x] scim/acceptance.TestAccForceUserImport (12.87s)
 * [x] scim/acceptance.TestAccGroupMemberResource (19.60s)
 * [x] scim/acceptance.TestAccGroupResource (10.59s)
 * [x] scim/acceptance.TestAccGroupResource_verify_entitlements (9.75s)
 * [x] scim/acceptance.TestAccGroupsExternalIdAndScimProvisioning (15.47s)
 * [x] scim/acceptance.TestAccServicePrincipalResourceOnAws (7.52s)
 * [x] scim/acceptance.TestAccUserResource (9.70s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipals (1.57s)
 * [x] secrets/acceptance.TestAccInitialManagePrincipalsGroup (0.78s)
 * [x] secrets/acceptance.TestAccSecretAclResource (10.83s)
 * [x] secrets/acceptance.TestAccSecretAclResourceDefaultPrincipal (4.54s)
 * [x] secrets/acceptance.TestAccSecretResource (3.76s)
 * [x] secrets/acceptance.TestAccSecretScopeResource (5.29s)
 * [x] storage.TestAccCreateFile (7.82s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaContent (4.48s)
 * [x] storage/acceptance.TestAccDatabricksDBFSFile_CreateViaSource (2.27s)
 * [x] storage/acceptance.TestAccInvalidSecretScopeFails (3.37s)
 * [x] storage/acceptance.TestAccSourceOnInvalidMountFails (31.94s)
 * [x] tokens.TestAccCreateToken (0.45s)
 * [x] tokens.TestAccCreateToken_NoExpiration (0.37s)
 * [x] tokens/acceptance.TestAccTokenResource (3.60s)
 * [x] workspace/acceptance.TestAccGlobalInitScriptResource_Create (4.77s)
 * [x] workspace/acceptance.TestAccNotebookResourceScalability (4.73s)
 * [x] workspace/acceptance.TestAccWorkspaceConfFullLifecycle (2.42s)